### PR TITLE
fix: resolve 21 failing integration tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,17 @@
 """Pytest global fixtures and configuration."""
 
+import re
 import shutil
 import tempfile
 import uuid
 from pathlib import Path
 
 import pytest
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from text (e.g., Rich color codes)."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/test_env_commands.py
+++ b/tests/integration/test_env_commands.py
@@ -4,6 +4,7 @@ import pytest
 from typer.testing import CliRunner
 from zima.cli import app
 from tests.base import TestIsolator
+from tests.conftest import strip_ansi
 
 
 runner = CliRunner()
@@ -340,8 +341,9 @@ class TestEnvSet(TestIsolator):
         ])
         
         assert result.exit_code == 0
-        assert "Variable 'MY_VAR' set" in result.output
-        assert "my_value" in result.output
+        clean = strip_ansi(result.output)
+        assert "Variable 'MY_VAR' set" in clean
+        assert "my_value" in clean
     
     def test_set_secret_env_source(self, monkeypatch):
         """Test setting secret with env source."""
@@ -363,8 +365,9 @@ class TestEnvSet(TestIsolator):
         ])
         
         assert result.exit_code == 0
-        assert "Secret 'API_KEY' set" in result.output
-    
+        clean = strip_ansi(result.output)
+        assert "Secret 'API_KEY' set" in clean
+
     def test_set_secret_file_source(self, tmp_path):
         """Test setting secret with file source."""
         key_file = tmp_path / "key.txt"
@@ -386,8 +389,9 @@ class TestEnvSet(TestIsolator):
         ])
         
         assert result.exit_code == 0
-        assert "Secret 'API_KEY' set" in result.output
-    
+        clean = strip_ansi(result.output)
+        assert "Secret 'API_KEY' set" in clean
+
     def test_set_secret_missing_source_field(self):
         """Test setting secret without required source field."""
         runner.invoke(app, [
@@ -500,7 +504,8 @@ class TestEnvGet(TestIsolator):
         ])
         
         assert result.exit_code == 0
-        assert "<secret:env>" in result.output
+        clean = strip_ansi(result.output)
+        assert "<secret:env>" in clean
     
     def test_get_secret_resolved(self, monkeypatch):
         """Test getting secret with --resolve."""
@@ -553,8 +558,9 @@ class TestEnvExport(TestIsolator):
         ])
         
         assert result.exit_code == 0
-        assert "KEY1=value1" in result.output
-    
+        clean = strip_ansi(result.output)
+        assert "KEY1=value1" in clean
+
     def test_export_shell(self):
         """Test exporting as shell script."""
         runner.invoke(app, [
@@ -575,8 +581,9 @@ class TestEnvExport(TestIsolator):
         ])
         
         assert result.exit_code == 0
-        assert "#!/bin/bash" in result.output
-        assert "export KEY1=" in result.output
+        clean = strip_ansi(result.output)
+        assert "#!/bin/bash" in clean
+        assert "export KEY1=" in clean
     
     def test_export_json(self):
         """Test exporting as JSON."""
@@ -598,7 +605,8 @@ class TestEnvExport(TestIsolator):
         ])
         
         assert result.exit_code == 0
-        assert '"KEY1": "value1"' in result.output
+        clean = strip_ansi(result.output)
+        assert '"KEY1": "value1"' in clean
     
     def test_export_to_file(self, tmp_path):
         """Test exporting to file."""
@@ -710,7 +718,8 @@ class TestEnvLifecycle(TestIsolator):
             "--key", "API_KEY"
         ])
         assert result.exit_code == 0
-        assert "<secret:" in result.output
+        clean = strip_ansi(result.output)
+        assert "<secret:" in clean
         
         # Get (resolved)
         result = runner.invoke(app, [
@@ -719,15 +728,17 @@ class TestEnvLifecycle(TestIsolator):
             "--resolve"
         ])
         assert result.exit_code == 0
-        assert "sk-test-key" in result.output
-        
+        clean = strip_ansi(result.output)
+        assert "sk-test-key" in clean
+
         # Export
         result = runner.invoke(app, [
             "env", "export", "lifecycle-env",
             "--format", "dotenv"
         ])
         assert result.exit_code == 0
-        assert "TIMEOUT=30" in result.output
+        clean = strip_ansi(result.output)
+        assert "TIMEOUT=30" in clean
         
         # Update
         result = runner.invoke(app, [

--- a/tests/integration/test_kimi_agent_integration.py
+++ b/tests/integration/test_kimi_agent_integration.py
@@ -44,7 +44,7 @@ class TestKimiAgentConfigLayer:
         )
         
         # Verify default parameters from template are merged
-        assert agent.parameters["model"] == "kimi-k2-072515-preview"
+        assert agent.parameters["model"] == "kimi-code/kimi-for-coding"
         assert agent.parameters["maxStepsPerTurn"] == 50
         assert agent.parameters["maxRalphIterations"] == 10
         assert agent.parameters["maxRetriesPerStep"] == 3
@@ -153,7 +153,7 @@ class TestKimiAgentConfigLayer:
         
         # Verify command differences
         assert kimi_cmd == ["kimi", "--print", "--yolo"]
-        assert claude_cmd == ["claude", "--print"]
+        assert claude_cmd == ["claude", "-p"]
         assert gemini_cmd == ["gemini", "--yolo"]
         
         # Verify work-dir parameter differences

--- a/tests/integration/test_kimi_agent_real.py
+++ b/tests/integration/test_kimi_agent_real.py
@@ -38,6 +38,7 @@ def check_kimi_available():
             ["kimi", "--version"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=5
         )
         return result.returncode == 0
@@ -87,6 +88,7 @@ class TestKimiAgentRealCommands:
             ["kimi", "--help"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=10
         )
         
@@ -118,6 +120,7 @@ class TestKimiAgentRealCommands:
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=60  # Give it up to 60 seconds
         )
         
