### PR TITLE
feat(executor): move PJob temp dir to ZIMA_HOME (#47)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,12 +98,14 @@ zima pjob run <code>
 │   ├── daemon.log
 │   ├── state.json
 │   └── history/*.jsonl
+├── temp/                      # Temporary execution artifacts
+│   └── pjobs/                # PJob execution working directories (auto-cleaned)
 └── history/
     └── pjobs.json           # Execution history (per-PJob records, max 100 each)
 ```
 
 **Execution artifacts** (ephemeral by default):
-- Working directory: system temp dir (`%TEMP%/zima-pjobs/<code>-<id>/` on Windows, `/tmp/zima-pjobs/...` on Unix)
+- Working directory: `~/.zima/temp/pjobs/<code>-<id>/` (under ZIMA_HOME, not system temp)
 - Rendered prompt: `<temp_dir>/prompt.md`
 - Temp dir is cleaned up after execution unless `keep_temp` or `save_to` is set
 - Full stdout/stderr is returned in-memory; only a 500-char preview is persisted to history

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,12 +98,14 @@ zima pjob run <code>
 │   ├── daemon.log
 │   ├── state.json
 │   └── history/*.jsonl
+├── temp/                      # Temporary execution artifacts
+│   └── pjobs/                # PJob execution working directories (auto-cleaned)
 └── history/
     └── pjobs.json           # Execution history (per-PJob records, max 100 each)
 ```
 
 **Execution artifacts** (ephemeral by default):
-- Working directory: system temp dir (`%TEMP%/zima-pjobs/<code>-<id>/` on Windows, `/tmp/zima-pjobs/...` on Unix)
+- Working directory: `~/.zima/temp/pjobs/<code>-<id>/` (under ZIMA_HOME, not system temp)
 - Rendered prompt: `<temp_dir>/prompt.md`
 - Temp dir is cleaned up after execution unless `keep_temp` or `save_to` is set
 - Full stdout/stderr is returned in-memory; only a 500-char preview is persisted to history

--- a/tests/unit/test_executor_fixes.py
+++ b/tests/unit/test_executor_fixes.py
@@ -96,3 +96,45 @@ class TestFixShellCommand:
         monkeypatch.setattr(os, "name", "posix")
         result = PJobExecutor._fix_shell_command("cd /tmp && ls")
         assert result == "cd /tmp && ls"
+
+
+class TestCreateTempDir:
+    """Test PJobExecutor._create_temp_dir() uses ZIMA_HOME (#47)."""
+
+    def test_temp_dir_under_zima_home(self, monkeypatch):
+        import tempfile
+        from pathlib import Path
+
+        fake_home = Path(tempfile.mkdtemp(prefix="zima-test-tempdir-"))
+        monkeypatch.setenv("ZIMA_HOME", str(fake_home))
+
+        executor = PJobExecutor()
+        result = executor._create_temp_dir("my-pjob", "abc123")
+
+        expected = fake_home / "temp" / "pjobs" / "my-pjob-abc123"
+        assert result == expected
+        assert result.exists()
+
+        # Cleanup
+        import shutil
+        shutil.rmtree(fake_home, ignore_errors=True)
+
+    def test_temp_dir_creates_parents(self, monkeypatch):
+        import tempfile
+        from pathlib import Path
+
+        fake_home = Path(tempfile.mkdtemp(prefix="zima-test-tempdir-"))
+        monkeypatch.setenv("ZIMA_HOME", str(fake_home))
+
+        # temp/pjobs/ should not exist yet
+        assert not (fake_home / "temp").exists()
+
+        executor = PJobExecutor()
+        result = executor._create_temp_dir("test-pjob", "id1")
+
+        assert (fake_home / "temp" / "pjobs").exists()
+        assert result.exists()
+
+        # Cleanup
+        import shutil
+        shutil.rmtree(fake_home, ignore_errors=True)

--- a/tests/unit/test_executor_fixes.py
+++ b/tests/unit/test_executor_fixes.py
@@ -101,40 +101,24 @@ class TestFixShellCommand:
 class TestCreateTempDir:
     """Test PJobExecutor._create_temp_dir() uses ZIMA_HOME (#47)."""
 
-    def test_temp_dir_under_zima_home(self, monkeypatch):
-        import tempfile
-        from pathlib import Path
-
-        fake_home = Path(tempfile.mkdtemp(prefix="zima-test-tempdir-"))
-        monkeypatch.setenv("ZIMA_HOME", str(fake_home))
+    def test_temp_dir_under_zima_home(self, monkeypatch, temp_dir):
+        monkeypatch.setenv("ZIMA_HOME", str(temp_dir))
 
         executor = PJobExecutor()
         result = executor._create_temp_dir("my-pjob", "abc123")
 
-        expected = fake_home / "temp" / "pjobs" / "my-pjob-abc123"
+        expected = temp_dir / "temp" / "pjobs" / "my-pjob-abc123"
         assert result == expected
         assert result.exists()
 
-        # Cleanup
-        import shutil
-        shutil.rmtree(fake_home, ignore_errors=True)
-
-    def test_temp_dir_creates_parents(self, monkeypatch):
-        import tempfile
-        from pathlib import Path
-
-        fake_home = Path(tempfile.mkdtemp(prefix="zima-test-tempdir-"))
-        monkeypatch.setenv("ZIMA_HOME", str(fake_home))
+    def test_temp_dir_creates_parents(self, monkeypatch, temp_dir):
+        monkeypatch.setenv("ZIMA_HOME", str(temp_dir))
 
         # temp/pjobs/ should not exist yet
-        assert not (fake_home / "temp").exists()
+        assert not (temp_dir / "temp").exists()
 
         executor = PJobExecutor()
         result = executor._create_temp_dir("test-pjob", "id1")
 
-        assert (fake_home / "temp" / "pjobs").exists()
+        assert (temp_dir / "temp" / "pjobs").exists()
         assert result.exists()
-
-        # Cleanup
-        import shutil
-        shutil.rmtree(fake_home, ignore_errors=True)

--- a/zima/execution/executor.py
+++ b/zima/execution/executor.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
-import tempfile
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -16,7 +15,7 @@ from typing import Optional
 from zima.config.manager import ConfigManager
 from zima.models.config_bundle import ConfigBundle
 from zima.models.pjob import Overrides, PJobConfig
-from zima.utils import generate_timestamp
+from zima.utils import generate_timestamp, get_zima_home
 
 
 class ExecutionStatus(Enum):
@@ -301,8 +300,8 @@ class PJobExecutor:
         return bundle
 
     def _create_temp_dir(self, pjob_code: str, execution_id: str) -> Path:
-        """Create temporary directory for execution."""
-        temp_dir = Path(tempfile.gettempdir()) / "zima-pjobs" / f"{pjob_code}-{execution_id}"
+        """Create temporary directory for execution under ZIMA_HOME."""
+        temp_dir = get_zima_home() / "temp" / "pjobs" / f"{pjob_code}-{execution_id}"
         temp_dir.mkdir(parents=True, exist_ok=True)
         return temp_dir
 


### PR DESCRIPTION
## Summary

- Move PJob temp working directory from system temp (`%TEMP%/zima-pjobs/`) to ZIMA_HOME (`ZIMA_HOME/temp/pjobs/`)
- All Zima files now live under the user-configurable ZIMA_HOME directory
- Update CLAUDE.md and AGENTS.md Data Layout sections

Closes #47

## Changes

- `zima/execution/executor.py`: Replace `tempfile.gettempdir()` with `get_zima_home()`, remove `tempfile` import
- `tests/unit/test_executor_fixes.py`: Add `TestCreateTempDir` with 2 tests verifying new location
- `CLAUDE.md`: Update Data Layout with `temp/pjobs/` directory
- `AGENTS.md`: Sync Data Layout to match

## Test plan

- [x] New unit tests: `TestCreateTempDir.test_temp_dir_under_zima_home`, `TestCreateTempDir.test_temp_dir_creates_parents`
- [x] Full unit test suite: 467 passed (2 new + 465 existing)
- [x] No `tempfile` references remain in executor.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)