### PR TITLE
feat: add Claude Code agent runner with stream-json NDJSON parsing

### DIFF
--- a/tests/unit/test_claude_runner.py
+++ b/tests/unit/test_claude_runner.py
@@ -1,0 +1,269 @@
+"""Tests for Claude Code agent type and runner."""
+
+from __future__ import annotations
+
+import json
+import pytest
+from pathlib import Path
+
+from zima.models.agent import AgentConfig, CycleResult
+from zima.core.claude_runner import ClaudeRunner
+
+
+class TestClaudeAgentConfig:
+    """Test Claude agent configuration."""
+
+    def test_claude_parameter_template(self):
+        """Test Claude default parameters are correct."""
+        config = AgentConfig.create("test-claude", "Test Claude", "claude")
+
+        assert config.parameters["model"] == "claude-sonnet-4-6"
+        assert config.parameters["maxTurns"] == 100
+        assert config.parameters["permissionMode"] == "plan"
+        assert config.parameters["outputFormat"] == "stream-json"
+        assert config.parameters["allowedTools"] == []
+        assert config.parameters["disallowedTools"] == []
+
+    def test_claude_cli_template(self):
+        """Test Claude CLI template uses -p, not --print."""
+        config = AgentConfig.create("test-claude", "Test Claude", "claude")
+        template = config.get_cli_command_template()
+
+        assert template == ["claude", "-p"]
+
+    def test_claude_needs_stdin_pipe(self):
+        """Test Claude agent type requires stdin pipe for prompt."""
+        config = AgentConfig.create("test-claude", "Test Claude", "claude")
+        assert config.needs_stdin_pipe is True
+
+    def test_kimi_does_not_need_stdin_pipe(self):
+        """Test Kimi agent type does NOT need stdin pipe."""
+        config = AgentConfig.create("test-kimi", "Test Kimi", "kimi")
+        assert config.needs_stdin_pipe is False
+
+    def test_claude_build_command_basic(self):
+        """Test basic Claude command building."""
+        config = AgentConfig.create("test-claude", "Test Claude", "claude")
+
+        cmd = config.build_command(
+            prompt_file=Path("/tmp/prompt.md"),
+            work_dir=Path("/tmp/workspace"),
+        )
+
+        assert "claude" in cmd
+        assert "-p" in cmd
+        assert "--model" in cmd
+        assert "claude-sonnet-4-6" in cmd
+        assert "--max-turns" in cmd
+        assert "100" in cmd
+        assert "--permission-mode" in cmd
+        assert "plan" in cmd
+        assert "--output-format" in cmd
+        assert "stream-json" in cmd
+
+    def test_claude_build_command_no_prompt_flag(self):
+        """Test Claude command does NOT include --prompt flag."""
+        config = AgentConfig.create("test-claude", "Test Claude", "claude")
+
+        cmd = config.build_command(prompt_file=Path("/tmp/prompt.md"))
+
+        # Claude receives prompt via stdin pipe, not CLI argument
+        assert "--prompt" not in cmd
+        assert "/tmp/prompt.md" not in cmd
+
+    def test_claude_build_command_custom_params(self):
+        """Test Claude command with custom parameters."""
+        config = AgentConfig.create(
+            "test-claude",
+            "Test Claude",
+            "claude",
+            parameters={
+                "maxTurns": 30,
+                "model": "claude-opus-4-6",
+                "allowedTools": ["Bash", "Read", "Edit"],
+                "disallowedTools": ["Write"],
+                "appendSystemPrompt": "Always use TypeScript",
+            },
+        )
+
+        cmd = config.build_command(
+            prompt_file=Path("/tmp/prompt.md"),
+            work_dir=Path("/tmp/workspace"),
+        )
+
+        assert "--max-turns" in cmd
+        assert "30" in cmd
+        assert "--model" in cmd
+        assert "claude-opus-4-6" in cmd
+        assert "--allowedTools" in cmd
+        assert "Bash,Read,Edit" in cmd
+        assert "--disallowedTools" in cmd
+        assert "Write" in cmd
+        assert "--append-system-prompt" in cmd
+        assert "Always use TypeScript" in cmd
+
+    def test_claude_build_command_add_dirs(self):
+        """Test Claude command with additional directories."""
+        config = AgentConfig.create(
+            "test-claude",
+            "Test Claude",
+            "claude",
+            parameters={"addDirs": ["./src", "./tests"]},
+        )
+
+        cmd = config.build_command()
+
+        assert "--add-dir" in cmd
+        assert "./src" in cmd
+        assert "./tests" in cmd
+
+    def test_claude_build_command_empty_tools_lists(self):
+        """Test that empty allowed/disallowed tools lists are not added."""
+        config = AgentConfig.create("test-claude", "Test Claude", "claude")
+
+        cmd = config.build_command()
+
+        assert "--allowedTools" not in cmd
+        assert "--disallowedTools" not in cmd
+
+    def test_claude_build_command_verbose(self):
+        """Test Claude command with verbose flag."""
+        config = AgentConfig.create(
+            "test-claude",
+            "Test Claude",
+            "claude",
+            parameters={"verbose": True},
+        )
+
+        cmd = config.build_command()
+
+        assert "--verbose" in cmd
+
+    def test_claude_build_command_without_prompt_file(self):
+        """Test Claude command without prompt file."""
+        config = AgentConfig.create("test-claude", "Test Claude", "claude")
+
+        cmd = config.build_command()
+
+        assert "claude" in cmd
+        assert "-p" in cmd
+        assert "--model" in cmd
+
+
+class TestClaudeRunnerParsing:
+    """Test ClaudeRunner NDJSON parsing logic."""
+
+    @pytest.fixture
+    def runner(self, tmp_path):
+        """Create a ClaudeRunner with temp directory."""
+        config = AgentConfig.create("test-claude", "Test Claude", "claude")
+        agent_dir = tmp_path / "agents" / "test-claude"
+        agent_dir.mkdir(parents=True)
+        return ClaudeRunner(config, agent_dir)
+
+    def test_parse_valid_ndjson(self, runner):
+        """Test parsing valid NDJSON lines."""
+        line = '{"type": "assistant", "message": {"content": [{"type": "text", "text": "Hello"}]}}'
+        result = runner._parse_ndjson_line(line)
+        assert result is not None
+        assert result["type"] == "assistant"
+
+    def test_parse_invalid_ndjson(self, runner):
+        """Test parsing invalid JSON returns None."""
+        result = runner._parse_ndjson_line("not json at all")
+        assert result is None
+
+    def test_parse_empty_line(self, runner):
+        """Test parsing empty line returns None."""
+        assert runner._parse_ndjson_line("") is None
+        assert runner._parse_ndjson_line("   ") is None
+
+    def test_extract_result_success(self, runner):
+        """Test extracting success result from events."""
+        events = [
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "Working..."}]}},
+            {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+            {"type": "tool_result", "content": "file1.txt\nfile2.txt"},
+            {"type": "result", "subtype": "success", "cost_usd": 0.05, "duration_ms": 5000, "session_id": "abc123"},
+        ]
+
+        result = runner._extract_result(events, returncode=0)
+
+        assert result["status"] == "completed"
+        assert result["progress"] == 100
+        assert result["next_action"] == "complete"
+        assert "Cost: $0.0500" in result["details"]
+        assert "Session: abc123" in result["details"]
+
+    def test_extract_result_error(self, runner):
+        """Test extracting error result from events."""
+        events = [
+            {"type": "result", "subtype": "error", "cost_usd": 0.01, "duration_ms": 1000},
+        ]
+
+        result = runner._extract_result(events, returncode=1)
+
+        assert result["status"] == "failed"
+        assert result["next_action"] == "retry"
+
+    def test_extract_result_no_result_event(self, runner):
+        """Test extracting result when no result event is present."""
+        events = [
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "Done"}]}},
+        ]
+
+        # Success returncode
+        result = runner._extract_result(events, returncode=0)
+        assert result["status"] == "completed"
+
+        # Failed returncode
+        result = runner._extract_result(events, returncode=1)
+        assert result["status"] == "failed"
+
+    def test_extract_result_timeout_exit_code(self, runner):
+        """Test that exit code 5 is recognized as timeout."""
+        events = []
+        result = runner._extract_result(events, returncode=5)
+
+        assert result["status"] == "timeout"
+        assert result["next_action"] == "retry"
+
+    def test_extract_summary_from_assistant(self, runner):
+        """Test extracting summary from last assistant message."""
+        events = [
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "First message"}]}},
+            {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "Task completed successfully"}]}},
+            {"type": "result", "subtype": "success", "cost_usd": 0.05, "duration_ms": 5000},
+        ]
+
+        result = runner._extract_result(events, returncode=0)
+        assert "Task completed successfully" in result["summary"]
+
+    def test_estimate_progress(self, runner):
+        """Test progress estimation from tool usage."""
+        events = [
+            {"type": "tool_use", "name": "Bash"},
+            {"type": "tool_use", "name": "Read"},
+            {"type": "tool_use", "name": "Edit"},
+        ]
+
+        progress = runner._estimate_progress(events)
+        assert 0 < progress <= 95
+
+    def test_estimate_progress_no_tools(self, runner):
+        """Test progress estimation with no tools."""
+        events = []
+        progress = runner._estimate_progress(events)
+        assert progress == 50  # Default
+
+    def test_runner_creates_directories(self, tmp_path):
+        """Test that runner creates required directories."""
+        config = AgentConfig.create("test-claude", "Test Claude", "claude")
+        agent_dir = tmp_path / "agents" / "test-claude"
+
+        runner = ClaudeRunner(config, agent_dir)
+
+        assert runner.prompts_dir.exists()
+        assert runner.logs_dir.exists()
+        assert runner.workspace.exists()

