### PR TITLE
feat(agent): omit --model flag by default for all agent types

### DIFF
--- a/tests/integration/test_kimi_agent_integration.py
+++ b/tests/integration/test_kimi_agent_integration.py
@@ -39,8 +39,8 @@ class TestKimiAgentConfigLayer:
             code="test-kimi-default", name="Test Kimi Agent", agent_type="kimi"
         )
 
-        # Verify default parameters from template are merged
-        assert agent.parameters["model"] == "kimi-code/kimi-for-coding"
+        # Verify default parameters from template are merged (model omitted)
+        assert "model" not in agent.parameters
         assert agent.parameters["maxStepsPerTurn"] == 50
         assert agent.parameters["maxRalphIterations"] == 10
         assert agent.parameters["maxRetriesPerStep"] == 3

--- a/tests/unit/test_claude_runner.py
+++ b/tests/unit/test_claude_runner.py
@@ -17,7 +17,7 @@ class TestClaudeAgentConfig:
         """Test Claude default parameters are correct."""
         config = AgentConfig.create("test-claude", "Test Claude", "claude")
 
-        assert config.parameters["model"] == "claude-sonnet-4-6"
+        assert "model" not in config.parameters
         assert config.parameters["maxTurns"] == 100
         assert config.parameters["permissionMode"] == "plan"
         assert config.parameters["outputFormat"] == "stream-json"
@@ -52,8 +52,7 @@ class TestClaudeAgentConfig:
 
         assert "claude" in cmd
         assert "-p" in cmd
-        assert "--model" in cmd
-        assert "claude-sonnet-4-6" in cmd
+        assert "--model" not in cmd
         assert "--max-turns" in cmd
         assert "100" in cmd
         assert "--permission-mode" in cmd
@@ -147,7 +146,7 @@ class TestClaudeAgentConfig:
 
         assert "claude" in cmd
         assert "-p" in cmd
-        assert "--model" in cmd
+        assert "--model" not in cmd
 
 
 class TestClaudeRunnerParsing:

--- a/tests/unit/test_models_agent.py
+++ b/tests/unit/test_models_agent.py
@@ -329,9 +329,7 @@ class TestAgentConfigCommandBuilding(TestIsolator):
 
     def test_build_kimi_command_explicit_model(self):
         """Test that --model is included when explicitly set."""
-        config = AgentConfig.create(
-            "test", "Test", "kimi", parameters={"model": "kimi-k2"}
-        )
+        config = AgentConfig.create("test", "Test", "kimi", parameters={"model": "kimi-k2"})
         cmd = config.build_command()
 
         assert "--model" in cmd

--- a/tests/unit/test_models_agent.py
+++ b/tests/unit/test_models_agent.py
@@ -18,7 +18,7 @@ class TestAgentConfigCreation(TestIsolator):
         assert config.metadata.code == "kimi-agent"
         assert config.metadata.name == "Kimi Agent"
         assert config.type == "kimi"
-        assert config.parameters["model"] == "kimi-code/kimi-for-coding"
+        assert "model" not in config.parameters
         assert config.parameters["yolo"] is True
         assert config.parameters["maxStepsPerTurn"] == 50
 
@@ -27,7 +27,7 @@ class TestAgentConfigCreation(TestIsolator):
         config = AgentConfig.create(code="claude-agent", name="Claude Agent", agent_type="claude")
 
         assert config.type == "claude"
-        assert config.parameters["model"] == "claude-sonnet-4-6"
+        assert "model" not in config.parameters
         assert config.parameters["maxTurns"] == 100
 
     def test_create_gemini_agent(self):
@@ -35,7 +35,7 @@ class TestAgentConfigCreation(TestIsolator):
         config = AgentConfig.create(code="gemini-agent", name="Gemini Agent", agent_type="gemini")
 
         assert config.type == "gemini"
-        assert config.parameters["model"] == "gemini-2.5-flash"
+        assert "model" not in config.parameters
         assert config.parameters["approvalMode"] == "default"
 
     def test_create_with_custom_params(self):
@@ -320,6 +320,37 @@ class TestAgentConfigCommandBuilding(TestIsolator):
 
         assert "overridden-model" in cmd
 
+    def test_build_kimi_command_no_model_by_default(self):
+        """Test that --model is omitted when no model is set."""
+        config = AgentConfig.create("test", "Test", "kimi")
+        cmd = config.build_command()
+
+        assert "--model" not in cmd
+
+    def test_build_kimi_command_explicit_model(self):
+        """Test that --model is included when explicitly set."""
+        config = AgentConfig.create(
+            "test", "Test", "kimi", parameters={"model": "kimi-k2"}
+        )
+        cmd = config.build_command()
+
+        assert "--model" in cmd
+        assert "kimi-k2" in cmd
+
+    def test_build_claude_command_no_model_by_default(self):
+        """Test that --model is omitted for claude when no model is set."""
+        config = AgentConfig.create("test", "Test", "claude")
+        cmd = config.build_command()
+
+        assert "--model" not in cmd
+
+    def test_build_gemini_command_no_model_by_default(self):
+        """Test that -m is omitted for gemini when no model is set."""
+        config = AgentConfig.create("test", "Test", "gemini")
+        cmd = config.build_command()
+
+        assert "-m" not in cmd
+
 
 class TestAgentConfigDefaults(TestIsolator):
     """Test default references management."""
@@ -371,5 +402,4 @@ class TestValidAgentTypes(TestIsolator):
         """Test that parameter templates exist for all valid types."""
         for agent_type in VALID_AGENT_TYPES:
             assert agent_type in AGENT_PARAMETER_TEMPLATES
-            assert "model" in AGENT_PARAMETER_TEMPLATES[agent_type]
             assert "workDir" in AGENT_PARAMETER_TEMPLATES[agent_type]

--- a/zima/models/agent.py
+++ b/zima/models/agent.py
@@ -12,7 +12,6 @@ from zima.utils import generate_timestamp, validate_code
 # Agent-specific parameters templates
 AGENT_PARAMETER_TEMPLATES = {
     "kimi": {
-        "model": "kimi-code/kimi-for-coding",
         "maxStepsPerTurn": 50,
         "maxRalphIterations": 10,
         "maxRetriesPerStep": 3,
@@ -22,7 +21,6 @@ AGENT_PARAMETER_TEMPLATES = {
         "outputFormat": "text",
     },
     "claude": {
-        "model": "claude-sonnet-4-6",
         "maxTurns": 100,
         "permissionMode": "plan",
         "outputFormat": "stream-json",
@@ -34,7 +32,6 @@ AGENT_PARAMETER_TEMPLATES = {
         "addDirs": [],
     },
     "gemini": {
-        "model": "gemini-2.5-flash",
         "approvalMode": "default",
         "checkpointing": False,
         "workDir": "./workspace",


### PR DESCRIPTION
## Summary

- Remove hardcoded `model` defaults from all three `AGENT_PARAMETER_TEMPLATES` (kimi, claude, gemini) so each CLI uses its own default model
- Users can still explicitly set model via config YAML or `--set-param model=xxx`
- Update unit and integration tests to match new behavior

Closes #53

## Test plan

- [x] 669 tests pass (0 failures)
- [x] ruff check passes
- [x] black formatting passes
- [x] Verified model flag is omitted by default for kimi, claude, gemini
- [x] Verified model flag is included when explicitly set

🤖 Generated with [Claude Code](https://claude.com/claude-code)