### PR TITLE
feat: add Claude Code automations (skills, hooks, subagent)

### DIFF
--- a/.claude/agents/test-reviewer.md
+++ b/.claude/agents/test-reviewer.md
@@ -1,0 +1,45 @@
+---
+name: test-reviewer
+description: Reviews test files for proper isolation, coverage, and conventions
+model: haiku
+---
+
+# Test Reviewer
+
+You are a specialized test reviewer for the Zima Blue CLI project. Review test files against the project's testing conventions.
+
+## Review Checklist
+
+For each test file, check:
+
+1. **Isolation**: Tests using filesystem/config operations must inherit from `TestIsolator` (in `tests/base.py`). This provides automatic `ZIMA_HOME` isolation via `monkeypatch`.
+
+2. **Fixture usage**: Use shared fixtures from `tests/conftest.py`:
+   - `isolated_zima_home` — temp ZIMA_HOME directory
+   - `config_manager` — pre-configured ConfigManager
+   - `cli_runner` — Typer CliRunner instance
+   - `unique_code` — unique test identifier generator
+
+3. **Test placement**:
+   - Pure unit tests (no subprocess, no filesystem) → `tests/unit/`
+   - CLI command tests, subprocess tests → `tests/integration/`
+
+4. **Naming convention**:
+   - File: `test_<module_path>.py` (e.g., `zima/models/agent.py` → `test_models_agent.py`)
+   - Class: `Test<ClassName>`
+   - Method: `test_<behavior>_<condition>`
+
+5. **Coverage quality**:
+   - Happy path + edge cases + error handling
+   - Use `pytest.raises` for expected exceptions
+   - No trivial tests (e.g., only testing that an object exists)
+
+6. **Docstrings**: Google-style docstrings on test classes, concise descriptions on methods.
+
+## Output Format
+
+Report issues grouped by severity:
+
+- **MUST FIX**: Missing isolation, wrong placement, broken fixtures
+- **SHOULD FIX**: Missing edge cases, poor naming, missing docstrings
+- **NICE TO HAVE**: Style improvements, additional coverage suggestions

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE=\"$CLAUDE_FILE_PATH\"; if [[ \"$FILE\" == *.py ]]; then black \"$FILE\" --line-length 100 --quiet 2>/dev/null; ruff check \"$FILE\" --fix --quiet 2>/dev/null; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/gen-test/SKILL.md
+++ b/.claude/skills/gen-test/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: gen-test
+description: Generate pytest unit tests for a given source module or function
+---
+
+# Generate Tests
+
+Generate pytest unit tests for a target Python module or function.
+
+## Usage
+
+- `/gen-test zima/models/agent.py` — generate tests for the agent model
+- `/gen-test zima/config/manager.py::ConfigManager.save_config` — generate tests for a specific method
+
+## Instructions
+
+1. **Read the target source file** to understand its public API, classes, and functions.
+
+2. **Determine the test file path** using the project convention:
+   - Source: `zima/foo/bar.py` -> Test: `tests/unit/test_foo_bar.py` (flattened with underscores)
+   - But check existing naming first: `zima/models/agent.py` -> `tests/unit/test_models_agent.py`
+   - If the test file already exists, **append** new test classes/methods rather than overwriting.
+
+3. **Generate tests** following these conventions:
+   - Test classes inherit from `TestIsolator` (from `tests/base.py`) when filesystem/config isolation is needed
+   - Use `monkeypatch` for `ZIMA_HOME` isolation (handled by `TestIsolator`)
+   - Use fixtures from `tests/conftest.py` (`config_manager`, `cli_runner`, `unique_code`, `isolated_zima_home`)
+   - Google-style docstrings on test classes
+   - Cover: happy path, edge cases, error handling
+   - Use `pytest.raises` for expected exceptions
+   - Use `tmp_path` or `TestIsolator.get_test_path()` for temp files
+
+4. **Example test structure**:
+
+```python
+"""Tests for <module description>."""
+
+import pytest
+
+from zima.<module> import <TargetClass>
+from tests.base import TestIsolator
+
+
+class Test<TargetClass>(TestIsolator):
+    """Tests for <TargetClass>."""
+
+    def test_<behavior>_success(self):
+        """Test <behavior> with valid input."""
+        # arrange
+        ...
+        # act
+        result = ...
+        # assert
+        assert result == expected
+
+    def test_<behavior>_invalid_input(self):
+        """Test <behavior> raises on invalid input."""
+        with pytest.raises(ValueError):
+            ...
+```
+
+5. **After generating**, run the test to verify it passes:
+   ```bash
+   pytest <test_file> -v
+   ```
+
+6. **Report** the test file path, number of tests generated, and pass/fail status.

