### PR TITLE
feat: add daemon scheduler for 32-cycle PJob scheduling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,9 @@ python scripts/cleanup.py --auto
 
 ## Architecture
 
-### Configuration Entity System (5 + 1 types)
+### Configuration Entity System (6 + 1 types)
 
-The core design is composability through six YAML-based configuration types:
+The core design is composability through seven YAML-based configuration types:
 
 | Entity | Model | Purpose |
 |--------|-------|---------|
@@ -56,13 +56,14 @@ The core design is composability through six YAML-based configuration types:
 | Env | `EnvConfig` | Secrets and env vars (env/file/cmd/vault sources) |
 | PMG | `PMGConfig` | Dynamic CLI parameter groups with conditions |
 | **PJob** | `PJobConfig` | **Execution layer** — composes all above into a runnable job |
+| **Schedule** | `ScheduleConfig` | **Daemon scheduling** — 32-cycle PJob scheduling with stages |
 
 **Resolution precedence** (highest to lowest): PJob runtime overrides → PJob explicit refs → Agent defaults → System defaults.
 
 ### Key Layers
 
 - **`zima/cli.py`** — Typer CLI entry point. Registers subcommand groups. Has Windows UTF-8 fix.
-- **`zima/commands/`** — CLI subcommand implementations (agent, workflow, variable, env, pmg, pjob).
+- **`zima/commands/`** — CLI subcommand implementations (agent, workflow, variable, env, pmg, pjob, schedule).
 - **`zima/config/manager.py`** — `ConfigManager`: unified CRUD for all config types. Single class handles create/read/update/delete/list for every entity kind via `KINDS` set.
 - **`zima/models/`** — Dataclasses for each entity. `BaseConfig` provides common YAML load/save. `Metadata` has code/name/description.
 - **`zima/core/runner.py`** — `AgentRunner`: simple single-execution via subprocess. Builds kimi command, captures output, parses JSON result.
@@ -72,6 +73,7 @@ The core design is composability through six YAML-based configuration types:
 - **`zima/execution/background_runner.py`** — Background PJob execution in detached process.
 - **`zima/execution/history.py`** — Execution history tracking with PID recording.
 - **`zima/daemon_runner.py`** — Entry point for detached daemon process (`python -m zima.daemon_runner`).
+- **`zima/core/daemon_scheduler.py`** — `DaemonScheduler`: 32-cycle PJob scheduling with stage timers, PJob spawn/kill, JSONL history.
 - **`zima/utils.py`** — Shared utilities (`ensure_dir`, etc.).
 
 ### Execution Flow
