### PR TITLE
feat: add --example flag to all entity create commands

### DIFF
--- a/tests/integration/test_example_flag.py
+++ b/tests/integration/test_example_flag.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from typer.testing import CliRunner
 
 from zima.commands.agent import app as agent_app
+from zima.commands.env import app as env_app
+from zima.commands.pjob import app as pjob_app
+from zima.commands.pmg import app as pmg_app
+from zima.commands.variable import app as variable_app
+from zima.commands.workflow import app as workflow_app
 
 runner = CliRunner()
 
@@ -28,3 +33,38 @@ class TestAgentExample:
     def test_create_without_example_still_requires_params(self):
         result = runner.invoke(agent_app, ["create"])
         assert result.exit_code == 1
+
+
+class TestWorkflowExample:
+    def test_create_example(self):
+        result = runner.invoke(workflow_app, ["create", "--example"])
+        assert result.exit_code == 0
+        assert "kind: Workflow" in result.output
+
+
+class TestVariableExample:
+    def test_create_example(self):
+        result = runner.invoke(variable_app, ["create", "--example"])
+        assert result.exit_code == 0
+        assert "kind: Variable" in result.output
+
+
+class TestEnvExample:
+    def test_create_example(self):
+        result = runner.invoke(env_app, ["create", "--example"])
+        assert result.exit_code == 0
+        assert "kind: Env" in result.output
+
+
+class TestPmgExample:
+    def test_create_example(self):
+        result = runner.invoke(pmg_app, ["create", "--example"])
+        assert result.exit_code == 0
+        assert "kind: PMG" in result.output
+
+
+class TestPjobExample:
+    def test_create_example(self):
+        result = runner.invoke(pjob_app, ["create", "--example"])
+        assert result.exit_code == 0
+        assert "kind: PJob" in result.output