--- a/.claude/skills/new-entity/SKILL.md
+++ b/.claude/skills/new-entity/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: new-entity
+description: Scaffold a new configuration entity type (model, commands, manager integration, CLI registration)
+disable-model-invocation: true
+---
+
+# New Config Entity Scaffold
+
+Scaffold a new configuration entity type for the Zima Blue CLI platform.
+
+## Usage
+
+- `/new-entity Trigger` — create a new entity called "Trigger"
+- `/new-entity Schedule` — create a new entity called "Schedule"
+
+## Instructions
+
+Follow the 4-step extension pattern documented in CLAUDE.md:
+
+### Step 1: Create Model
+
+Create `zima/models/<entity>.py`:
+
+- Follow the pattern from existing models (e.g., `zima/models/agent.py`)
+- Inherit from `BaseConfig` or create a standalone dataclass
+- Include `Metadata` with `code`, `name`, `description`
+- YAML structure: `apiVersion: zima.io/v1` / `kind: <Entity>` / `metadata` / `spec`
+- Add `KIND = "<entity>"` class constant
+- Implement `from_dict` classmethod and `to_dict` method
+- Add validation for `metadata.code`: lowercase letters, numbers, hyphens only, max 64 chars
+
+### Step 2: Register in ConfigManager
+
+Edit `zima/config/manager.py`:
+
+- Add the new kind string to `ConfigManager.KINDS` set
+- No other changes needed — `ConfigManager` handles all entity types generically
+
+### Step 3: Create Commands
+
+Create `zima/commands/<entity>.py`:
+
+- Follow the pattern from existing commands (e.g., `zima/commands/agent.py`)
+- Use Typer `app = typer.Typer(help="<Entity> management commands")`
+- Implement standard CRUD: `list`, `get`, `create`, `delete`
+- For `create`: accept YAML file via `--file` option, validate and save
+- Use `ConfigManager` for all config operations
+- Use `rich` for formatted output
+
+### Step 4: Register CLI Subcommand
+
+Edit `zima/cli.py`:
+
+- Import the new command app: `from zima.commands.<entity> import app as <entity>_app`
+- Register: `app.add_typer(<entity>_app, name="<entity>")`
+
+### Step 5: Create Test Fixtures (Optional)
+
+Create sample YAML config in `tests/fixtures/configs/`:
+
+```yaml
+apiVersion: zima.io/v1
+kind: <Entity>
+metadata:
+  code: sample-<entity>
+  name: Sample <Entity>
+  description: For testing
+spec:
+  # entity-specific fields
+```
+
+### Verification
+
+After scaffolding, verify:
+1. `python -c "from zima.models.<entity> import <Entity>Config"` — import works
+2. `zima <entity> --help` — CLI registered correctly
+3. `pytest tests/` — no existing tests broken


### PR DESCRIPTION
## Summary
- Add `gen-test` skill: `/gen-test <module>` to generate pytest unit tests following project conventions
- Add `new-entity` skill: `/new-entity <Name>` to scaffold new config entity types (model, commands, CLI registration)
- Add PostToolUse hook: auto-format Python files with `black` + `ruff` after every Edit/Write
- Add `test-reviewer` subagent: haiku-model agent that reviews test quality (isolation, coverage, naming)

## Test plan
- [ ] Verify `/gen-test zima/models/agent.py` generates correct test file
- [ ] Verify `/new-entity Trigger` scaffolds all 4 files correctly
- [ ] Edit a Python file and confirm auto-formatting hook runs
- [ ] Verify test-reviewer subagent is discoverable

🤖 Generated with [Claude Code](https://claude.com/claude-code)