--- a/tests/unit/test_models_agent.py
+++ b/tests/unit/test_models_agent.py
@@ -273,9 +273,9 @@ class TestAgentConfigCommandBuilding(TestIsolator):
         """Test getting Claude command template."""
         config = AgentConfig.create("test", "Test", "claude")
         template = config.get_cli_command_template()
-        
+
         assert "claude" in template
-        assert "--print" in template
+        assert "-p" in template
     
     def test_get_cli_template_gemini(self):
         """Test getting Gemini command template."""
@@ -320,14 +320,16 @@ class TestAgentConfigCommandBuilding(TestIsolator):
             "claude",
             parameters={"maxTurns": 50}
         )
-        
+
         cmd = config.build_command(
-            prompt_file="/tmp/prompt.md",
-            work_dir="/tmp/workspace"
+            prompt_file=Path("/tmp/prompt.md"),
+            work_dir=Path("/tmp/workspace")
         )
-        
+
         assert "claude" in cmd
-        assert "--prompt" in cmd
+        assert "-p" in cmd
+        # Claude receives prompt via stdin pipe, not --prompt flag
+        assert "--prompt" not in cmd
         assert "--work-dir" in cmd
         assert "--max-turns" in cmd
         assert "50" in cmd
@@ -340,14 +342,14 @@ class TestAgentConfigCommandBuilding(TestIsolator):
             "gemini",
             parameters={"model": "gemini-pro"}
         )