@@ -257,6 +260,7 @@ Then output this JSON:
             cmd,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=60
         )
         
@@ -422,6 +426,7 @@ class TestKimiAgentErrorHandling:
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=30
         )
         

--- a/tests/integration/test_pmg_commands.py
+++ b/tests/integration/test_pmg_commands.py
@@ -4,6 +4,7 @@ import pytest
 from typer.testing import CliRunner
 from zima.cli import app
 from tests.base import TestIsolator
+from tests.conftest import strip_ansi
 
 
 runner = CliRunner()
@@ -341,8 +342,9 @@ class TestPMGAddParam(TestIsolator):
         ])
         
         assert result.exit_code == 0
-        assert "Parameter 'model' added" in result.output
-    
+        clean = strip_ansi(result.output)
+        assert "Parameter 'model' added" in clean
+
     def test_add_flag_param(self):
         """Test adding flag parameter."""
         runner.invoke(app, [
@@ -360,8 +362,9 @@ class TestPMGAddParam(TestIsolator):
         ])
         
         assert result.exit_code == 0
-        assert "Parameter 'verbose' added" in result.output
-    
+        clean = strip_ansi(result.output)
+        assert "Parameter 'verbose' added" in clean
+
     def test_add_repeatable_param(self):
         """Test adding repeatable parameter."""
         runner.invoke(app, [
@@ -379,8 +382,9 @@ class TestPMGAddParam(TestIsolator):
         ])
         
         assert result.exit_code == 0
-        assert "Parameter 'add-dir' added" in result.output
-    
+        clean = strip_ansi(result.output)
+        assert "Parameter 'add-dir' added" in clean
+
     def test_add_invalid_type_fails(self):
         """Test adding parameter with invalid type fails."""
         runner.invoke(app, [

--- a/tests/integration/test_variable_commands.py
+++ b/tests/integration/test_variable_commands.py
@@ -4,6 +4,7 @@ import pytest
 from typer.testing import CliRunner
 from zima.cli import app
 from tests.base import TestIsolator
+from tests.conftest import strip_ansi
 
 
 runner = CliRunner()
@@ -486,5 +487,6 @@ class TestVariableWorkflowLifecycle(TestIsolator):
         ])
         
         assert result.exit_code == 0
-        assert "Task: Integration Test" in result.output
-        assert "step1, step2, step3" in result.output
+        clean = strip_ansi(result.output)
+        assert "Task: Integration Test" in clean
+        assert "step1, step2, step3" in clean

--- a/tests/integration/test_workflow_commands.py
+++ b/tests/integration/test_workflow_commands.py
@@ -4,6 +4,7 @@ import pytest
 from typer.testing import CliRunner
 from zima.cli import app
 from tests.base import TestIsolator
+from tests.conftest import strip_ansi
 
 
 runner = CliRunner()
@@ -341,8 +342,8 @@ class TestWorkflowRender(TestIsolator):
         ])
         
         assert result.exit_code == 0
-        assert "Hello World!" in result.output
-    
+        assert "Hello World!" in strip_ansi(result.output)
+
     def test_render_with_variable_config(self):
         """Test rendering with variable config."""
         # Create workflow
@@ -372,8 +373,8 @@ class TestWorkflowRender(TestIsolator):
         ])
         
         assert result.exit_code == 0
-        assert "Task: Test Task" in result.output
-    
+        assert "Task: Test Task" in strip_ansi(result.output)
+
     def test_render_validation_failure(self):
         """Test render with validation failure."""
         runner.invoke(app, [
@@ -417,7 +418,7 @@ class TestWorkflowAddVar(TestIsolator):
         ])
         
         assert result.exit_code == 0
-        assert "Variable 'new_var' added" in result.output
+        assert "Variable 'new_var' added" in strip_ansi(result.output)
 
 
 class TestWorkflowLifecycle(TestIsolator):
@@ -455,8 +456,8 @@ class TestWorkflowLifecycle(TestIsolator):
             "--var", "name=World"
         ])
         assert result.exit_code == 0
-        assert "Hello World!" in result.output
-        
+        assert "Hello World!" in strip_ansi(result.output)
+
         # Update
         result = runner.invoke(app, [
             "workflow", "update", "lifecycle-wf",


### PR DESCRIPTION
## Summary
- Fix 18 tests broken by Rich ANSI escape codes in CLI output (added `strip_ansi` helper)
- Fix 2 tests with outdated assertions (kimi model default, claude CLI flag `-p` vs `--print`)
- Fix 2 kimi real tests by adding `encoding="utf-8"` to subprocess calls (Windows GBK)

## Test plan
- [x] 566 passed, 0 failed (`pytest tests/`)
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)