--- a/tests/integration/test_example_flag.py
+++ b/tests/integration/test_example_flag.py
@@ -1,0 +1,30 @@
+"""CLI integration tests for --example flag on create commands."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from zima.commands.agent import app as agent_app
+
+runner = CliRunner()
+
+
+class TestAgentExample:
+    def test_create_example_exits_zero(self):
+        result = runner.invoke(agent_app, ["create", "--example"])
+        assert result.exit_code == 0
+
+    def test_create_example_outputs_yaml(self):
+        result = runner.invoke(agent_app, ["create", "--example"])
+        assert "apiVersion: zima.io/v1" in result.output
+        assert "kind: Agent" in result.output
+        assert "my-agent" in result.output
+
+    def test_create_example_ignores_other_params(self):
+        result = runner.invoke(agent_app, ["create", "--example", "--name", "test"])
+        assert result.exit_code == 0
+        assert "my-agent" in result.output
+
+    def test_create_without_example_still_requires_params(self):
+        result = runner.invoke(agent_app, ["create"])
+        assert result.exit_code == 1

--- a/tests/unit/test_examples.py
+++ b/tests/unit/test_examples.py
@@ -1,0 +1,214 @@
+"""Tests for example YAML templates."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from zima.models.agent import AgentConfig
+from zima.models.env import EnvConfig
+from zima.models.pjob import PJobConfig
+from zima.models.pmg import PMGConfig
+from zima.models.variable import VariableConfig
+from zima.models.workflow import WorkflowConfig
+from zima.templates.examples import (
+    AGENT_EXAMPLE,
+    ENV_EXAMPLE,
+    EXAMPLES,
+    PJOB_EXAMPLE,
+    PMG_EXAMPLE,
+    VALID_KINDS,
+    VARIABLE_EXAMPLE,
+    WORKFLOW_EXAMPLE,
+)
+
+# Mapping from kind string to model class and example constant
+KIND_MODEL_MAP = {
+    "agent": (AgentConfig, AGENT_EXAMPLE),
+    "workflow": (WorkflowConfig, WORKFLOW_EXAMPLE),
+    "variable": (VariableConfig, VARIABLE_EXAMPLE),
+    "env": (EnvConfig, ENV_EXAMPLE),
+    "pmg": (PMGConfig, PMG_EXAMPLE),
+    "pjob": (PJobConfig, PJOB_EXAMPLE),
+}
+
+
+class TestExamplesStructure:
+    """Parametrized tests for YAML structure correctness."""
+
+    @pytest.mark.parametrize("kind", list(EXAMPLES.keys()))
+    def test_example_is_valid_yaml(self, kind: str):
+        """Each example must parse as valid YAML."""
+        data = yaml.safe_load(EXAMPLES[kind])
+        assert isinstance(data, dict)
+
+    @pytest.mark.parametrize("kind", list(EXAMPLES.keys()))
+    def test_example_has_required_top_level_fields(self, kind: str):
+        """Each example must have apiVersion, kind, metadata, spec."""
+        data = yaml.safe_load(EXAMPLES[kind])
+        assert "apiVersion" in data, f"{kind}: missing apiVersion"
+        assert "kind" in data, f"{kind}: missing kind"
+        assert "metadata" in data, f"{kind}: missing metadata"
+        assert "spec" in data, f"{kind}: missing spec"
+
+    @pytest.mark.parametrize("kind", list(EXAMPLES.keys()))
+    def test_example_metadata_has_code_and_name(self, kind: str):
+        """Each example metadata must have code and name."""
+        data = yaml.safe_load(EXAMPLES[kind])
+        metadata = data["metadata"]
+        assert "code" in metadata, f"{kind}: metadata missing code"
+        assert "name" in metadata, f"{kind}: metadata missing name"
+        assert metadata["code"], f"{kind}: metadata.code is empty"
+        assert metadata["name"], f"{kind}: metadata.name is empty"
+
+    @pytest.mark.parametrize("kind", list(EXAMPLES.keys()))
+    def test_example_kind_matches_entity(self, kind: str):
+        """Each example kind field must match its entity type (capitalized)."""
+        data = yaml.safe_load(EXAMPLES[kind])
+        kind_map = {
+            "agent": "Agent",
+            "workflow": "Workflow",
+            "variable": "Variable",
+            "env": "Env",
+            "pmg": "PMG",
+            "pjob": "PJob",
+        }
+        assert (
+            data["kind"] == kind_map[kind]
+        ), f"{kind}: kind={data['kind']}, expected={kind_map[kind]}"
+
+
+class TestExamplesCoverage:
+    """Tests for EXAMPLES dict coverage."""
+
+    def test_examples_covers_all_six_kinds(self):
+        """EXAMPLES dict must contain exactly 6 kinds."""
+        expected = {"agent", "workflow", "variable", "env", "pmg", "pjob"}
+        assert set(EXAMPLES.keys()) == expected
+
+    def test_valid_kinds_constant(self):
+        """VALID_KINDS must be the correct set of 6 kind strings."""
+        expected = {"Agent", "Workflow", "Variable", "Env", "PMG", "PJob"}
+        assert VALID_KINDS == expected
+
+    def test_valid_kinds_size(self):
+        """VALID_KINDS must have exactly 6 entries."""
+        assert len(VALID_KINDS) == 6
+
+
+class TestAgentRoundTrip:
+    """Round-trip test for Agent example."""
+
+    def test_agent_from_dict(self):
+        data = yaml.safe_load(AGENT_EXAMPLE)
+        config = AgentConfig.from_dict(data)
+        assert config.kind == "Agent"
+        assert config.metadata.code == "my-agent"
+        assert config.metadata.name == "My Agent"
+        assert config.type == "kimi"
+        assert config.parameters["model"] == "moonshot-v1-8k"
+        assert config.defaults["workflow"] == "my-workflow"
+        assert config.defaults["env"] == "my-env"
+        assert config.is_valid()
+
+
+class TestWorkflowRoundTrip:
+    """Round-trip test for Workflow example."""
+
+    def test_workflow_from_dict(self):
+        data = yaml.safe_load(WORKFLOW_EXAMPLE)
+        config = WorkflowConfig.from_dict(data)
+        assert config.kind == "Workflow"
+        assert config.metadata.code == "my-workflow"
+        assert config.metadata.name == "My Workflow"
+        assert config.format == "jinja2"
+        assert "{{ role }}" in config.template
+        assert "{{ task }}" in config.template
+        assert len(config.variables) == 2
+        assert config.variables[0].name == "role"
+        assert config.variables[0].required is True
+        assert config.variables[1].name == "task"
+        assert "example" in config.tags
+        assert config.version == "1.0.0"
+        assert config.is_valid()
+
+
+class TestVariableRoundTrip:
+    """Round-trip test for Variable example."""
+
+    def test_variable_from_dict(self):
+        data = yaml.safe_load(VARIABLE_EXAMPLE)
+        config = VariableConfig.from_dict(data)
+        assert config.kind == "Variable"
+        assert config.metadata.code == "my-variables"
+        assert config.metadata.name == "My Variables"
+        assert config.for_workflow == "my-workflow"
+        assert config.values["role"] == "senior developer"
+        assert config.values["task"] == "code review"
+        assert config.is_valid()
+
+
+class TestEnvRoundTrip:
+    """Round-trip test for Env example."""
+
+    def test_env_from_dict(self):
+        data = yaml.safe_load(ENV_EXAMPLE)
+        config = EnvConfig.from_dict(data)
+        assert config.kind == "Env"
+        assert config.metadata.code == "my-env"
+        assert config.metadata.name == "My Environment"
+        assert config.for_type == "kimi"
+        assert config.variables["DEBUG"] == "false"
+        assert len(config.secrets) == 1
+        assert config.secrets[0].name == "API_KEY"
+        assert config.secrets[0].source == "env"
+        assert config.secrets[0].key == "MY_API_KEY"
+        assert config.override_existing is False
+        assert config.is_valid()
+
+
+class TestPMGRoundTrip:
+    """Round-trip test for PMG example."""
+
+    def test_pmg_from_dict(self):
+        data = yaml.safe_load(PMG_EXAMPLE)
+        config = PMGConfig.from_dict(data)
+        assert config.kind == "PMG"
+        assert config.metadata.code == "my-pmg"
+        assert config.metadata.name == "My Parameter Group"
+        assert "kimi" in config.for_types
+        assert "claude" in config.for_types
+        assert len(config.parameters) == 2
+        # verbose flag
+        assert config.parameters[0].name == "verbose"
+        assert config.parameters[0].type == "flag"
+        assert config.parameters[0].enabled is True
+        # model long param
+        assert config.parameters[1].name == "model"
+        assert config.parameters[1].type == "long"
+        assert config.parameters[1].value == "moonshot-v1-8k"
+        assert config.is_valid()
+
+
+class TestPJobRoundTrip:
+    """Round-trip test for PJob example."""
+
+    def test_pjob_from_dict(self):
+        data = yaml.safe_load(PJOB_EXAMPLE)
+        config = PJobConfig.from_dict(data)
+        assert config.kind == "PJob"
+        assert config.metadata.code == "my-job"
+        assert config.metadata.name == "My Job"
+        assert "example" in config.metadata.labels
+        assert config.spec.agent == "my-agent"
+        assert config.spec.workflow == "my-workflow"
+        assert config.spec.variable == "my-variables"
+        assert config.spec.env == "my-env"
+        assert config.spec.pmg == "my-pmg"
+        assert config.spec.execution.work_dir == "."
+        assert config.spec.execution.timeout == 600
+        assert config.spec.execution.keep_temp is False
+        assert config.spec.output.save_to == "./output.md"
+        assert config.spec.output.format == "raw"
+        assert config.spec.output.append is False
+        assert config.is_valid()