-        
+
         cmd = config.build_command(
-            prompt_file="/tmp/prompt.md",
-            work_dir="/tmp/workspace"
+            prompt_file=Path("/tmp/prompt.md"),
+            work_dir=Path("/tmp/workspace")
         )
-        
+
         assert "gemini" in cmd
-        assert "--prompt" in cmd
+        assert "-p" in cmd  # Gemini uses -p for prompt file
         assert "--worktree" in cmd  # Gemini uses --worktree
         assert "-m" in cmd
         assert "gemini-pro" in cmd

--- a/zima/core/__init__.py
+++ b/zima/core/__init__.py
@@ -1,5 +1,6 @@
 """Core components for ZimaBlue - v2"""
 
 from .runner import AgentRunner
+from .claude_runner import ClaudeRunner
 
-__all__ = ["AgentRunner"]
+__all__ = ["AgentRunner", "ClaudeRunner"]

--- a/zima/core/claude_runner.py
+++ b/zima/core/claude_runner.py
@@ -17,8 +17,13 @@ class ClaudeRunner:
     """Runs Claude Code CLI via subprocess with stream-json NDJSON parsing.
 
     Unlike KimiRunner which drives external cycles, ClaudeRunner leverages
-    Claude Code's built-in agentic loop (--max-turns). A single run() call
+    Claude Code's built-in agentic loop (--max-turns). A single run_cycle() call
     executes the full agentic workflow in one subprocess invocation.
+
+    NOTE: Currently used via PJobExecutor for PJob-based execution (stdin pipe path).
+    This runner provides a KimiRunner-compatible run_cycle() interface for future
+    cycle-based execution patterns (daemon/scheduler). The NDJSON parsing and
+    CycleResult extraction logic are tested independently.
 
     Stream-JSON format (NDJSON, one JSON object per line):
       {"type": "system", ...}            - System messages

--- a/zima/core/claude_runner.py
+++ b/zima/core/claude_runner.py
@@ -1,0 +1,311 @@
+"""Claude Code CLI runner - executes Claude Code via subprocess with stream-json parsing."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from zima.models import AgentConfig, CycleResult
+from zima.utils import safe_print, icon
+
+
+class ClaudeRunner:
+    """Runs Claude Code CLI via subprocess with stream-json NDJSON parsing.
+
+    Unlike KimiRunner which drives external cycles, ClaudeRunner leverages
+    Claude Code's built-in agentic loop (--max-turns). A single run() call
+    executes the full agentic workflow in one subprocess invocation.
+
+    Stream-JSON format (NDJSON, one JSON object per line):
+      {"type": "system", ...}            - System messages
+      {"type": "assistant", "message": {}}  - Claude text responses
+      {"type": "tool_use", ...}          - Tool invocations (Bash, Read, Edit, etc.)
+      {"type": "tool_result", ...}       - Tool outputs
+      {"type": "result", ...}            - Final result (cost_usd, duration, session_id)
+    """
+
+    def __init__(self, config: AgentConfig, agent_dir: Path):
+        self.config = config
+        self.agent_dir = agent_dir
+        self.workspace = agent_dir / "workspace"
+        self.prompts_dir = agent_dir / "prompts"
+        self.logs_dir = agent_dir / "logs"
+
+        # Ensure directories exist
+        self.prompts_dir.mkdir(parents=True, exist_ok=True)
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        self.workspace.mkdir(parents=True, exist_ok=True)
+
+    def run_cycle(
+        self,
+        prompt: str,
+        cycle_num: int,
+        task_name: str = "",
+    ) -> CycleResult:
+        """Execute a single cycle using Claude Code's built-in agentic loop.
+
+        This is the main entry point, compatible with KimiRunner's interface.
+
+        Args:
+            prompt: The prompt to send to Claude Code
+            cycle_num: Current cycle number
+            task_name: Name of the current task
+
+        Returns:
+            CycleResult with execution results
+        """
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        cycle_start = datetime.now()
+
+        # Prepare files
+        prompt_file = self.prompts_dir / f"cycle_{timestamp}.md"
+        log_file = self.logs_dir / f"cycle_{timestamp}.log"
+
+        # Write prompt to file (will be piped as stdin)
+        prompt_file.write_text(prompt, encoding="utf-8")
+
+        # Ensure workspace exists with absolute path
+        workspace_abs = self.workspace.resolve()
+        workspace_abs.mkdir(parents=True, exist_ok=True)
+
+        # Build command using AgentConfig's build_command method
+        cmd = self.config.build_command(
+            prompt_file=prompt_file,
+            work_dir=workspace_abs,
+        )
+
+        safe_print(f"{icon('rocket')} Starting Claude Code cycle {cycle_num}")
+        safe_print(f"   Prompt: {prompt_file.name}")
+        safe_print(f"   Log: {log_file.name}")
+        safe_print(f"   Command: {' '.join(cmd)}")
+
+        # Execute with stream-json parsing
+        start_time = datetime.now()
+        process = None
+
+        try:
+            with open(prompt_file, "r", encoding="utf-8") as stdin_handle:
+                process = subprocess.Popen(
+                    cmd,
+                    stdin=stdin_handle,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    cwd=str(workspace_abs),
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                )
+
+                events = []
+                with open(log_file, "w", encoding="utf-8") as log_f:
+                    for line in process.stdout:
+                        # Write raw line to log
+                        log_f.write(line)
+                        log_f.flush()
+
+                        # Parse NDJSON
+                        event = self._parse_ndjson_line(line)
+                        if event:
+                            events.append(event)
+
+                        # Also display to console
+                        try:
+                            sys.stdout.write(line)
+                            sys.stdout.flush()
+                        except (OSError, IOError):
+                            pass
+
+                returncode = process.wait()
+
+            elapsed = (datetime.now() - start_time).total_seconds()
+
+            # Extract result from accumulated events
+            result_data = self._extract_result(events, returncode)
+
+            return CycleResult(
+                cycle_num=cycle_num,
+                status=result_data["status"],
+                progress=result_data["progress"],
+                summary=result_data["summary"],
+                details=result_data["details"],
+                next_action=result_data["next_action"],
+                log_file=log_file,
+                prompt_file=prompt_file,
+                elapsed_time=elapsed,
+                return_code=returncode,
+            )
+
+        except subprocess.TimeoutExpired:
+            elapsed = (datetime.now() - start_time).total_seconds()
+            if process:
+                process.kill()
+                process.wait()
+
+            return CycleResult(
+                cycle_num=cycle_num,
+                status="timeout",
+                progress=50,
+                summary="Claude Code execution timed out",
+                next_action="retry",
+                log_file=log_file,
+                prompt_file=prompt_file,
+                elapsed_time=elapsed,
+                return_code=-1,
+            )
+
+        except KeyboardInterrupt:
+            if process and process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+
+            elapsed = (datetime.now() - start_time).total_seconds()
+
+            return CycleResult(
+                cycle_num=cycle_num,
+                status="error",
+                summary="Execution cancelled by user (Ctrl+C)",
+                next_action="retry",
+                log_file=log_file,
+                prompt_file=prompt_file,
+                elapsed_time=elapsed,
+                return_code=-1,
+            )
+
+        except Exception as e:
+            elapsed = (datetime.now() - start_time).total_seconds()
+
+            return CycleResult(
+                cycle_num=cycle_num,
+                status="error",
+                summary=f"Claude Code execution error: {e}",
+                next_action="retry",
+                log_file=log_file,
+                prompt_file=prompt_file,
+                elapsed_time=elapsed,
+                return_code=-1,
+            )
+
+    def _parse_ndjson_line(self, line: str) -> Optional[dict]:
+        """Parse a single NDJSON line from stream-json output.
+
+        Returns:
+            Parsed dict or None if line is not valid JSON.
+        """
+        line = line.strip()
+        if not line:
+            return None
+
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            return None
+
+    def _extract_result(self, events: list[dict], returncode: int) -> dict:
+        """Extract final result from accumulated stream events.
+
+        Maps Claude Code stream-json events to Zima's CycleResult fields.
+
+        Returns:
+            dict with keys: status, progress, summary, details, next_action
+        """
+        result = {
+            "status": "unknown",
+            "progress": 0,
+            "summary": "",
+            "details": "",
+            "next_action": "continue",
+        }
+
+        # Find the final "result" event
+        final_result = None
+        for event in reversed(events):
+            if event.get("type") == "result":
+                final_result = event
+                break
+
+        if final_result:
+            # Extract status from result
+            # Claude Code result event has: subtype, cost_usd, duration_ms, etc.
+            subtype = final_result.get("subtype", "")
+            if subtype == "success":
+                result["status"] = "completed"
+                result["progress"] = 100
+                result["next_action"] = "complete"
+            elif subtype == "error":
+                result["status"] = "failed"
+                result["next_action"] = "retry"
+            elif subtype == "cancelled":
+                result["status"] = "error"
+                result["next_action"] = "retry"
+            else:
+                result["status"] = "completed" if returncode == 0 else "failed"
+
+            # Extract cost info
+            cost_usd = final_result.get("cost_usd", 0)
+            duration_ms = final_result.get("duration_ms", 0)
+            session_id = final_result.get("session_id", "")
+
+            result["details"] = (
+                f"Cost: ${cost_usd:.4f} | Duration: {duration_ms / 1000:.1f}s"
+                f"{' | Session: ' + session_id if session_id else ''}"
+            )
+        else:
+            # No result event - infer from returncode
+            if returncode == 0:
+                result["status"] = "completed"
+                result["progress"] = 100
+                result["next_action"] = "complete"
+            elif returncode == 5:
+                # Claude Code exit code 5 = timeout
+                result["status"] = "timeout"
+                result["next_action"] = "retry"
+            else:
+                result["status"] = "failed"
+                result["next_action"] = "retry"
+
+        # Extract summary from assistant messages
+        assistant_messages = []
+        for event in events:
+            if event.get("type") == "assistant":
+                msg = event.get("message", {})
+                content = msg.get("content", [])
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        text = block.get("text", "").strip()
+                        if text:
+                            assistant_messages.append(text)
+
+        if assistant_messages and not result["summary"]:
+            # Use the last assistant message as summary (most relevant)
+            last_msg = assistant_messages[-1]
+            result["summary"] = last_msg[:500]  # Truncate long summaries
+
+        # Estimate progress from tool usage
+        if result["progress"] == 0:
+            result["progress"] = self._estimate_progress(events)
+
+        return result
+
+    def _estimate_progress(self, events: list[dict]) -> int:
+        """Estimate progress 0-100 from tool usage events.
+
+        Uses a heuristic based on the number of tool calls relative
+        to maxTurns parameter.
+        """
+        tool_use_count = sum(1 for e in events if e.get("type") == "tool_use")
+
+        max_turns = self.config.parameters.get("maxTurns", 100)
+
+        if max_turns > 0 and tool_use_count > 0:
+            # Each turn roughly maps to one or more tool uses
+            estimated = min(int((tool_use_count / max_turns) * 100), 95)
+            return max(estimated, 10)
+
+        return 50  # Default: unknown progress