@@ -91,7 +93,12 @@ zima pjob run <code>
 
 ```
 ~/.zima/
-├── configs/{agents,workflows,variables,envs,pmgs,pjobs}/   # YAML configs
+├── configs/{agents,workflows,variables,envs,pmgs,pjobs,schedules}/   # YAML configs
+├── daemon/                    # Daemon runtime (PID, state, logs, history)
+│   ├── daemon.pid
+│   ├── daemon.log
+│   ├── state.json
+│   └── history/*.jsonl
 └── agents/<code>/
     ├── workspace/     # Working directory for execution
     ├── prompts/       # Rendered prompt files
@@ -102,7 +109,7 @@ Customizable via `ZIMA_HOME` env var.
 
 ### Legacy Components (Unused in v2)
 
-`core/daemon.py`, `core/scheduler.py`, `core/state_manager.py` — retained for reference only. v2 replaced 15-min cycle architecture with single execution (see ADR 004).
+`core/daemon.py`, `core/scheduler.py`, `core/state_manager.py` — retained for reference only. v2 replaced 15-min cycle architecture with single execution (see ADR 004). `core/daemon_scheduler.py` is the new v3 daemon scheduler.
 
 ## Code Conventions
 

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -22,7 +22,7 @@ class TestConfigManagerBasics(TestIsolator):
 
     def test_kinds_constant(self):
         """Test KINDS constant."""
-        assert ConfigManager.KINDS == {"agent", "workflow", "variable", "env", "pmg", "pjob"}
+        assert ConfigManager.KINDS == {"agent", "workflow", "variable", "env", "pmg", "pjob", "schedule"}
 
 
 class TestConfigManagerCRUD(TestIsolator):

--- a/tests/unit/test_daemon_scheduler.py
+++ b/tests/unit/test_daemon_scheduler.py
@@ -1,0 +1,78 @@
+import json
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from zima.core.daemon_scheduler import DaemonScheduler
+from zima.models.schedule import ScheduleConfig
+
+
+class TestCycleMath:
+    def test_current_cycle_num_at_midnight(self):
+        cfg = ScheduleConfig.create(code="daily", name="Daily")
+        sched = DaemonScheduler(cfg, Path("/tmp/daemon"))
+        dt = datetime(2026, 4, 16, 0, 0, 0)
+        assert sched._current_cycle_num(dt) == 0
+
+    def test_current_cycle_num_at_45_min(self):
+        cfg = ScheduleConfig.create(code="daily", name="Daily")
+        sched = DaemonScheduler(cfg, Path("/tmp/daemon"))
+        dt = datetime(2026, 4, 16, 0, 45, 0)
+        assert sched._current_cycle_num(dt) == 1
+
+    def test_current_cycle_num_at_22_30(self):
+        cfg = ScheduleConfig.create(code="daily", name="Daily")
+        sched = DaemonScheduler(cfg, Path("/tmp/daemon"))
+        dt = datetime(2026, 4, 16, 22, 30, 0)
+        assert sched._current_cycle_num(dt) == 30
+
+    def test_cycle_start_time(self):
+        cfg = ScheduleConfig.create(code="daily", name="Daily")
+        sched = DaemonScheduler(cfg, Path("/tmp/daemon"))
+        # 10:15 is in the cycle that started at 9:45 (13th cycle: 13*45=585min=9h45m)
+        dt = datetime(2026, 4, 16, 10, 15, 0)
+        start = sched._cycle_start_time(dt)
+        assert start == datetime(2026, 4, 16, 9, 45, 0)
+
+
+class TestStageTransitions:
+    def test_kill_all_pjobs_records_timeout(self, tmp_path):
+        cfg = ScheduleConfig.create(code="daily", name="Daily")
+        sched = DaemonScheduler(cfg, tmp_path)
+        sched.current_cycle = 5
+        sched.current_stage = "work"
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        sched.active_pjobs["p1"] = mock_proc
+
+        sched._kill_all_pjobs("rest")
+
+        mock_proc.terminate.assert_called_once()
+        mock_proc.wait.assert_called_once_with(timeout=5)
+
+        # Check history file
+        history_file = tmp_path / "history"
+        jsonl_files = list(history_file.glob("*.jsonl"))
+        assert len(jsonl_files) == 1
+        lines = jsonl_files[0].read_text(encoding="utf-8").strip().split("\n")
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["pjobCode"] == "p1"
+        assert record["status"] == "killed_timeout"
+
+    def test_start_pjob_launch_failed(self, tmp_path):
+        cfg = ScheduleConfig.create(code="daily", name="Daily")
+        sched = DaemonScheduler(cfg, tmp_path)
+        sched.current_cycle = 1
+        sched.current_stage = "work"
+
+        with patch("zima.core.daemon_scheduler.subprocess.Popen", side_effect=OSError("boom")):
+            sched._start_pjob("bad-pjob")
+
+        history_file = tmp_path / "history"
+        jsonl_files = list(history_file.glob("*.jsonl"))
+        assert len(jsonl_files) == 1
+        record = json.loads(jsonl_files[0].read_text(encoding="utf-8").strip().split("\n")[0])
+        assert record["pjobCode"] == "bad-pjob"
+        assert record["status"] == "launch_failed"

--- a/tests/unit/test_daemon_scheduler.py
+++ b/tests/unit/test_daemon_scheduler.py
@@ -59,7 +59,7 @@ class TestStageTransitions:
         assert len(lines) == 1
         record = json.loads(lines[0])
         assert record["pjobCode"] == "p1"
-        assert record["status"] == "killed_timeout"
+        assert record["status"] == "terminated"
 
     def test_start_pjob_launch_failed(self, tmp_path):
         cfg = ScheduleConfig.create(code="daily", name="Daily")

--- a/tests/unit/test_examples.py
+++ b/tests/unit/test_examples.py
@@ -72,6 +72,7 @@ class TestExamplesStructure:
             "env": "Env",
             "pmg": "PMG",
             "pjob": "PJob",
+            "schedule": "Schedule",
         }
         assert (
             data["kind"] == kind_map[kind]
@@ -82,18 +83,18 @@ class TestExamplesCoverage:
     """Tests for EXAMPLES dict coverage."""
 
     def test_examples_covers_all_six_kinds(self):
-        """EXAMPLES dict must contain exactly 6 kinds."""
-        expected = {"agent", "workflow", "variable", "env", "pmg", "pjob"}
+        """EXAMPLES dict must contain all entity kinds."""
+        expected = {"agent", "workflow", "variable", "env", "pmg", "pjob", "schedule"}
         assert set(EXAMPLES.keys()) == expected
 
     def test_valid_kinds_constant(self):
-        """VALID_KINDS must be the correct set of 6 kind strings."""
-        expected = {"Agent", "Workflow", "Variable", "Env", "PMG", "PJob"}
+        """VALID_KINDS must be the correct set of kind strings."""
+        expected = {"Agent", "Workflow", "Variable", "Env", "PMG", "PJob", "Schedule"}
         assert VALID_KINDS == expected
 
     def test_valid_kinds_size(self):
-        """VALID_KINDS must have exactly 6 entries."""
-        assert len(VALID_KINDS) == 6
+        """VALID_KINDS must have the correct number of entries."""
+        assert len(VALID_KINDS) == 7
 
 
 class TestAgentRoundTrip:

--- a/tests/unit/test_models_schedule.py
+++ b/tests/unit/test_models_schedule.py
@@ -1,0 +1,69 @@
+import pytest
+
+from zima.models.schedule import ScheduleConfig, ScheduleCycleType, ScheduleStage
+
+
+class TestScheduleStage:
+    def test_to_dict_and_from_dict(self):
+        stage = ScheduleStage(name="work", offset_minutes=0, duration_minutes=20)
+        data = stage.to_dict()
+        assert data == {"name": "work", "offsetMinutes": 0, "durationMinutes": 20}
+        restored = ScheduleStage.from_dict(data)
+        assert restored == stage
+
+
+class TestScheduleCycleType:
+    def test_get_stage_pjobs(self):
+        ct = ScheduleCycleType(type_id="A", work=["p1"], rest=["p2"], dream=["p3"])
+        assert ct.get_stage_pjobs("work") == ["p1"]
+        assert ct.get_stage_pjobs("rest") == ["p2"]
+        assert ct.get_stage_pjobs("dream") == ["p3"]
+        assert ct.get_stage_pjobs("unknown") == []
+
+
+class TestScheduleConfig:
+    def test_create_defaults(self):
+        cfg = ScheduleConfig.create(code="daily", name="Daily")
+        assert cfg.cycle_minutes == 45
+        assert cfg.daily_cycles == 32
+        assert len(cfg.stages) == 3
+        assert len(cfg.cycle_mapping) == 32
+        assert cfg.cycle_mapping[0] == "idle"
+
+    def test_validate_valid(self):
+        cfg = ScheduleConfig.create(code="daily", name="Daily")
+        cfg.cycle_types = [ScheduleCycleType(type_id="A")]
+        cfg.cycle_mapping = ["A"] * 32
+        assert cfg.validate() == []
+
+    def test_validate_missing_code(self):
+        cfg = ScheduleConfig.create(code="", name="Daily")
+        errors = cfg.validate()
+        assert any("metadata.code is required" in e for e in errors)
+
+    def test_validate_stage_overflow(self):
+        cfg = ScheduleConfig.create(code="daily", name="Daily")
+        cfg.stages = [ScheduleStage(name="work", offset_minutes=0, duration_minutes=50)]
+        errors = cfg.validate()
+        assert any("exceeding cycle" in e for e in errors)
+
+    def test_validate_unsorted_stages(self):
+        cfg = ScheduleConfig.create(code="daily", name="Daily")
+        cfg.stages = [
+            ScheduleStage(name="rest", offset_minutes=20, duration_minutes=15),
+            ScheduleStage(name="work", offset_minutes=0, duration_minutes=20),
+        ]
+        errors = cfg.validate()
+        assert any("sorted by offsetMinutes" in e for e in errors)
+
+    def test_validate_mapping_length(self):
+        cfg = ScheduleConfig.create(code="daily", name="Daily")
+        cfg.cycle_mapping = ["A"] * 10
+        errors = cfg.validate()
+        assert any("must equal dailyCycles" in e for e in errors)
+
+    def test_validate_unknown_type_id(self):
+        cfg = ScheduleConfig.create(code="daily", name="Daily")
+        cfg.cycle_mapping = ["Z"] * 32
+        errors = cfg.validate()
+        assert any("unknown typeId 'Z'" in e for e in errors)

--- a/zima/cli.py
+++ b/zima/cli.py
@@ -338,6 +338,16 @@ def daemon_start(
     # Detach file handle — daemon process owns it now
     log_fh.close()
 
+    # Brief check that child didn't exit immediately (e.g. validation failure)
+    import time
+
+    time.sleep(0.5)
+    if proc.poll() is not None:
+        pid_file.unlink(missing_ok=True)
+        console.print(f"[red]✗[/red] Daemon exited immediately (code {proc.returncode})")
+        console.print(f"   Check log: {log_file}")
+        raise typer.Exit(1)
+
     pid_file.write_text(str(proc.pid), encoding="utf-8")
     console.print(f"[green]✓[/green] Daemon started (PID {proc.pid})")
     console.print(f"   Schedule: {schedule}")

--- a/zima/cli.py
+++ b/zima/cli.py
@@ -357,7 +357,22 @@ def daemon_stop():
     try:
         pid = int(pid_file.read_text(encoding="utf-8").strip())
         if sys.platform == "win32":
-            subprocess.run(["taskkill", "/PID", str(pid), "/F"], check=False)
+            # Try graceful shutdown first, then force after 5s
+            subprocess.run(["taskkill", "/PID", str(pid)], check=False)
+            import time
+
+            time.sleep(5)
+            # Force kill if still alive
+            try:
+                import ctypes
+
+                kernel32 = ctypes.windll.kernel32
+                handle = kernel32.OpenProcess(1, False, pid)
+                if handle:
+                    kernel32.CloseHandle(handle)
+                    subprocess.run(["taskkill", "/PID", str(pid), "/F"], check=False)
+            except Exception:
+                pass
         else:
             import os
             import signal

--- a/zima/cli.py
+++ b/zima/cli.py
@@ -319,22 +319,27 @@ def daemon_start(
     ]
 
     log_fh = open(log_file, "w", encoding="utf-8")
-    if sys.platform == "win32":
-        proc = subprocess.Popen(
-            cmd,
-            stdout=log_fh,
-            stderr=subprocess.STDOUT,
-            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW,
-            close_fds=True,
-        )
-    else:
-        proc = subprocess.Popen(
-            cmd,
-            stdout=log_fh,
-            stderr=subprocess.STDOUT,
-            start_new_session=True,
-            close_fds=True,
-        )
+    try:
+        if sys.platform == "win32":
+            proc = subprocess.Popen(
+                cmd,
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW,
+                close_fds=True,
+            )
+        else:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                close_fds=True,
+            )
+    except Exception as e:
+        log_fh.close()
+        console.print(f"[red]✗[/red] Failed to start daemon: {e}")
+        raise typer.Exit(1)
     # Detach file handle — daemon process owns it now
     log_fh.close()
 

--- a/zima/cli.py
+++ b/zima/cli.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Optional
 
 # Fix Windows UTF-8 encoding issue
-from zima.utils import setup_windows_utf8
+from zima.utils import get_zima_home, setup_windows_utf8
 
 setup_windows_utf8()
 
@@ -274,7 +274,7 @@ def daemon_start(
     schedule: str = typer.Option(..., "--schedule", "-s", help="Schedule code"),
 ):
     """Start the global daemon"""
-    daemon_dir = Path.home() / ".zima" / "daemon"
+    daemon_dir = get_zima_home() / "daemon"
     pid_file = daemon_dir / "daemon.pid"
 
     if pid_file.exists():
@@ -318,10 +318,11 @@ def daemon_start(
         schedule,
     ]
 
+    log_fh = open(log_file, "w", encoding="utf-8")
     if sys.platform == "win32":
         proc = subprocess.Popen(
             cmd,
-            stdout=open(log_file, "w", encoding="utf-8"),
+            stdout=log_fh,
             stderr=subprocess.STDOUT,
             creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW,
             close_fds=True,
@@ -329,11 +330,13 @@ def daemon_start(
     else:
         proc = subprocess.Popen(
             cmd,
-            stdout=open(log_file, "w", encoding="utf-8"),
+            stdout=log_fh,
             stderr=subprocess.STDOUT,
             start_new_session=True,
             close_fds=True,
         )
+    # Detach file handle — daemon process owns it now
+    log_fh.close()
 
     pid_file.write_text(str(proc.pid), encoding="utf-8")
     console.print(f"[green]✓[/green] Daemon started (PID {proc.pid})")
@@ -344,7 +347,7 @@ def daemon_start(
 @app.command()
 def daemon_stop():
     """Stop the global daemon"""
-    daemon_dir = Path.home() / ".zima" / "daemon"
+    daemon_dir = get_zima_home() / "daemon"
     pid_file = daemon_dir / "daemon.pid"
 
     if not pid_file.exists():
@@ -370,7 +373,7 @@ def daemon_stop():
 @app.command()
 def daemon_status():
     """Show daemon status"""
-    daemon_dir = Path.home() / ".zima" / "daemon"
+    daemon_dir = get_zima_home() / "daemon"
     pid_file = daemon_dir / "daemon.pid"
     state_file = daemon_dir / "state.json"
 
@@ -423,7 +426,7 @@ def daemon_logs(
     tail: int = typer.Option(20, "--tail", "-n", help="Number of lines"),
 ):
     """Show daemon logs"""
-    log_file = Path.home() / ".zima" / "daemon" / "daemon.log"
+    log_file = get_zima_home() / "daemon" / "daemon.log"
     if not log_file.exists():
         console.print("[yellow]No daemon logs found[/yellow]")
         raise typer.Exit(0)

--- a/zima/cli.py
+++ b/zima/cli.py
@@ -19,6 +19,7 @@ from zima.commands import agent as agent_cmd
 from zima.commands import env as env_cmd
 from zima.commands import pjob as pjob_cmd
 from zima.commands import pmg as pmg_cmd
+from zima.commands import schedule as schedule_cmd
 from zima.commands import variable as variable_cmd
 from zima.commands import workflow as workflow_cmd
 from zima.core import AgentRunner
@@ -37,6 +38,7 @@ app.add_typer(variable_cmd.app, name="variable")
 app.add_typer(env_cmd.app, name="env")
 app.add_typer(pmg_cmd.app, name="pmg")
 app.add_typer(pjob_cmd.app, name="pjob")
+app.add_typer(schedule_cmd.app, name="schedule")
 console = Console(legacy_windows=False, force_terminal=True)
 
 

--- a/zima/cli.py
+++ b/zima/cli.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -22,8 +24,10 @@ from zima.commands import pmg as pmg_cmd
 from zima.commands import schedule as schedule_cmd
 from zima.commands import variable as variable_cmd
 from zima.commands import workflow as workflow_cmd
+from zima.config.manager import ConfigManager
 from zima.core import AgentRunner
 from zima.models import AgentConfig
+from zima.models.schedule import ScheduleConfig
 
 app = typer.Typer(
     name="zima",
@@ -258,6 +262,175 @@ def logs(
             console.print(line)
     except Exception as e:
         console.print(f"[red]Error reading log: {e}[/red]")
+
+
+# ---------------------------------------------------------------------------
+# Daemon commands
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def daemon_start(
+    schedule: str = typer.Option(..., "--schedule", "-s", help="Schedule code"),
+):
+    """Start the global daemon"""
+    daemon_dir = Path.home() / ".zima" / "daemon"
+    pid_file = daemon_dir / "daemon.pid"
+
+    if pid_file.exists():
+        try:
+            pid = int(pid_file.read_text(encoding="utf-8").strip())
+            # Check if process is alive
+            import ctypes
+
+            kernel32 = ctypes.windll.kernel32
+            handle = kernel32.OpenProcess(1, False, pid)
+            if handle:
+                kernel32.CloseHandle(handle)
+                console.print(f"[yellow]⚠[/yellow] Daemon already running (PID {pid})")
+                raise typer.Exit(1)
+        except Exception:
+            pass
+        pid_file.unlink(missing_ok=True)
+
+    manager = ConfigManager()
+    if not manager.config_exists("schedule", schedule):
+        console.print(f"[red]✗[/red] Schedule '{schedule}' not found")
+        raise typer.Exit(1)
+
+    data = manager.load_config("schedule", schedule)
+    cfg = ScheduleConfig.from_dict(data)
+    errors = cfg.validate(resolve_refs=True)
+    if errors:
+        console.print("[red]✗[/red] Schedule validation failed:")
+        for e in errors:
+            console.print(f"   [red]•[/red] {e}")
+        raise typer.Exit(1)
+
+    log_file = daemon_dir / "daemon.log"
+    daemon_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "zima.daemon_runner",
+        "--schedule",
+        schedule,
+    ]
+
+    if sys.platform == "win32":
+        proc = subprocess.Popen(
+            cmd,
+            stdout=open(log_file, "w", encoding="utf-8"),
+            stderr=subprocess.STDOUT,
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW,
+            close_fds=True,
+        )
+    else:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=open(log_file, "w", encoding="utf-8"),
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            close_fds=True,
+        )
+
+    pid_file.write_text(str(proc.pid), encoding="utf-8")
+    console.print(f"[green]✓[/green] Daemon started (PID {proc.pid})")
+    console.print(f"   Schedule: {schedule}")
+    console.print(f"   Log: {log_file}")
+
+
+@app.command()
+def daemon_stop():
+    """Stop the global daemon"""
+    daemon_dir = Path.home() / ".zima" / "daemon"
+    pid_file = daemon_dir / "daemon.pid"
+
+    if not pid_file.exists():
+        console.print("[yellow]⚠[/yellow] Daemon is not running")
+        raise typer.Exit(0)
+
+    try:
+        pid = int(pid_file.read_text(encoding="utf-8").strip())
+        if sys.platform == "win32":
+            subprocess.run(["taskkill", "/PID", str(pid), "/F"], check=False)
+        else:
+            import os
+            import signal
+
+            os.kill(pid, signal.SIGTERM)
+        pid_file.unlink(missing_ok=True)
+        console.print(f"[green]✓[/green] Daemon stopped (PID {pid})")
+    except Exception as e:
+        console.print(f"[red]✗[/red] Failed to stop daemon: {e}")
+        raise typer.Exit(1)
+
+
+@app.command()
+def daemon_status():
+    """Show daemon status"""
+    daemon_dir = Path.home() / ".zima" / "daemon"
+    pid_file = daemon_dir / "daemon.pid"
+    state_file = daemon_dir / "state.json"
+
+    if not pid_file.exists():
+        console.print("[yellow]Daemon is not running[/yellow]")
+        raise typer.Exit(0)
+
+    try:
+        pid = int(pid_file.read_text(encoding="utf-8").strip())
+    except ValueError:
+        console.print("[red]Invalid PID file[/red]")
+        raise typer.Exit(1)
+
+    # Check if alive
+    alive = False
+    if sys.platform == "win32":
+        import ctypes
+
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.OpenProcess(1, False, pid)
+        if handle:
+            kernel32.CloseHandle(handle)
+            alive = True
+    else:
+        import os
+
+        try:
+            os.kill(pid, 0)
+            alive = True
+        except OSError:
+            pass
+
+    if not alive:
+        console.print(f"[yellow]Daemon PID {pid} is not alive[/yellow]")
+        raise typer.Exit(0)
+
+    console.print(f"[green]Daemon is running[/green] (PID {pid})")
+
+    if state_file.exists():
+        import json
+
+        state = json.loads(state_file.read_text(encoding="utf-8"))
+        console.print(f"   Current cycle: {state.get('currentCycle', 'unknown')}")
+        console.print(f"   Current stage: {state.get('currentStage', 'unknown')}")
+        console.print(f"   Active PJobs: {state.get('activePjobs', [])}")
+
+
+@app.command()
+def daemon_logs(
+    tail: int = typer.Option(20, "--tail", "-n", help="Number of lines"),
+):
+    """Show daemon logs"""
+    log_file = Path.home() / ".zima" / "daemon" / "daemon.log"
+    if not log_file.exists():
+        console.print("[yellow]No daemon logs found[/yellow]")
+        raise typer.Exit(0)
+
+    lines = log_file.read_text(encoding="utf-8").splitlines()
+    for line in lines[-tail:]:
+        console.print(line)
 
 
 if __name__ == "__main__":

--- a/zima/cli.py
+++ b/zima/cli.py
@@ -368,7 +368,8 @@ def daemon_stop():
         pid = int(pid_file.read_text(encoding="utf-8").strip())
         if sys.platform == "win32":
             # Try graceful shutdown first, then force after 5s
-            subprocess.run(["taskkill", "/PID", str(pid)], check=False)
+            # /T kills the entire process tree (PJobs spawned with CREATE_NEW_PROCESS_GROUP)
+            subprocess.run(["taskkill", "/PID", str(pid), "/T"], check=False)
             import time
 
             time.sleep(5)
@@ -380,7 +381,7 @@ def daemon_stop():
                 handle = kernel32.OpenProcess(1, False, pid)
                 if handle:
                     kernel32.CloseHandle(handle)
-                    subprocess.run(["taskkill", "/PID", str(pid), "/F"], check=False)
+                    subprocess.run(["taskkill", "/PID", str(pid), "/T", "/F"], check=False)
             except Exception:
                 pass
         else:

--- a/zima/commands/schedule.py
+++ b/zima/commands/schedule.py
@@ -26,7 +26,9 @@ def create(
 ):
     """Create a new Schedule"""
     if example:
-        print(EXAMPLE_YAML)
+        from zima.templates.examples import EXAMPLES
+
+        print(EXAMPLES["schedule"])
         raise typer.Exit(0)
 
     if not name or not code:
@@ -242,35 +244,3 @@ def set_mapping(
     cfg.cycle_mapping[index] = type_id
     manager.save_config("schedule", code, cfg.to_dict())
     console.print(f"[green]✓[/green] Set cycleMapping[{index}] = '{type_id}'")
-
-
-EXAMPLE_YAML = """\
-apiVersion: zima.io/v1
-kind: Schedule
-metadata:
-  code: daily-32
-  name: "每日32周期调度"
-spec:
-  cycleMinutes: 45
-  dailyCycles: 32
-  stages:
-    - name: work
-      offsetMinutes: 0
-      durationMinutes: 20
-    - name: rest
-      offsetMinutes: 20
-      durationMinutes: 15
-    - name: dream
-      offsetMinutes: 35
-      durationMinutes: 10
-  cycleTypes:
-    - typeId: A
-      work: [pjob-a1]
-      rest: [pjob-a2]
-      dream: [pjob-a3]
-  cycleMapping:
-    - A
-    - idle
-    - A
-    # ... total 32 items
-"""

--- a/zima/commands/schedule.py
+++ b/zima/commands/schedule.py
@@ -1,0 +1,268 @@
+"""Schedule management commands for daemon-mode cycle configuration."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+from rich.tree import Tree
+
+from zima.config.manager import ConfigManager
+from zima.models.schedule import ScheduleConfig, ScheduleCycleType
+from zima.utils import validate_code_with_error
+
+app = typer.Typer(name="schedule", help="Schedule management - daemon cycle configuration")
+console = Console(legacy_windows=False, force_terminal=True)
+
+
+@app.command()
+def create(
+    example: bool = typer.Option(False, "--example", help="Print example YAML and exit"),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Display name"),
+    code: Optional[str] = typer.Option(None, "--code", "-c", help="Unique code"),
+    force: bool = typer.Option(False, "--force", "-f", help="Overwrite if exists"),
+):
+    """Create a new Schedule"""
+    if example:
+        print(EXAMPLE_YAML)
+        raise typer.Exit(0)
+
+    if not name or not code:
+        console.print("[red]✗[/red] --name and --code are required")
+        raise typer.Exit(1)
+
+    is_valid, error = validate_code_with_error(code)
+    if not is_valid:
+        console.print(f"[red]✗[/red] Invalid code: {error}")
+        raise typer.Exit(1)
+
+    manager = ConfigManager()
+    if manager.config_exists("schedule", code):
+        if force:
+            manager.delete_config("schedule", code)
+            console.print(f"[yellow]⚠[/yellow] Overwriting existing schedule '{code}'")
+        else:
+            console.print(f"[red]✗[/red] Schedule '{code}' already exists")
+            raise typer.Exit(1)
+
+    config = ScheduleConfig.create(code=code, name=name)
+    manager.save_config("schedule", code, config.to_dict())
+    console.print(f"[green]✓[/green] Schedule '{code}' created")
+    console.print(f"   File: {manager.get_config_path('schedule', code)}")
+
+
+@app.command("list")
+def list_schedules():
+    """List all Schedules"""
+    manager = ConfigManager()
+    configs = manager.list_configs("schedule")
+
+    if not configs:
+        console.print("[yellow]No schedules found.[/yellow]")
+        return
+
+    table = Table(title="Schedules")
+    table.add_column("Code", style="cyan")
+    table.add_column("Name", style="green")
+    table.add_column("Cycles", style="yellow")
+    table.add_column("Types", style="blue")
+
+    for data in configs:
+        cfg = ScheduleConfig.from_dict(data)
+        type_count = len(cfg.cycle_types)
+        table.add_row(cfg.metadata.code, cfg.metadata.name, str(cfg.daily_cycles), str(type_count))
+
+    console.print(table)
+
+
+@app.command()
+def show(
+    code: str = typer.Argument(..., help="Schedule code"),
+):
+    """Show Schedule details"""
+    manager = ConfigManager()
+    if not manager.config_exists("schedule", code):
+        console.print(f"[red]✗[/red] Schedule '{code}' not found")
+        raise typer.Exit(1)
+
+    data = manager.load_config("schedule", code)
+    cfg = ScheduleConfig.from_dict(data)
+
+    tree = Tree(f"[bold cyan]Schedule: {code}[/bold cyan]")
+    meta = tree.add("[bold]Metadata[/bold]")
+    meta.add(f"Name: {cfg.metadata.name}")
+    if cfg.metadata.description:
+        meta.add(f"Description: {cfg.metadata.description}")
+
+    spec = tree.add("[bold]Spec[/bold]")
+    spec.add(f"Cycle: {cfg.cycle_minutes} minutes")
+    spec.add(f"Daily cycles: {cfg.daily_cycles}")
+
+    stages = tree.add("[bold]Stages[/bold]")
+    for s in cfg.stages:
+        stages.add(f"{s.name}: +{s.offset_minutes}m ({s.duration_minutes}m)")
+
+    types = tree.add("[bold]Cycle Types[/bold]")
+    for ct in cfg.cycle_types:
+        types.add(f"{ct.type_id}: work={ct.work}, rest={ct.rest}, dream={ct.dream}")
+
+    mapping = tree.add("[bold]Cycle Mapping (first 16)[/bold]")
+    mapping.add(str(cfg.cycle_mapping[:16]))
+
+    console.print(tree)
+
+
+@app.command()
+def update(
+    code: str = typer.Argument(..., help="Schedule code"),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="New display name"),
+    description: Optional[str] = typer.Option(None, "--description", "-d", help="New description"),
+):
+    """Update Schedule metadata"""
+    manager = ConfigManager()
+    if not manager.config_exists("schedule", code):
+        console.print(f"[red]✗[/red] Schedule '{code}' not found")
+        raise typer.Exit(1)
+
+    data = manager.load_config("schedule", code)
+    cfg = ScheduleConfig.from_dict(data)
+    if name:
+        cfg.metadata.name = name
+    if description is not None:
+        cfg.metadata.description = description
+
+    manager.save_config("schedule", code, cfg.to_dict())
+    console.print(f"[green]✓[/green] Schedule '{code}' updated")
+
+
+@app.command()
+def delete(
+    code: str = typer.Argument(..., help="Schedule code"),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
+):
+    """Delete a Schedule"""
+    manager = ConfigManager()
+    if not manager.config_exists("schedule", code):
+        console.print(f"[red]✗[/red] Schedule '{code}' not found")
+        raise typer.Exit(1)
+
+    if not force:
+        if not typer.confirm(f"Delete schedule '{code}'?"):
+            console.print("Cancelled")
+            raise typer.Exit(0)
+
+    manager.delete_config("schedule", code)
+    console.print(f"[green]✓[/green] Schedule '{code}' deleted")
+
+
+@app.command()
+def validate(
+    code: str = typer.Argument(..., help="Schedule code"),
+    strict: bool = typer.Option(True, "--strict/--no-strict", help="Check PJob refs exist"),
+):
+    """Validate a Schedule"""
+    manager = ConfigManager()
+    if not manager.config_exists("schedule", code):
+        console.print(f"[red]✗[/red] Schedule '{code}' not found")
+        raise typer.Exit(1)
+
+    data = manager.load_config("schedule", code)
+    cfg = ScheduleConfig.from_dict(data)
+    errors = cfg.validate(resolve_refs=strict)
+
+    if errors:
+        console.print(f"[red]✗[/red] Validation failed:")
+        for e in errors:
+            console.print(f"   [red]•[/red] {e}")
+        raise typer.Exit(1)
+
+    console.print(f"[green]✓[/green] Schedule '{code}' is valid")
+
+
+@app.command()
+def set_type(
+    code: str = typer.Argument(..., help="Schedule code"),
+    type_id: str = typer.Option(..., "--typeId", help="Cycle type ID (e.g., A)"),
+    stage: str = typer.Option(..., "--stage", help="Stage name: work/rest/dream"),
+    pjobs: List[str] = typer.Option(..., "--pjobs", help="PJob codes"),
+):
+    """Set PJobs for a cycle type and stage"""
+    valid_stages = {"work", "rest", "dream"}
+    if stage not in valid_stages:
+        console.print(f"[red]✗[/red] stage must be one of {valid_stages}")
+        raise typer.Exit(1)
+
+    manager = ConfigManager()
+    if not manager.config_exists("schedule", code):
+        console.print(f"[red]✗[/red] Schedule '{code}' not found")
+        raise typer.Exit(1)
+
+    data = manager.load_config("schedule", code)
+    cfg = ScheduleConfig.from_dict(data)
+
+    # Find or create cycle type
+    ct = cfg.get_cycle_type(type_id)
+    if ct is None:
+        ct = ScheduleCycleType(type_id=type_id)
+        cfg.cycle_types.append(ct)
+
+    setattr(ct, stage, list(pjobs))
+    manager.save_config("schedule", code, cfg.to_dict())
+    console.print(f"[green]✓[/green] Set {code}/{type_id}/{stage} = {list(pjobs)}")
+
+
+@app.command()
+def set_mapping(
+    code: str = typer.Argument(..., help="Schedule code"),
+    index: int = typer.Option(..., "--index", help="Cycle index 0-31"),
+    type_id: str = typer.Option(..., "--type", help="Type ID or 'idle'"),
+):
+    """Set cycle mapping at a specific index"""
+    if not (0 <= index <= 31):
+        console.print("[red]✗[/red] index must be 0-31")
+        raise typer.Exit(1)
+
+    manager = ConfigManager()
+    if not manager.config_exists("schedule", code):
+        console.print(f"[red]✗[/red] Schedule '{code}' not found")
+        raise typer.Exit(1)
+
+    data = manager.load_config("schedule", code)
+    cfg = ScheduleConfig.from_dict(data)
+    cfg.cycle_mapping[index] = type_id
+    manager.save_config("schedule", code, cfg.to_dict())
+    console.print(f"[green]✓[/green] Set cycleMapping[{index}] = '{type_id}'")
+
+
+EXAMPLE_YAML = """\
+apiVersion: zima.io/v1
+kind: Schedule
+metadata:
+  code: daily-32
+  name: "每日32周期调度"
+spec:
+  cycleMinutes: 45
+  dailyCycles: 32
+  stages:
+    - name: work
+      offsetMinutes: 0
+      durationMinutes: 20
+    - name: rest
+      offsetMinutes: 20
+      durationMinutes: 15
+    - name: dream
+      offsetMinutes: 35
+      durationMinutes: 10
+  cycleTypes:
+    - typeId: A
+      work: [pjob-a1]
+      rest: [pjob-a2]
+      dream: [pjob-a3]
+  cycleMapping:
+    - A
+    - idle
+    - A
+    # ... total 32 items
+"""

--- a/zima/commands/schedule.py
+++ b/zima/commands/schedule.py
@@ -231,6 +231,14 @@ def set_mapping(
 
     data = manager.load_config("schedule", code)
     cfg = ScheduleConfig.from_dict(data)
+
+    # Validate type_id against defined cycle types
+    if type_id != "idle":
+        valid_type_ids = {ct.type_id for ct in cfg.cycle_types}
+        if type_id not in valid_type_ids:
+            console.print(f"[red]✗[/red] Unknown typeId '{type_id}'. Valid: {sorted(valid_type_ids) or '(none defined)'}")
+            raise typer.Exit(1)
+
     cfg.cycle_mapping[index] = type_id
     manager.save_config("schedule", code, cfg.to_dict())
     console.print(f"[green]✓[/green] Set cycleMapping[{index}] = '{type_id}'")

--- a/zima/config/manager.py
+++ b/zima/config/manager.py
@@ -29,7 +29,7 @@ class ConfigManager:
     """
 
     # Supported configuration kinds
-    KINDS = {"agent", "workflow", "variable", "env", "pmg", "pjob"}
+    KINDS = {"agent", "workflow", "variable", "env", "pmg", "pjob", "schedule"}
 
     def __init__(self, config_dir: Optional[Path] = None):
         """

--- a/zima/core/__init__.py
+++ b/zima/core/__init__.py
@@ -1,6 +1,7 @@
 """Core components for ZimaBlue - v2"""
 
 from .claude_runner import ClaudeRunner
+from .daemon_scheduler import DaemonScheduler
 from .runner import AgentRunner
 
-__all__ = ["AgentRunner", "ClaudeRunner"]
+__all__ = ["AgentRunner", "ClaudeRunner", "DaemonScheduler"]

--- a/zima/core/daemon_scheduler.py
+++ b/zima/core/daemon_scheduler.py
@@ -26,7 +26,7 @@ class DaemonScheduler:
         self.active_pjobs: dict[str, subprocess.Popen] = {}
         self._pjob_log_handles: dict[str, object] = {}
         self._timers: list[threading.Timer] = []
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
 
         # Ensure runtime directories
         self.daemon_dir.mkdir(parents=True, exist_ok=True)

--- a/zima/core/daemon_scheduler.py
+++ b/zima/core/daemon_scheduler.py
@@ -98,12 +98,14 @@ class DaemonScheduler:
         if not self.running:
             return
 
-        self.current_stage = stage_name
+        previous_stage = self.current_stage
         self._log(f"Stage '{stage_name}' triggered in cycle {self.current_cycle}")
 
-        # Kill previous stage PJobs
+        # Kill previous stage PJobs (use previous stage name for history)
         with self._lock:
-            self._kill_all_pjobs(stage_name=f"pre-{stage_name}")
+            self._kill_all_pjobs(stage_name=previous_stage or "startup")
+
+        self.current_stage = stage_name
 
         pjob_codes = cycle_type.get_stage_pjobs(stage_name)
         for code in pjob_codes:
@@ -130,6 +132,7 @@ class DaemonScheduler:
             )
         else:
             kwargs["start_new_session"] = True
+        kwargs["close_fds"] = True
 
         try:
             proc = subprocess.Popen(cmd, **kwargs)

--- a/zima/core/daemon_scheduler.py
+++ b/zima/core/daemon_scheduler.py
@@ -1,0 +1,222 @@
+"""Daemon scheduler for 32-cycle PJob execution."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import threading
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from zima.models.schedule import ScheduleConfig
+
+
+class DaemonScheduler:
+    """Runs PJobs on a fixed 45-minute cycle schedule with 3 stages."""
+
+    def __init__(self, schedule: ScheduleConfig, daemon_dir: Path):
+        self.schedule = schedule
+        self.daemon_dir = daemon_dir
+        self.running = False
+        self.current_cycle = -1
+        self.current_stage: str | None = None
+        self.active_pjobs: dict[str, subprocess.Popen] = {}
+        self._timers: list[threading.Timer] = []
+        self._lock = threading.Lock()
+
+        # Ensure runtime directories
+        self.daemon_dir.mkdir(parents=True, exist_ok=True)
+        self.log_dir = daemon_dir / "history"
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+
+    def run(self) -> None:
+        """Main scheduling loop."""
+        self.running = True
+        self._log("DaemonScheduler started")
+        self._save_state()
+
+        while self.running:
+            now = datetime.now()
+            cycle_num = self._current_cycle_num(now)
+            cycle_start = self._cycle_start_time(now)
+            next_cycle_start = cycle_start + timedelta(minutes=self.schedule.cycle_minutes)
+
+            if cycle_num != self.current_cycle:
+                self.current_cycle = cycle_num
+                self._log(f"Entering cycle {cycle_num}")
+                self._start_cycle(cycle_num, cycle_start)
+
+            # Sleep until next cycle boundary
+            sleep_seconds = (next_cycle_start - datetime.now()).total_seconds()
+            if sleep_seconds > 0:
+                self._sleep(sleep_seconds)
+
+        self._log("DaemonScheduler stopped")
+
+    def stop(self) -> None:
+        """Stop the scheduler gracefully."""
+        self.running = False
+        for timer in self._timers:
+            timer.cancel()
+        self._timers.clear()
+        with self._lock:
+            self._kill_all_pjobs(stage_name="shutdown")
+        self._log("Received stop signal")
+
+    def _start_cycle(self, cycle_num: int, cycle_start: datetime) -> None:
+        """Schedule stage timers for this cycle."""
+        self._cancel_timers()
+        mapped_type = self.schedule.cycle_mapping[cycle_num]
+
+        if mapped_type == "idle":
+            self._log(f"Cycle {cycle_num} is idle, sleeping")
+            return
+
+        cycle_type = self.schedule.get_cycle_type(mapped_type)
+        if cycle_type is None:
+            self._log(f"Cycle {cycle_num}: unknown typeId '{mapped_type}', skipping")
+            return
+
+        now = datetime.now()
+        for stage in self.schedule.stages:
+            stage_start = cycle_start + timedelta(minutes=stage.offset_minutes)
+            delay = (stage_start - now).total_seconds()
+            if delay < 0:
+                delay = 0  # Already passed, trigger immediately
+
+            timer = threading.Timer(delay, self._trigger_stage, args=[stage.name, cycle_type])
+            timer.daemon = True
+            timer.start()
+            self._timers.append(timer)
+
+    def _trigger_stage(self, stage_name: str, cycle_type) -> None:
+        """Trigger a stage: kill previous, start new PJobs."""
+        if not self.running:
+            return
+
+        self.current_stage = stage_name
+        self._log(f"Stage '{stage_name}' triggered in cycle {self.current_cycle}")
+
+        # Kill previous stage PJobs
+        with self._lock:
+            self._kill_all_pjobs(stage_name=f"pre-{stage_name}")
+
+        pjob_codes = cycle_type.get_stage_pjobs(stage_name)
+        for code in pjob_codes:
+            self._start_pjob(code)
+
+        self._save_state()
+
+    def _start_pjob(self, code: str) -> None:
+        """Start a PJob asynchronously."""
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        log_file = self.log_dir / f"{code}_{timestamp}_{self.current_cycle}.log"
+
+        cmd = [sys.executable, "-m", "zima.cli", "pjob", "run", code]
+
+        # Build platform-specific subprocess kwargs
+        kwargs: dict = {
+            "stdout": open(log_file, "w", encoding="utf-8"),  # noqa: SIM115
+            "stderr": subprocess.STDOUT,
+        }
+        if sys.platform == "win32":
+            kwargs["creationflags"] = (
+                subprocess.CREATE_NO_WINDOW | subprocess.CREATE_NEW_PROCESS_GROUP
+            )
+        else:
+            kwargs["start_new_session"] = True
+
+        try:
+            proc = subprocess.Popen(cmd, **kwargs)
+            with self._lock:
+                self.active_pjobs[code] = proc
+            self._log(f"Started PJob {code} (PID {proc.pid}), log: {log_file}")
+        except Exception as e:
+            self._log(f"Failed to start PJob {code}: {e}")
+            self._record_history(code, "launch_failed", str(e))
+
+    def _kill_all_pjobs(self, stage_name: str) -> None:
+        """Kill all active PJobs and record timeouts."""
+        for code, proc in list(self.active_pjobs.items()):
+            self._kill_pjob(code, proc, stage_name)
+        self.active_pjobs.clear()
+
+    def _kill_pjob(self, code: str, proc: subprocess.Popen, stage_name: str) -> None:
+        """Kill a single PJob process."""
+        if proc.poll() is not None:
+            return  # Already finished
+
+        self._log(f"Killing PJob {code} (PID {proc.pid}) at stage transition '{stage_name}'")
+        try:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+        except Exception as e:
+            self._log(f"Error killing PJob {code}: {e}")
+
+        self._record_history(code, "killed_timeout", stage_name)
+
+    def _record_history(self, code: str, status: str, detail: str) -> None:
+        """Append a history record."""
+        today = datetime.now().strftime("%Y-%m-%d")
+        history_file = self.log_dir / f"{today}.jsonl"
+        record = {
+            "pjobCode": code,
+            "scheduleCode": self.schedule.metadata.code,
+            "cycleNum": self.current_cycle,
+            "stage": self.current_stage or "",
+            "status": status,
+            "detail": detail,
+            "timestamp": datetime.now().isoformat(),
+        }
+        with open(history_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    def _save_state(self) -> None:
+        """Persist lightweight runtime state."""
+        state_file = self.daemon_dir / "state.json"
+        state = {
+            "running": self.running,
+            "currentCycle": self.current_cycle,
+            "currentStage": self.current_stage,
+            "activePjobs": list(self.active_pjobs.keys()),
+            "updatedAt": datetime.now().isoformat(),
+        }
+        state_file.write_text(json.dumps(state, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    def _log(self, message: str) -> None:
+        """Write to daemon log."""
+        log_file = self.daemon_dir / "daemon.log"
+        line = f"[{datetime.now().isoformat()}] {message}\n"
+        with open(log_file, "a", encoding="utf-8") as f:
+            f.write(line)
+
+    def _cancel_timers(self) -> None:
+        for timer in self._timers:
+            timer.cancel()
+        self._timers.clear()
+
+    def _sleep(self, seconds: float) -> None:
+        """Sleep in small chunks so stop() is responsive."""
+        end = time.time() + seconds
+        while time.time() < end and self.running:
+            time.sleep(min(1.0, end - time.time()))
+
+    def _current_cycle_num(self, dt: datetime) -> int:
+        """Compute which 45-minute cycle we're in (0-31) based on midnight."""
+        midnight = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+        minutes_since_midnight = (dt - midnight).total_seconds() / 60
+        cycle_num = int(minutes_since_midnight // self.schedule.cycle_minutes)
+        return cycle_num % self.schedule.daily_cycles
+
+    def _cycle_start_time(self, dt: datetime) -> datetime:
+        """Compute the start time of the current cycle."""
+        midnight = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+        minutes_since_midnight = (dt - midnight).total_seconds() / 60
+        cycle_num = int(minutes_since_midnight // self.schedule.cycle_minutes)
+        return midnight + timedelta(minutes=cycle_num * self.schedule.cycle_minutes)

--- a/zima/core/daemon_scheduler.py
+++ b/zima/core/daemon_scheduler.py
@@ -154,7 +154,11 @@ class DaemonScheduler:
     def _kill_pjob(self, code: str, proc: subprocess.Popen, stage_name: str) -> None:
         """Kill a single PJob process."""
         if proc.poll() is not None:
-            return  # Already finished
+            # Already finished — close log handle
+            log_fh = self._pjob_log_handles.pop(code, None)
+            if log_fh:
+                log_fh.close()
+            return
 
         self._log(f"Killing PJob {code} (PID {proc.pid}) at stage transition '{stage_name}'")
         status = "killed_timeout"
@@ -184,8 +188,9 @@ class DaemonScheduler:
             "detail": detail,
             "timestamp": datetime.now().isoformat(),
         }
-        with open(history_file, "a", encoding="utf-8") as f:
-            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        with self._lock:
+            with open(history_file, "a", encoding="utf-8") as f:
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
 
     def _save_state(self) -> None:
         """Persist lightweight runtime state."""

--- a/zima/core/daemon_scheduler.py
+++ b/zima/core/daemon_scheduler.py
@@ -122,6 +122,7 @@ class DaemonScheduler:
         # Build platform-specific subprocess kwargs
         log_fh = open(log_file, "w", encoding="utf-8")
         kwargs: dict = {
+            "stdin": subprocess.DEVNULL,
             "stdout": log_fh,
             "stderr": subprocess.STDOUT,
         }

--- a/zima/core/daemon_scheduler.py
+++ b/zima/core/daemon_scheduler.py
@@ -9,6 +9,7 @@ import threading
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
+from pathlib import Path
 
 from zima.models.schedule import ScheduleConfig
 
@@ -23,6 +24,7 @@ class DaemonScheduler:
         self.current_cycle = -1
         self.current_stage: str | None = None
         self.active_pjobs: dict[str, subprocess.Popen] = {}
+        self._pjob_log_handles: dict[str, object] = {}
         self._timers: list[threading.Timer] = []
         self._lock = threading.Lock()
 
@@ -117,8 +119,9 @@ class DaemonScheduler:
         cmd = [sys.executable, "-m", "zima.cli", "pjob", "run", code]
 
         # Build platform-specific subprocess kwargs
+        log_fh = open(log_file, "w", encoding="utf-8")
         kwargs: dict = {
-            "stdout": open(log_file, "w", encoding="utf-8"),  # noqa: SIM115
+            "stdout": log_fh,
             "stderr": subprocess.STDOUT,
         }
         if sys.platform == "win32":
@@ -132,8 +135,10 @@ class DaemonScheduler:
             proc = subprocess.Popen(cmd, **kwargs)
             with self._lock:
                 self.active_pjobs[code] = proc
+                self._pjob_log_handles[code] = log_fh
             self._log(f"Started PJob {code} (PID {proc.pid}), log: {log_file}")
         except Exception as e:
+            log_fh.close()
             self._log(f"Failed to start PJob {code}: {e}")
             self._record_history(code, "launch_failed", str(e))
 
@@ -141,6 +146,9 @@ class DaemonScheduler:
         """Kill all active PJobs and record timeouts."""
         for code, proc in list(self.active_pjobs.items()):
             self._kill_pjob(code, proc, stage_name)
+            log_fh = self._pjob_log_handles.pop(code, None)
+            if log_fh:
+                log_fh.close()
         self.active_pjobs.clear()
 
     def _kill_pjob(self, code: str, proc: subprocess.Popen, stage_name: str) -> None:
@@ -149,17 +157,19 @@ class DaemonScheduler:
             return  # Already finished
 
         self._log(f"Killing PJob {code} (PID {proc.pid}) at stage transition '{stage_name}'")
+        status = "killed_timeout"
         try:
             proc.terminate()
             try:
                 proc.wait(timeout=5)
+                status = "terminated"
             except subprocess.TimeoutExpired:
                 proc.kill()
                 proc.wait(timeout=5)
         except Exception as e:
             self._log(f"Error killing PJob {code}: {e}")
 
-        self._record_history(code, "killed_timeout", stage_name)
+        self._record_history(code, status, stage_name)
 
     def _record_history(self, code: str, status: str, detail: str) -> None:
         """Append a history record."""

--- a/zima/core/daemon_scheduler.py
+++ b/zima/core/daemon_scheduler.py
@@ -9,7 +9,6 @@ import threading
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
-from pathlib import Path
 
 from zima.models.schedule import ScheduleConfig
 

--- a/zima/daemon_runner.py
+++ b/zima/daemon_runner.py
@@ -1,60 +1,61 @@
 """
-Daemon runner - executed as a separate process for background agent execution
+Daemon runner - executed as a separate process for background scheduling.
 
-Usage: python -m zima.daemon_runner <agent_dir>
+Usage: python -m zima.daemon_runner --schedule <schedule_code>
 """
 
+import argparse
+import os
 import sys
-from datetime import datetime
 from pathlib import Path
 
+from zima.config.manager import ConfigManager
+from zima.core.daemon_scheduler import DaemonScheduler
+from zima.models.schedule import ScheduleConfig
 from zima.utils import setup_windows_utf8
 
 setup_windows_utf8()
 
 
+def parse_args():
+    parser = argparse.ArgumentParser(description="Zima Daemon Runner")
+    parser.add_argument("--schedule", required=True, help="Schedule code to run")
+    return parser.parse_args()
+
+
 def main():
-    if len(sys.argv) < 2:
-        print("Usage: python -m zima.daemon_runner <agent_dir>")
+    args = parse_args()
+    schedule_code = args.schedule
+
+    manager = ConfigManager()
+    if not manager.config_exists("schedule", schedule_code):
+        print(f"Error: Schedule '{schedule_code}' not found")
         sys.exit(1)
 
-    agent_dir = Path(sys.argv[1])
+    data = manager.load_config("schedule", schedule_code)
+    schedule = ScheduleConfig.from_dict(data)
 
-    if not agent_dir.exists():
-        print(f"Error: Agent directory not found: {agent_dir}")
+    errors = schedule.validate(resolve_refs=True)
+    if errors:
+        print("Error: Schedule validation failed:")
+        for e in errors:
+            print(f"  - {e}")
         sys.exit(1)
 
-    # Load config
-    from zima.models import AgentConfig
+    daemon_dir = Path.home() / ".zima" / "daemon"
+    scheduler = DaemonScheduler(schedule, daemon_dir)
 
-    config_path = agent_dir / "agent.yaml"
-
-    if not config_path.exists():
-        print(f"Error: Agent config not found: {config_path}")
-        sys.exit(1)
-
-    config = AgentConfig.from_yaml(config_path)
-
-    # Initialize components
-    from zima.core import CycleScheduler, KimiRunner, StateManager
-
-    runner = KimiRunner(config, agent_dir)
-    state_manager = StateManager(agent_dir)
-    scheduler = CycleScheduler(config, runner, state_manager)
-
-    print(f"[{datetime.now().isoformat()}] Daemon started for agent: {config.name}")
-    print(f"[{datetime.now().isoformat()}] Agent directory: {agent_dir}")
+    # Write PID file
+    pid_file = daemon_dir / "daemon.pid"
+    pid_file.parent.mkdir(parents=True, exist_ok=True)
+    pid_file.write_text(str(os.getpid()), encoding="utf-8")
 
     try:
         scheduler.run()
-    except Exception as e:
-        print(f"[{datetime.now().isoformat()}] Daemon error: {e}")
-        import traceback
-
-        traceback.print_exc()
-        sys.exit(1)
-
-    print(f"[{datetime.now().isoformat()}] Daemon stopped")
+    except KeyboardInterrupt:
+        scheduler.stop()
+    finally:
+        pid_file.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/zima/daemon_runner.py
+++ b/zima/daemon_runner.py
@@ -6,6 +6,7 @@ Usage: python -m zima.daemon_runner --schedule <schedule_code>
 
 import argparse
 import os
+import signal
 import sys
 from pathlib import Path
 
@@ -50,9 +51,16 @@ def main():
     pid_file.parent.mkdir(parents=True, exist_ok=True)
     pid_file.write_text(str(os.getpid()), encoding="utf-8")
 
+    # Handle SIGTERM (Linux) for graceful shutdown
+    def _handle_signal(signum, frame):
+        scheduler.stop()
+
+    if sys.platform != "win32":
+        signal.signal(signal.SIGTERM, _handle_signal)
+
     try:
         scheduler.run()
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, SystemExit):
         scheduler.stop()
     finally:
         pid_file.unlink(missing_ok=True)

--- a/zima/daemon_runner.py
+++ b/zima/daemon_runner.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from zima.config.manager import ConfigManager
 from zima.core.daemon_scheduler import DaemonScheduler
 from zima.models.schedule import ScheduleConfig
-from zima.utils import setup_windows_utf8
+from zima.utils import get_zima_home, setup_windows_utf8
 
 setup_windows_utf8()
 
@@ -42,7 +42,7 @@ def main():
             print(f"  - {e}")
         sys.exit(1)
 
-    daemon_dir = Path.home() / ".zima" / "daemon"
+    daemon_dir = get_zima_home() / "daemon"
     scheduler = DaemonScheduler(schedule, daemon_dir)
 
     # Write PID file

--- a/zima/models/__init__.py
+++ b/zima/models/__init__.py
@@ -4,6 +4,7 @@ from .agent import AgentConfig, AgentState, CycleResult, RunResult
 from .config_bundle import ConfigBundle
 from .env import VALID_ENV_FOR_TYPES, VALID_SECRET_SOURCES, EnvConfig, SecretDef, SecretResolver
 from .pjob import ExecutionOptions, OutputOptions, Overrides, PJobConfig, PJobMetadata, PJobSpec
+from .schedule import ScheduleConfig, ScheduleCycleType, ScheduleStage
 from .pmg import (
     VALID_PARAM_TYPES,
     VALID_PMG_FOR_TYPES,
@@ -44,5 +45,8 @@ __all__ = [
     "ExecutionOptions",
     "OutputOptions",
     "Overrides",
+    "ScheduleConfig",
+    "ScheduleCycleType",
+    "ScheduleStage",
     "ConfigBundle",
 ]

--- a/zima/models/schedule.py
+++ b/zima/models/schedule.py
@@ -1,0 +1,199 @@
+"""Schedule configuration model for daemon-mode cycle scheduling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from zima.models.base import BaseConfig, Metadata
+from zima.utils import generate_timestamp, validate_code
+
+
+@dataclass
+class ScheduleStage:
+    """A stage within a cycle (e.g., work, rest, dream)."""
+
+    name: str = ""
+    offset_minutes: int = 0
+    duration_minutes: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "offsetMinutes": self.offset_minutes,
+            "durationMinutes": self.duration_minutes,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ScheduleStage:
+        return cls(
+            name=data.get("name", ""),
+            offset_minutes=data.get("offsetMinutes", 0),
+            duration_minutes=data.get("durationMinutes", 0),
+        )
+
+
+@dataclass
+class ScheduleCycleType:
+    """Mapping of stage names to PJob codes for one cycle type."""
+
+    type_id: str = ""
+    work: list[str] = field(default_factory=list)
+    rest: list[str] = field(default_factory=list)
+    dream: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        result: dict = {"typeId": self.type_id}
+        if self.work:
+            result["work"] = self.work
+        if self.rest:
+            result["rest"] = self.rest
+        if self.dream:
+            result["dream"] = self.dream
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ScheduleCycleType:
+        return cls(
+            type_id=data.get("typeId", ""),
+            work=data.get("work", []),
+            rest=data.get("rest", []),
+            dream=data.get("dream", []),
+        )
+
+    def get_stage_pjobs(self, stage_name: str) -> list[str]:
+        return getattr(self, stage_name, [])
+
+
+@dataclass
+class ScheduleConfig(BaseConfig):
+    """Schedule configuration for daemon-mode 32-cycle scheduling."""
+
+    kind: str = "Schedule"
+    metadata: Metadata = field(default_factory=Metadata)
+    cycle_minutes: int = 45
+    daily_cycles: int = 32
+    stages: list[ScheduleStage] = field(default_factory=list)
+    cycle_types: list[ScheduleCycleType] = field(default_factory=list)
+    cycle_mapping: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "apiVersion": self.api_version,
+            "kind": self.kind,
+            "metadata": self.metadata.to_dict(),
+            "spec": {
+                "cycleMinutes": self.cycle_minutes,
+                "dailyCycles": self.daily_cycles,
+                "stages": [s.to_dict() for s in self.stages],
+                "cycleTypes": [ct.to_dict() for ct in self.cycle_types],
+                "cycleMapping": self.cycle_mapping,
+            },
+            "createdAt": self.created_at,
+            "updatedAt": self.updated_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ScheduleConfig:
+        spec = data.get("spec", {})
+        return cls(
+            api_version=data.get("apiVersion", "zima.io/v1"),
+            kind=data.get("kind", "Schedule"),
+            metadata=Metadata.from_dict(data.get("metadata", {})),
+            cycle_minutes=spec.get("cycleMinutes", 45),
+            daily_cycles=spec.get("dailyCycles", 32),
+            stages=[ScheduleStage.from_dict(s) for s in spec.get("stages", [])],
+            cycle_types=[ScheduleCycleType.from_dict(ct) for ct in spec.get("cycleTypes", [])],
+            cycle_mapping=spec.get("cycleMapping", []),
+            created_at=data.get("createdAt", ""),
+            updated_at=data.get("updatedAt", ""),
+        )
+
+    @classmethod
+    def create(
+        cls,
+        code: str,
+        name: str,
+        description: str = "",
+    ) -> ScheduleConfig:
+        now = generate_timestamp()
+        return cls(
+            metadata=Metadata(code=code, name=name, description=description),
+            cycle_minutes=45,
+            daily_cycles=32,
+            stages=[
+                ScheduleStage(name="work", offset_minutes=0, duration_minutes=20),
+                ScheduleStage(name="rest", offset_minutes=20, duration_minutes=15),
+                ScheduleStage(name="dream", offset_minutes=35, duration_minutes=10),
+            ],
+            cycle_types=[],
+            cycle_mapping=["idle"] * 32,
+            created_at=now,
+            updated_at=now,
+        )
+
+    def validate(self, resolve_refs: bool = False) -> list[str]:
+        errors = []
+
+        if not self.metadata.code:
+            errors.append("metadata.code is required")
+        elif not validate_code(self.metadata.code):
+            errors.append(f"metadata.code '{self.metadata.code}' has invalid format")
+
+        if not self.metadata.name:
+            errors.append("metadata.name is required")
+
+        if self.cycle_minutes <= 0:
+            errors.append("spec.cycleMinutes must be > 0")
+
+        if self.daily_cycles != 32:
+            errors.append("spec.dailyCycles must be 32")
+
+        # Validate stages
+        prev_offset = -1
+        for stage in self.stages:
+            end = stage.offset_minutes + stage.duration_minutes
+            if end > self.cycle_minutes:
+                errors.append(
+                    f"stage '{stage.name}' ends at {end}m, exceeding cycle {self.cycle_minutes}m"
+                )
+            if stage.offset_minutes < prev_offset:
+                errors.append("stages must be sorted by offsetMinutes")
+            prev_offset = stage.offset_minutes
+
+        # Validate cycleMapping length
+        if len(self.cycle_mapping) != self.daily_cycles:
+            errors.append(
+                f"cycleMapping length ({len(self.cycle_mapping)}) must equal dailyCycles ({self.daily_cycles})"
+            )
+
+        # Validate typeIds
+        valid_type_ids = {ct.type_id for ct in self.cycle_types}
+        valid_type_ids.add("idle")
+        for i, mapped_type in enumerate(self.cycle_mapping):
+            if mapped_type not in valid_type_ids:
+                errors.append(
+                    f"cycleMapping[{i}] references unknown typeId '{mapped_type}'"
+                )
+
+        # Optional: validate PJob refs exist
+        if resolve_refs:
+            from zima.config.manager import ConfigManager
+
+            manager = ConfigManager()
+            all_pjobs = set()
+            for ct in self.cycle_types:
+                all_pjobs.update(ct.work)
+                all_pjobs.update(ct.rest)
+                all_pjobs.update(ct.dream)
+
+            for pjob in all_pjobs:
+                if not manager.config_exists("pjob", pjob):
+                    errors.append(f"referenced pjob '{pjob}' not found")
+
+        return errors
+
+    def get_cycle_type(self, type_id: str) -> ScheduleCycleType | None:
+        for ct in self.cycle_types:
+            if ct.type_id == type_id:
+                return ct
+        return None

--- a/zima/models/schedule.py
+++ b/zima/models/schedule.py
@@ -156,8 +156,8 @@ class ScheduleConfig(BaseConfig):
                 errors.append(
                     f"stage '{stage.name}' ends at {end}m, exceeding cycle {self.cycle_minutes}m"
                 )
-            if stage.offset_minutes < prev_offset:
-                errors.append("stages must be sorted by offsetMinutes")
+            if stage.offset_minutes <= prev_offset:
+                errors.append("stages must be sorted by offsetMinutes with no duplicates")
             prev_offset = stage.offset_minutes
 
         # Validate cycleMapping length

--- a/zima/templates/examples.py
+++ b/zima/templates/examples.py
@@ -118,6 +118,36 @@ spec:
     append: false
 """
 
+SCHEDULE_EXAMPLE = """\
+apiVersion: zima.io/v1
+kind: Schedule
+metadata:
+  code: daily-32
+  name: "Daily 32-cycle Schedule"
+spec:
+  cycleMinutes: 45
+  dailyCycles: 32
+  stages:
+    - name: work
+      offsetMinutes: 0
+      durationMinutes: 20
+    - name: rest
+      offsetMinutes: 20
+      durationMinutes: 15
+    - name: dream
+      offsetMinutes: 35
+      durationMinutes: 10
+  cycleTypes:
+    - typeId: A
+      work: [pjob-a1]
+      rest: [pjob-a2]
+      dream: [pjob-a3]
+  cycleMapping:
+    - A
+    - idle
+    - A
+"""
+
 EXAMPLES = {
     "agent": AGENT_EXAMPLE,
     "workflow": WORKFLOW_EXAMPLE,
@@ -125,6 +155,7 @@ EXAMPLES = {
     "env": ENV_EXAMPLE,
     "pmg": PMG_EXAMPLE,
     "pjob": PJOB_EXAMPLE,
+    "schedule": SCHEDULE_EXAMPLE,
 }
 
-VALID_KINDS = {"Agent", "Workflow", "Variable", "Env", "PMG", "PJob"}
+VALID_KINDS = {"Agent", "Workflow", "Variable", "Env", "PMG", "PJob", "Schedule"}

--- a/zima/templates/examples.py
+++ b/zima/templates/examples.py
@@ -144,8 +144,37 @@ spec:
       dream: [pjob-a3]
   cycleMapping:
     - A
+    - A
     - idle
     - A
+    - A
+    - idle
+    - A
+    - A
+    - idle
+    - A
+    - A
+    - idle
+    - A
+    - A
+    - idle
+    - idle
+    - A
+    - A
+    - idle
+    - A
+    - A
+    - idle
+    - A
+    - A
+    - idle
+    - A
+    - A
+    - idle
+    - A
+    - A
+    - idle
+    - idle
 """
 
 EXAMPLES = {


### PR DESCRIPTION
## Summary

- Add `ScheduleConfig` model with validation (stages, cycle types, mapping, PJob refs)
- Add `zima schedule *` CLI commands (create/list/show/update/delete/validate/set-type/set-mapping)
- Add `DaemonScheduler` core with cycle math, stage timers, PJob spawn/kill, and JSONL history
- Rewrite `daemon_runner.py` as v3 entry point with `--schedule` flag
- Add `zima daemon start/stop/status/logs` top-level commands

## Test plan

- [x] 9 new model tests for `ScheduleConfig` validation and serialization
- [x] 6 new daemon scheduler tests for cycle math and stage transitions
- [x] All 452 unit tests pass with no regressions
- [x] CLI smoke test: schedule create → set-type → validate → show → delete round-trip
- [x] CLI smoke test: daemon-status and daemon-logs commands work

🤖 Generated with [Claude Code](https://claude.com/claude-code)