--- a/zima/commands/agent.py
+++ b/zima/commands/agent.py
@@ -21,9 +21,10 @@ console = Console(legacy_windows=False, force_terminal=True)
 
 @app.command()
 def create(
-    name: str = typer.Option(..., "--name", "-n", help="Display name"),
-    code: str = typer.Option(
-        ..., "--code", "-c", help="Unique code (lowercase letters, numbers, hyphens)"
+    example: bool = typer.Option(False, "--example", help="Print example YAML and exit"),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Display name"),
+    code: Optional[str] = typer.Option(
+        None, "--code", "-c", help="Unique code (lowercase letters, numbers, hyphens)"
     ),
     agent_type: str = typer.Option("kimi", "--type", "-t", help="Agent type: kimi/claude/gemini"),
     description: str = typer.Option("", "--description", "-d", help="Description"),
@@ -35,6 +36,19 @@ def create(
     ),
 ):
     """Create a new agent"""
+    if example:
+        from zima.templates.examples import EXAMPLES
+
+        print(EXAMPLES["agent"])
+        raise typer.Exit(0)
+
+    if not name:
+        console.print("[red]✗[/red] --name is required")
+        raise typer.Exit(1)
+    if not code:
+        console.print("[red]✗[/red] --code is required")
+        raise typer.Exit(1)
+
     manager = ConfigManager()
 
     # 1. Validate code format

--- a/zima/commands/env.py
+++ b/zima/commands/env.py
@@ -20,12 +20,13 @@ console = Console(legacy_windows=False, force_terminal=True)
 
 @app.command()
 def create(
-    code: str = typer.Option(
-        ..., "--code", "-c", help="Unique code (lowercase letters, numbers, hyphens)"
+    example: bool = typer.Option(False, "--example", help="Print example YAML and exit"),
+    code: Optional[str] = typer.Option(
+        None, "--code", "-c", help="Unique code (lowercase letters, numbers, hyphens)"
     ),
-    name: str = typer.Option(..., "--name", "-n", help="Display name"),
-    for_type: str = typer.Option(
-        ..., "--for-type", "-t", help="Target agent type: kimi/claude/gemini"
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Display name"),
+    for_type: Optional[str] = typer.Option(
+        None, "--for-type", "-t", help="Target agent type: kimi/claude/gemini"
     ),
     description: str = typer.Option("", "--description", "-d", help="Description"),
     from_code: Optional[str] = typer.Option(None, "--from", help="Copy from existing env config"),
@@ -34,6 +35,22 @@ def create(
     ),
 ):
     """Create a new environment configuration"""
+    if example:
+        from zima.templates.examples import EXAMPLES
+
+        print(EXAMPLES["env"])
+        raise typer.Exit(0)
+
+    if not code:
+        console.print("[red]✗[/red] --code is required")
+        raise typer.Exit(1)
+    if not name:
+        console.print("[red]✗[/red] --name is required")
+        raise typer.Exit(1)
+    if not for_type:
+        console.print("[red]✗[/red] --for-type is required")
+        raise typer.Exit(1)
+
     manager = ConfigManager()
 
     # 1. Validate code format

--- a/zima/commands/pjob.py
+++ b/zima/commands/pjob.py
@@ -24,9 +24,10 @@ console = Console(legacy_windows=False, force_terminal=True)
 
 @app.command()
 def create(
-    name: str = typer.Option(..., "--name", "-n", help="Display name"),
-    code: str = typer.Option(
-        ..., "--code", "-c", help="Unique code (lowercase letters, numbers, hyphens)"
+    example: bool = typer.Option(False, "--example", help="Print example YAML and exit"),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Display name"),
+    code: Optional[str] = typer.Option(
+        None, "--code", "-c", help="Unique code (lowercase letters, numbers, hyphens)"
     ),
     agent: Optional[str] = typer.Option(None, "--agent", "-a", help="Agent code"),
     workflow: Optional[str] = typer.Option(None, "--workflow", "-w", help="Workflow code"),
@@ -46,6 +47,19 @@ def create(
     ),
 ):
     """Create a new PJob"""
+    if example:
+        from zima.templates.examples import EXAMPLES
+
+        print(EXAMPLES["pjob"])
+        raise typer.Exit(0)
+
+    if not name:
+        console.print("[red]✗[/red] --name is required")
+        raise typer.Exit(1)
+    if not code:
+        console.print("[red]✗[/red] --code is required")
+        raise typer.Exit(1)
+
     manager = ConfigManager()
 
     # 1. Validate code format

--- a/zima/commands/pmg.py
+++ b/zima/commands/pmg.py
@@ -19,12 +19,13 @@ console = Console(legacy_windows=False, force_terminal=True)
 
 @app.command()
 def create(
-    code: str = typer.Option(
-        ..., "--code", "-c", help="Unique code (lowercase letters, numbers, hyphens)"
+    example: bool = typer.Option(False, "--example", help="Print example YAML and exit"),
+    code: Optional[str] = typer.Option(
+        None, "--code", "-c", help="Unique code (lowercase letters, numbers, hyphens)"
     ),
-    name: str = typer.Option(..., "--name", "-n", help="Display name"),
-    for_types: List[str] = typer.Option(
-        ..., "--for-type", "-t", help="Target agent types (can specify multiple)"
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Display name"),
+    for_types: Optional[List[str]] = typer.Option(
+        None, "--for-type", "-t", help="Target agent types (can specify multiple)"
     ),
     description: str = typer.Option("", "--description", "-d", help="Description"),
     from_code: Optional[str] = typer.Option(None, "--from", help="Copy from existing PMG"),
@@ -33,6 +34,22 @@ def create(
     ),
 ):
     """Create a new parameters group"""
+    if example:
+        from zima.templates.examples import EXAMPLES
+
+        print(EXAMPLES["pmg"])
+        raise typer.Exit(0)
+
+    if not code:
+        console.print("[red]✗[/red] --code is required")
+        raise typer.Exit(1)
+    if not name:
+        console.print("[red]✗[/red] --name is required")
+        raise typer.Exit(1)
+    if not for_types:
+        console.print("[red]✗[/red] --for-type is required")
+        raise typer.Exit(1)
+
     manager = ConfigManager()
 
     # 1. Validate code format

--- a/zima/commands/variable.py
+++ b/zima/commands/variable.py
@@ -20,10 +20,11 @@ console = Console(legacy_windows=False, force_terminal=True)
 
 @app.command()
 def create(
-    code: str = typer.Option(
-        ..., "--code", "-c", help="Unique code (lowercase letters, numbers, hyphens)"
+    example: bool = typer.Option(False, "--example", help="Print example YAML and exit"),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Display name"),
+    code: Optional[str] = typer.Option(
+        None, "--code", "-c", help="Unique code (lowercase letters, numbers, hyphens)"
     ),
-    name: str = typer.Option(..., "--name", "-n", help="Display name"),
     for_workflow: Optional[str] = typer.Option(
         None, "--for-workflow", "-w", help="Target workflow code"
     ),
@@ -36,6 +37,19 @@ def create(
     ),
 ):
     """Create a new variable configuration"""
+    if example:
+        from zima.templates.examples import EXAMPLES
+
+        print(EXAMPLES["variable"])
+        raise typer.Exit(0)
+
+    if not name:
+        console.print("[red]✗[/red] --name is required")
+        raise typer.Exit(1)
+    if not code:
+        console.print("[red]✗[/red] --code is required")
+        raise typer.Exit(1)
+
     manager = ConfigManager()
 
     # 1. Validate code format

--- a/zima/commands/workflow.py
+++ b/zima/commands/workflow.py
@@ -23,10 +23,11 @@ console = Console(legacy_windows=False, force_terminal=True)
 
 @app.command()
 def create(
-    code: str = typer.Option(
-        ..., "--code", "-c", help="Unique code (lowercase letters, numbers, hyphens)"
+    example: bool = typer.Option(False, "--example", help="Print example YAML and exit"),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Display name"),
+    code: Optional[str] = typer.Option(
+        None, "--code", "-c", help="Unique code (lowercase letters, numbers, hyphens)"
     ),
-    name: str = typer.Option(..., "--name", "-n", help="Display name"),
     description: str = typer.Option("", "--description", "-d", help="Description"),
     template: Optional[str] = typer.Option(
         None, "--template", "-t", help="Template content (or @file to load from file)"
@@ -38,6 +39,19 @@ def create(
     force: bool = typer.Option(False, "--force", help="Force overwrite if workflow already exists"),
 ):
     """Create a new workflow"""
+    if example:
+        from zima.templates.examples import EXAMPLES
+
+        print(EXAMPLES["workflow"])
+        raise typer.Exit(0)
+
+    if not name:
+        console.print("[red]✗[/red] --name is required")
+        raise typer.Exit(1)
+    if not code:
+        console.print("[red]✗[/red] --code is required")
+        raise typer.Exit(1)
+
     manager = ConfigManager()
 
     # 1. Validate code format

--- a/zima/templates/__init__.py
+++ b/zima/templates/__init__.py
@@ -1,0 +1,2 @@
+"""YAML example templates for zima entity types."""
+from zima.templates.examples import EXAMPLES, VALID_KINDS

--- a/zima/templates/__init__.py
+++ b/zima/templates/__init__.py
@@ -1,2 +1,4 @@
 """YAML example templates for zima entity types."""
-from zima.templates.examples import EXAMPLES, VALID_KINDS
+
+from zima.templates.examples import EXAMPLES as EXAMPLES
+from zima.templates.examples import VALID_KINDS as VALID_KINDS

--- a/zima/templates/examples.py
+++ b/zima/templates/examples.py
@@ -1,0 +1,130 @@
+"""Example YAML templates for each entity type."""
+
+from __future__ import annotations
+
+AGENT_EXAMPLE = """\
+apiVersion: zima.io/v1
+kind: Agent
+metadata:
+  code: my-agent
+  name: My Agent
+  description: "An example agent"
+spec:
+  type: kimi
+  parameters:
+    model: moonshot-v1-8k
+  defaults:
+    workflow: my-workflow
+    env: my-env
+"""
+
+WORKFLOW_EXAMPLE = """\
+apiVersion: zima.io/v1
+kind: Workflow
+metadata:
+  code: my-workflow
+  name: My Workflow
+  description: "An example workflow"
+spec:
+  format: jinja2
+  template: |
+    You are {{ role }}.
+    Please help me with {{ task }}.
+  variables:
+    - name: role
+      type: string
+      required: true
+      description: "Agent role"
+    - name: task
+      type: string
+      required: true
+      description: "Task description"
+  tags: [example]
+  author: ""
+  version: "1.0.0"
+"""
+
+VARIABLE_EXAMPLE = """\
+apiVersion: zima.io/v1
+kind: Variable
+metadata:
+  code: my-variables
+  name: My Variables
+  description: "Example variables"
+spec:
+  forWorkflow: my-workflow
+  values:
+    role: "senior developer"
+    task: "code review"
+"""
+
+ENV_EXAMPLE = """\
+apiVersion: zima.io/v1
+kind: Env
+metadata:
+  code: my-env
+  name: My Environment
+  description: "Example env config"
+spec:
+  forType: kimi
+  variables:
+    DEBUG: "false"
+  secrets:
+    - name: API_KEY
+      source: env
+      key: MY_API_KEY
+  overrideExisting: false
+"""
+
+PMG_EXAMPLE = """\
+apiVersion: zima.io/v1
+kind: PMG
+metadata:
+  code: my-pmg
+  name: My Parameter Group
+  description: "Example PMG"
+spec:
+  forTypes: [kimi, claude]
+  parameters:
+    - name: verbose
+      type: flag
+      enabled: true
+    - name: model
+      type: long
+      value: "moonshot-v1-8k"
+"""
+
+PJOB_EXAMPLE = """\
+apiVersion: zima.io/v1
+kind: PJob
+metadata:
+  code: my-job
+  name: My Job
+  description: "Example PJob"
+  labels: [example]
+spec:
+  agent: my-agent
+  workflow: my-workflow
+  variable: my-variables
+  env: my-env
+  pmg: my-pmg
+  execution:
+    workDir: .
+    timeout: 600
+    keepTemp: false
+  output:
+    saveTo: ./output.md
+    format: raw
+    append: false
+"""
+
+EXAMPLES = {
+    "agent": AGENT_EXAMPLE,
+    "workflow": WORKFLOW_EXAMPLE,
+    "variable": VARIABLE_EXAMPLE,
+    "env": ENV_EXAMPLE,
+    "pmg": PMG_EXAMPLE,
+    "pjob": PJOB_EXAMPLE,
+}
+
+VALID_KINDS = {"Agent", "Workflow", "Variable", "Env", "PMG", "PJob"}


### PR DESCRIPTION
## Summary

Closes #12

- Add `--example` flag to all 6 entity `create` commands (agent, workflow, variable, env, pmg, pjob) that outputs a complete YAML example to stdout without creating files
- Create centralized `zima/templates/examples.py` with validated YAML templates for each entity type
- Add 33 unit tests (YAML structure + `from_dict()` round-trip) and 9 CLI integration tests

## Usage

```bash
zima agent create --example        # Print agent example YAML
zima pjob create --example         # Print pjob example YAML
zima pjob create --example > my-job.yaml  # Pipe to file
```

## Test plan

- [x] 628 tests pass (33 new unit + 9 new integration)
- [x] `ruff check` clean
- [x] `black --check` clean
- [x] Smoke tested all 6 `--example` commands
- [x] Verified `--example` ignores other params and exits early
- [x] Verified `create` without `--example` still requires mandatory params

🤖 Generated with [Claude Code](https://claude.com/claude-code)