--- a/zima/execution/executor.py
+++ b/zima/execution/executor.py
@@ -181,11 +181,15 @@ class PJobExecutor:
             result.status = ExecutionStatus.RUNNING
             self._current_process = None
             
+            # For Claude Code, pipe the prompt file as stdin
+            stdin_file = prompt_file if bundle.agent.needs_stdin_pipe else None
+
             returncode, stdout, stderr, process_pid = self._run_command(
                 command=command,
                 env=env_vars,
                 work_dir=bundle.work_dir,
                 timeout=pjob.spec.execution.timeout,
+                stdin_file=stdin_file,
             )
             
             result.returncode = returncode
@@ -384,60 +388,82 @@ class PJobExecutor:
         env: dict[str, str],
         work_dir: str,
         timeout: int,
+        stdin_file: Optional[Path] = None,
     ) -> tuple[int, str, str, int]:
         """
         Run the main agent command.
-        
+
+        Args:
+            command: Command arguments
+            env: Environment variables
+            work_dir: Working directory
+            timeout: Timeout in seconds (0 = no timeout)
+            stdin_file: Optional file to pipe as stdin (for Claude Code)
+
         Returns:
             Tuple of (returncode, stdout, stderr, pid)
         """
         import sys
-        
+
         cwd = work_dir if work_dir and Path(work_dir).exists() else None
-        
-        # Run command with real-time output
-        process = subprocess.Popen(
-            command,
-            env=env,
-            cwd=cwd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-        )
-        
-        self._current_process = process
-        
-        stdout_lines = []
-        stderr_lines = []
-        
-        # Stream output in real-time with error protection
-        if process.stdout:
-            for line in process.stdout:
-                stdout_lines.append(line)
+
+        # Open stdin file if provided (e.g., for Claude Code prompt piping)
+        stdin_handle = None
+        if stdin_file and stdin_file.exists():
+            stdin_handle = open(stdin_file, "r", encoding="utf-8")
+
+        try:
+            # Run command with real-time output
+            process = subprocess.Popen(
+                command,
+                env=env,
+                cwd=cwd,
+                stdin=stdin_handle,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+
+            self._current_process = process
+
+            stdout_lines = []
+            stderr_lines = []
+
+            # Stream output in real-time with error protection
+            if process.stdout:
+                for line in process.stdout:
+                    stdout_lines.append(line)
+                    try:
+                        sys.stdout.write(line)
+                        sys.stdout.flush()
+                    except (OSError, IOError) as e:
+                        # Windows may raise [Errno 22] Invalid argument for certain output
+                        # Continue execution without real-time display
+                        pass
+
+            if process.stderr:
+                for line in process.stderr:
+                    stderr_lines.append(line)
+                    try:
+                        sys.stderr.write(line)
+                        sys.stderr.flush()
+                    except (OSError, IOError) as e:
+                        # Windows may raise [Errno 22] Invalid argument for certain output
+                        # Continue execution without real-time display
+                        pass
+
+            returncode = process.wait(timeout=timeout if timeout > 0 else None)
+
+            return returncode, "".join(stdout_lines), "".join(stderr_lines), process.pid
+        finally:
+            # Ensure stdin file handle is closed
+            if stdin_handle:
                 try:
-                    sys.stdout.write(line)
-                    sys.stdout.flush()
-                except (OSError, IOError) as e:
-                    # Windows may raise [Errno 22] Invalid argument for certain output
-                    # Continue execution without real-time display
+                    stdin_handle.close()
+                except (OSError, IOError):
                     pass
-        
-        if process.stderr:
-            for line in process.stderr:
-                stderr_lines.append(line)
-                try:
-                    sys.stderr.write(line)
-                    sys.stderr.flush()
-                except (OSError, IOError) as e:
-                    # Windows may raise [Errno 22] Invalid argument for certain output
-                    # Continue execution without real-time display
-                    pass
-        
-        returncode = process.wait(timeout=timeout if timeout > 0 else None)
-        
-        return returncode, "".join(stdout_lines), "".join(stderr_lines), process.pid
     
     def _save_output(self, result: ExecutionResult, output_options) -> None:
         """Save output to file."""

--- a/zima/models/agent.py
+++ b/zima/models/agent.py
@@ -25,11 +25,14 @@ AGENT_PARAMETER_TEMPLATES = {
     "claude": {
         "model": "claude-sonnet-4-6",
         "maxTurns": 100,
-        "plan": False,
-        "acceptEdits": False,
+        "permissionMode": "plan",
+        "outputFormat": "stream-json",
+        "allowedTools": [],
+        "disallowedTools": [],
+        "systemPrompt": "",
+        "appendSystemPrompt": "",
         "workDir": "./workspace",
         "addDirs": [],
-        "outputFormat": "text",
     },
     "gemini": {
         "model": "gemini-2.5-flash",
@@ -198,13 +201,13 @@ class AgentConfig(BaseConfig):
     def get_cli_command_template(self) -> list[str]:
         """
         Get base CLI command template for this agent type.
-        
+
         Returns:
             Base command list (e.g., ["kimi", "--print", "--yolo"])
         """
         templates = {
             "kimi": ["kimi", "--print", "--yolo"],
-            "claude": ["claude", "--print"],
+            "claude": ["claude", "-p"],
             "gemini": ["gemini", "--yolo"],
         }
         return templates.get(self.type, [])
@@ -241,16 +244,23 @@ class AgentConfig(BaseConfig):
         elif self.type == "gemini":
             cmd = self._build_gemini_command(cmd, params)
         
-        # Add common parameters
+        # Add prompt file - agent-type-specific handling
+        # Claude Code: prompt passed via stdin pipe, not as CLI argument
+        # Kimi: uses --prompt flag
+        # Gemini: uses positional argument
         if prompt_file:
-            cmd.extend(["--prompt", str(prompt_file)])
-        
+            if self.type == "kimi":
+                cmd.extend(["--prompt", str(prompt_file)])
+            elif self.type == "gemini":
+                cmd.extend(["-p", str(prompt_file)])
+            # Claude: prompt_file is passed via stdin pipe by the executor, not added to cmd
+
         if work_dir:
             if self.type == "gemini":
                 cmd.extend(["--worktree", str(work_dir)])
             else:
                 cmd.extend(["--work-dir", str(work_dir)])
-        
+
         return cmd
     
     def _build_kimi_command(self, cmd: list[str], params: dict) -> list[str]:
@@ -277,26 +287,57 @@ class AgentConfig(BaseConfig):
         return cmd
     
     def _build_claude_command(self, cmd: list[str], params: dict) -> list[str]:
-        """Build Claude-specific command arguments."""
+        """Build Claude Code-specific command arguments.
+
+        Claude Code CLI flags (from official docs):
+          -p              : Print mode (non-interactive), reads prompt from stdin
+          --model         : Model selection (sonnet, opus, haiku, or full name)
+          --max-turns     : Limit agentic turns (print mode only)
+          --permission-mode : Unattended execution (plan, bypassPermissions, etc.)
+          --output-format : Output format (text, json, stream-json)
+          --allowedTools  : Tool whitelist
+          --disallowedTools : Tool blacklist
+          --system-prompt : Replace system prompt
+          --append-system-prompt : Append to default system prompt
+          --add-dir       : Additional working directories
+          --verbose       : Verbose logging (debug)
+          --max-tokens    : Max output tokens
+        """
         if params.get("model"):
             cmd.extend(["--model", str(params["model"])])
-        
+
         if params.get("maxTurns"):
             cmd.extend(["--max-turns", str(params["maxTurns"])])
-        
-        if params.get("plan"):
-            cmd.append("--plan")
-        
-        if params.get("acceptEdits"):
-            cmd.append("--accept-edits")
-        
+
+        if params.get("permissionMode"):
+            cmd.extend(["--permission-mode", str(params["permissionMode"])])
+
+        if params.get("outputFormat"):
+            cmd.extend(["--output-format", str(params["outputFormat"])])
+
+        if params.get("allowedTools"):
+            tools = params["allowedTools"]
+            if isinstance(tools, list) and tools:
+                cmd.extend(["--allowedTools", ",".join(str(t) for t in tools)])
+
+        if params.get("disallowedTools"):
+            tools = params["disallowedTools"]
+            if isinstance(tools, list) and tools:
+                cmd.extend(["--disallowedTools", ",".join(str(t) for t in tools)])
+
+        if params.get("systemPrompt"):
+            cmd.extend(["--system-prompt", str(params["systemPrompt"])])
+
+        if params.get("appendSystemPrompt"):
+            cmd.extend(["--append-system-prompt", str(params["appendSystemPrompt"])])
+
         # Handle addDirs
         for add_dir in params.get("addDirs", []):
             cmd.extend(["--add-dir", str(add_dir)])
-        
-        if params.get("outputFormat"):
-            cmd.extend(["--output-format", str(params["outputFormat"])])
-        
+
+        if params.get("verbose"):
+            cmd.append("--verbose")
+
         return cmd
     
     def _build_gemini_command(self, cmd: list[str], params: dict) -> list[str]:
@@ -318,7 +359,12 @@ class AgentConfig(BaseConfig):
             cmd.extend(["--output-format", str(params["outputFormat"])])
         
         return cmd
-    
+
+    @property
+    def needs_stdin_pipe(self) -> bool:
+        """Whether this agent type receives prompt via stdin pipe instead of CLI argument."""
+        return self.type == "claude"
+
     def get_default(self, key: str, default: any = None) -> any:
         """
         Get default workflow/variable/env/pmg reference.

--- a/zima/models/config_bundle.py
+++ b/zima/models/config_bundle.py
@@ -248,46 +248,28 @@ class ConfigBundle:
     ) -> list[str]:
         """
         Build the complete agent command.
-        
+
+        Delegates type-specific command building to AgentConfig.build_command()
+        which handles each agent's unique CLI flags and prompt passing mechanism.
+        Then appends PMG parameters on top.
+
         Args:
             prompt_file: Path to the rendered prompt file
             work_dir: Override work directory (optional)
-            
+
         Returns:
             Command as list of arguments (for subprocess)
         """
-        # Get agent binary
-        agent_type = self.agent.type
-        
-        # Build base command
-        cmd = [agent_type]
-        
-        # Add print/non-interactive flag
-        if agent_type == "kimi":
-            cmd.append("--print")
-        elif agent_type == "claude":
-            cmd.append("--print")
-        elif agent_type == "gemini":
-            cmd.append("-p")
-        
-        # Add PMG parameters
-        params = self.build_agent_params()
-        cmd.extend(params)
-        
-        # Add work directory
-        wd = work_dir or self.work_dir
-        if wd and wd != ".":
-            if agent_type in ("kimi", "claude"):
-                cmd.extend(["--work-dir", wd])
-            elif agent_type == "gemini":
-                cmd.extend(["--worktree", wd])
-        
-        # Add prompt file
-        if agent_type in ("kimi",):
-            cmd.extend(["--prompt", str(prompt_file)])
-        elif agent_type in ("claude", "gemini"):
-            cmd.extend(["-p", str(prompt_file)])
-        
+        # Delegate to AgentConfig for type-specific command building
+        cmd = self.agent.build_command(
+            prompt_file=prompt_file,
+            work_dir=Path(work_dir) if work_dir else None,
+        )
+
+        # Append PMG parameters (generic, agent-agnostic)
+        pmg_params = self.build_agent_params()
+        cmd.extend(pmg_params)
+
         return cmd
     
     def to_summary(self) -> dict:

--- a/zima/models/config_bundle.py
+++ b/zima/models/config_bundle.py
@@ -260,10 +260,13 @@ class ConfigBundle:
         Returns:
             Command as list of arguments (for subprocess)
         """
+        # Resolve work_dir: explicit param > bundle's resolved dir
+        wd = work_dir or self.work_dir
+
         # Delegate to AgentConfig for type-specific command building
         cmd = self.agent.build_command(
             prompt_file=prompt_file,
-            work_dir=Path(work_dir) if work_dir else None,
+            work_dir=Path(wd) if wd and wd != "." else None,
         )
 
         # Append PMG parameters (generic, agent-agnostic)


### PR DESCRIPTION
## Summary

- Add `ClaudeRunner` (`zima/core/claude_runner.py`) for executing Claude Code CLI with real-time NDJSON stream parsing
- Fix `ConfigBundle.build_command()` dual-path bug — now delegates to `AgentConfig.build_command()` so Claude gets correct flags (`-p` instead of `--print`)
- Update `_build_claude_command` with full Claude Code CLI flag support (`--permission-mode`, `--allowedTools`, `--disallowedTools`, `--system-prompt`, etc.)
- Add stdin pipe support in `PJobExecutor._run_command()` for Windows-compatible prompt passing
- Add `needs_stdin_pipe` property to `AgentConfig`

## Key Changes

| File | Change |
|------|--------|
| `zima/core/claude_runner.py` | **New** — ClaudeRunner with NDJSON parsing, progress estimation, Ctrl+C handling |
| `zima/models/agent.py` | Claude params: `stream-json`, `permissionMode`, `allowedTools`; fix `_build_claude_command` |
| `zima/models/config_bundle.py` | Delegate `build_command()` to `AgentConfig` instead of hardcoding |
| `zima/execution/executor.py` | Add `stdin_file` param to `_run_command()` |
| `tests/unit/test_claude_runner.py` | **New** — 22 tests for command building + NDJSON parsing |
| `tests/unit/test_models_agent.py` | Fix 2 tests for Claude `-p` and stdin pipe |

## Test plan

- [x] All 384 unit tests pass (`pytest tests/unit/`)
- [ ] Manual test: `zima pjob run <claude-pjob> --dry-run` verifies correct command
- [ ] Manual test: `zima pjob run <claude-pjob>` launches Claude Code correctly
- [ ] Verify Ctrl+C graceful cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)