### PR TITLE
feat: PR CR automation with postExec actions (#35)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,11 +66,15 @@ The core design is composability through seven YAML-based configuration types:
 - **`zima/commands/`** — CLI subcommand implementations (agent, workflow, variable, env, pmg, pjob, schedule, daemon).
 - **`zima/config/manager.py`** — `ConfigManager`: unified CRUD for all config types. Single class handles create/read/update/delete/list for every entity kind via `KINDS` set.
 - **`zima/models/`** — Dataclasses for each entity. `BaseConfig` provides common YAML load/save. `Metadata` has code/name/description.
-- **`zima/execution/executor.py`** — `PJobExecutor`: resolves ConfigBundle (agent+workflow+variable+env+pmg), renders template, builds command, executes subprocess.
+- **`zima/execution/executor.py`** — `PJobExecutor`: resolves ConfigBundle (agent+workflow+variable+env+pmg), renders template, builds command, executes subprocess, runs postExec actions.
 - **`zima/models/config_bundle.py`** — `ConfigBundle`: assembled config set ready for execution.
 - **`zima/core/kimi_runner.py`** / **`zima/core/claude_runner.py`** — Agent-specific subprocess runners for Kimi and Claude.
 - **`zima/execution/background_runner.py`** — Background PJob execution in detached process.
 - **`zima/execution/history.py`** — Execution history tracking with PID recording.
+- **`zima/execution/actions_runner.py`** — `ActionsRunner`: executes postExec actions (GitHub label/comment) after agent exit.
+- **`zima/review/parser.py`** — `ReviewParser`: parses `<zima-review>` XML blocks from agent stdout into structured review results.
+- **`zima/github/ops.py`** — `GitHubOps`: wraps `gh` CLI for label add/remove, comment post, PR diff fetch.
+- **`zima/models/actions.py`** — `PostExecAction` / `ActionsConfig`: dataclasses for PJob post-execution automation.
 - **`zima/daemon_runner.py`** — Entry point for detached daemon process (`python -m zima.daemon_runner`).
 - **`zima/core/daemon_scheduler.py`** — `DaemonScheduler`: 32-cycle PJob scheduling with stage timers, PJob spawn/kill, JSONL history.
 - **`zima/utils.py`** — Shared utilities (`ensure_dir`, etc.).
@@ -84,9 +88,15 @@ zima pjob run <code>
   → Renders Workflow template with Variables
   → Builds CLI command from Agent parameters
   → Executes subprocess (kimi/claude/gemini)
+  → Runs postExec actions (e.g. GitHub label transition) in finally block
   → Captures output, stores execution history centrally
   → Returns ExecutionResult
 ```
+
+**Post-exec actions** run unconditionally in the `finally` block:
+- On success (returncode=0): `condition: success` actions fire
+- On failure/timeout/cancel: `condition: failure` actions fire, `action_errors` recorded
+- Reviewer PJobs: `<zima-review>` XML in stdout is parsed, verdict maps to effective returncode
 
 ### Data Layout
 
@@ -154,7 +164,7 @@ To add a new **Configuration Entity**:
 2. Add kind to `ConfigManager.KINDS`
 3. Create commands in `zima/commands/<entity>.py`
 4. Register Typer subcommand in `zima/cli.py`
-5. Add example YAML to `zima/templates/examples.py` (`EXAMPLES` dict + `VALID_KINDS`)
+5. Add example YAML to `zima/templates/examples.py` (`EXAMPLES` dict + `VALID_KINDS`). `EXAMPLES` is nested: `EXAMPLES[kind][example_name]` → YAML string.
 
 ## Gotchas
 

--- a/tests/integration/test_executor_actions.py
+++ b/tests/integration/test_executor_actions.py
@@ -104,3 +104,91 @@ class TestExecutorActions:
 
         assert result.status.value == "success"
         mock_ops.post_comment.assert_not_called()
+
+
+class TestReviewerEndToEnd:
+    @pytest.fixture
+    def reviewer_configs(self, isolated_zima_home, config_manager):
+        """Set up complete reviewer agent + workflow + pjob configs."""
+        from zima.models.workflow import WorkflowConfig
+        from zima.models.variable import VariableConfig
+
+        # Agent with mockCommand that outputs approved review XML
+        agent_data = {
+            "apiVersion": "zima.io/v1",
+            "kind": "Agent",
+            "metadata": {"code": "reviewer-agent", "name": "Reviewer Agent"},
+            "spec": {
+                "type": "kimi",
+                "parameters": {
+                    "mockCommand": [
+                        "echo",
+                        "Review complete.\n<zima-review>\n  <verdict>approved</verdict>\n  <summary>LGTM</summary>\n</zima-review>",
+                    ]
+                },
+            },
+        }
+        config_manager.save_config("agent", "reviewer-agent", agent_data)
+
+        # Workflow
+        wf = WorkflowConfig.create(
+            code="reviewer-wf",
+            name="Reviewer Workflow",
+            template="Review PR {{pr_number}}: {{pr_diff}}",
+            variables=[
+                {"name": "pr_number", "type": "string", "required": True},
+                {"name": "pr_diff", "type": "string", "required": True},
+            ],
+        )
+        config_manager.save_config("workflow", "reviewer-wf", wf.to_dict())
+
+        # Variable
+        var = VariableConfig.create(
+            code="reviewer-var",
+            name="Reviewer Vars",
+            values={"pr_number": "42", "pr_diff": "+code"},
+        )
+        config_manager.save_config("variable", "reviewer-var", var.to_dict())
+
+        return agent_data, wf.to_dict(), var.to_dict()
+
+    def test_reviewer_approved_triggers_label(self, reviewer_configs, isolated_zima_home):
+        """Full flow: reviewer agent outputs approved -> label transition triggered."""
+        from zima.config.manager import ConfigManager
+        from zima.models.actions import ActionsConfig, PostExecAction
+        from zima.models.pjob import PJobConfig
+
+        manager = ConfigManager()
+
+        pjob = PJobConfig.create(
+            code="reviewer-e2e",
+            name="Reviewer E2E",
+            agent="reviewer-agent",
+            workflow="reviewer-wf",
+            variable="reviewer-var",
+        )
+        pjob.metadata.labels = ["reviewer"]
+        pjob.spec.actions = ActionsConfig(
+            post_exec=[
+                PostExecAction(
+                    condition="success",
+                    type="github_label",
+                    add_labels=["zima:approved"],
+                    remove_labels=["zima:needs-review"],
+                    repo="owner/repo",
+                    issue="42",
+                )
+            ]
+        )
+        manager.save_config("pjob", "reviewer-e2e", pjob.to_dict())
+
+        executor = PJobExecutor()
+        mock_ops = MagicMock()
+        executor._actions_runner._ops = mock_ops
+
+        result = executor.execute("reviewer-e2e")
+
+        assert result.status.value == "success"
+        assert "approved" in result.stdout
+        mock_ops.add_label.assert_called_once_with("owner/repo", 42, "zima:approved")
+        mock_ops.remove_label.assert_called_once_with("owner/repo", 42, "zima:needs-review")

--- a/tests/integration/test_executor_actions.py
+++ b/tests/integration/test_executor_actions.py
@@ -7,9 +7,10 @@ import pytest
 from zima.execution.executor import PJobExecutor
 from zima.models.actions import ActionsConfig, PostExecAction
 from zima.models.pjob import PJobConfig
+from tests.base import TestIsolator
 
 
-class TestExecutorActions:
+class TestExecutorActions(TestIsolator):
     @pytest.fixture
     def mock_configs(self, isolated_zima_home, config_manager, sample_agent_dict):
         """Set up agent and workflow configs for testing."""
@@ -106,7 +107,7 @@ class TestExecutorActions:
         mock_ops.post_comment.assert_not_called()
 
 
-class TestReviewerEndToEnd:
+class TestReviewerEndToEnd(TestIsolator):
     @pytest.fixture
     def reviewer_configs(self, isolated_zima_home, config_manager):
         """Set up complete reviewer agent + workflow + pjob configs."""

--- a/tests/integration/test_executor_actions.py
+++ b/tests/integration/test_executor_actions.py
@@ -1,0 +1,106 @@
+"""Integration tests for PJobExecutor postExec actions."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from zima.execution.executor import PJobExecutor
+from zima.models.actions import ActionsConfig, PostExecAction
+from zima.models.pjob import PJobConfig
+
+
+class TestExecutorActions:
+    @pytest.fixture
+    def mock_configs(self, isolated_zima_home, config_manager, sample_agent_dict):
+        """Set up agent and workflow configs for testing."""
+        from zima.models.workflow import WorkflowConfig
+
+        agent_data = sample_agent_dict.copy()
+        agent_data["metadata"]["code"] = "test-agent"
+        agent_data["spec"]["parameters"]["mockCommand"] = ["echo", "mock output"]
+        config_manager.save_config("agent", "test-agent", agent_data)
+
+        wf = WorkflowConfig.create(
+            code="test-wf",
+            name="Test Workflow",
+            template="Hello {{name}}",
+            variables=[{"name": "name", "type": "string", "required": True}],
+        )
+        config_manager.save_config("workflow", "test-wf", wf.to_dict())
+
+        from zima.models.variable import VariableConfig
+
+        var = VariableConfig.create(
+            code="test-var", name="Test Variables", values={"name": "World"}
+        )
+        config_manager.save_config("variable", "test-var", var.to_dict())
+
+        return agent_data, wf.to_dict(), var.to_dict()
+
+    def test_executor_runs_success_actions(self, mock_configs, isolated_zima_home):
+        """Test executor runs postExec success actions after agent exits."""
+        from zima.config.manager import ConfigManager
+
+        manager = ConfigManager()
+        pjob = PJobConfig.create(
+            code="test-pjob-actions",
+            name="Test PJob with Actions",
+            agent="test-agent",
+            workflow="test-wf",
+            variable="test-var",
+        )
+        pjob.spec.actions = ActionsConfig(
+            post_exec=[
+                PostExecAction(
+                    condition="success",
+                    type="github_label",
+                    add_labels=["zima:test-passed"],
+                    remove_labels=["zima:test-pending"],
+                    repo="owner/repo",
+                    issue="42",
+                )
+            ]
+        )
+        manager.save_config("pjob", "test-pjob-actions", pjob.to_dict())
+
+        executor = PJobExecutor()
+        mock_ops = MagicMock()
+        executor._actions_runner._ops = mock_ops
+        result = executor.execute("test-pjob-actions")
+
+        assert result.status.value == "success"
+        mock_ops.add_label.assert_called_once_with("owner/repo", 42, "zima:test-passed")
+        mock_ops.remove_label.assert_called_once_with("owner/repo", 42, "zima:test-pending")
+
+    def test_executor_skips_failure_actions_on_success(self, mock_configs, isolated_zima_home):
+        """Test failure actions are not run when agent succeeds."""
+        from zima.config.manager import ConfigManager
+
+        manager = ConfigManager()
+        pjob = PJobConfig.create(
+            code="test-pjob-skip",
+            name="Test Skip",
+            agent="test-agent",
+            workflow="test-wf",
+            variable="test-var",
+        )
+        pjob.spec.actions = ActionsConfig(
+            post_exec=[
+                PostExecAction(
+                    condition="failure",
+                    type="github_comment",
+                    body="This should not run",
+                    repo="owner/repo",
+                    issue="42",
+                )
+            ]
+        )
+        manager.save_config("pjob", "test-pjob-skip", pjob.to_dict())
+
+        executor = PJobExecutor()
+        mock_ops = MagicMock()
+        executor._actions_runner._ops = mock_ops
+        result = executor.execute("test-pjob-skip")
+
+        assert result.status.value == "success"
+        mock_ops.post_comment.assert_not_called()

--- a/tests/integration/test_executor_actions.py
+++ b/tests/integration/test_executor_actions.py
@@ -4,10 +4,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests.base import TestIsolator
 from zima.execution.executor import PJobExecutor
 from zima.models.actions import ActionsConfig, PostExecAction
 from zima.models.pjob import PJobConfig
-from tests.base import TestIsolator
 
 
 class TestExecutorActions(TestIsolator):
@@ -111,8 +111,8 @@ class TestReviewerEndToEnd(TestIsolator):
     @pytest.fixture
     def reviewer_configs(self, isolated_zima_home, config_manager):
         """Set up complete reviewer agent + workflow + pjob configs."""
-        from zima.models.workflow import WorkflowConfig
         from zima.models.variable import VariableConfig
+        from zima.models.workflow import WorkflowConfig
 
         # Agent with mockCommand that outputs approved review XML
         agent_data = {

--- a/tests/unit/test_actions_runner.py
+++ b/tests/unit/test_actions_runner.py
@@ -117,24 +117,23 @@ class TestActionsRunner:
             assert "my-org/my-repo" in called_body
             assert "42" in called_body
 
-    def test_run_with_review_result(self):
-        """Test runner accepts optional review_result parameter."""
+    def test_run_failure_condition(self):
+        """Test runner matches failure condition with non-zero returncode."""
         runner = ActionsRunner()
-        review = ReviewResult(verdict="approved", summary="LGTM")
         actions = ActionsConfig(
             post_exec=[
                 PostExecAction(
-                    condition="success",
-                    type="github_label",
-                    add_labels=["zima:approved"],
+                    condition="failure",
+                    type="github_comment",
+                    body="Failed",
                     repo="o/r",
                     issue="1",
                 )
             ]
         )
         with patch.object(runner, "_ops") as mock_ops:
-            runner.run(actions, returncode=0, env={}, review_result=review)
-            mock_ops.add_label.assert_called_once()
+            runner.run(actions, returncode=1, env={})
+            mock_ops.post_comment.assert_called_once_with("o/r", 1, "Failed")
 
     def test_run_skips_without_repo_or_issue(self):
         """Test actions without repo/issue are silently skipped."""

--- a/tests/unit/test_actions_runner.py
+++ b/tests/unit/test_actions_runner.py
@@ -1,8 +1,7 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-from zima.models.actions import ActionsConfig, PostExecAction
 from zima.execution.actions_runner import ActionsRunner, _matches_condition
-from zima.review.parser import ReviewResult
+from zima.models.actions import ActionsConfig, PostExecAction
 
 
 class TestMatchesCondition:

--- a/tests/unit/test_actions_runner.py
+++ b/tests/unit/test_actions_runner.py
@@ -1,0 +1,153 @@
+from unittest.mock import MagicMock, patch
+
+from zima.models.actions import ActionsConfig, PostExecAction
+from zima.execution.actions_runner import ActionsRunner, _matches_condition
+from zima.review.parser import ReviewResult
+
+
+class TestMatchesCondition:
+    def test_success_with_zero_returncode(self):
+        """Test success condition matches zero returncode."""
+        assert _matches_condition("success", returncode=0) is True
+
+    def test_success_with_nonzero_returncode(self):
+        """Test success condition does not match non-zero returncode."""
+        assert _matches_condition("success", returncode=1) is False
+
+    def test_failure_with_nonzero_returncode(self):
+        """Test failure condition matches non-zero returncode."""
+        assert _matches_condition("failure", returncode=1) is True
+
+    def test_failure_with_zero_returncode(self):
+        """Test failure condition does not match zero returncode."""
+        assert _matches_condition("failure", returncode=0) is False
+
+    def test_always_matches(self):
+        """Test always condition matches any returncode."""
+        assert _matches_condition("always", returncode=0) is True
+        assert _matches_condition("always", returncode=1) is True
+
+
+class TestActionsRunner:
+    def test_run_no_actions(self):
+        """Test runner with no actions does nothing."""
+        runner = ActionsRunner()
+        runner.run(ActionsConfig(), returncode=0, env={})
+        # Should not raise
+
+    def test_run_success_action(self):
+        """Test running success-conditioned label actions."""
+        runner = ActionsRunner()
+        actions = ActionsConfig(
+            post_exec=[
+                PostExecAction(
+                    condition="success",
+                    type="github_label",
+                    add_labels=["zima:needs-fix"],
+                    remove_labels=["zima:needs-review"],
+                    repo="owner/repo",
+                    issue="123",
+                )
+            ]
+        )
+        with patch.object(runner, "_ops") as mock_ops:
+            runner.run(actions, returncode=0, env={})
+            mock_ops.add_label.assert_called_once_with("owner/repo", 123, "zima:needs-fix")
+            mock_ops.remove_label.assert_called_once_with("owner/repo", 123, "zima:needs-review")
+
+    def test_run_failure_action_not_triggered_on_success(self):
+        """Test failure actions are skipped on success."""
+        runner = ActionsRunner()
+        actions = ActionsConfig(
+            post_exec=[
+                PostExecAction(
+                    condition="failure",
+                    type="github_comment",
+                    body="Failed",
+                    repo="owner/repo",
+                    issue="123",
+                )
+            ]
+        )
+        with patch.object(runner, "_ops") as mock_ops:
+            runner.run(actions, returncode=0, env={})
+            mock_ops.post_comment.assert_not_called()
+
+    def test_run_comment_action(self):
+        """Test running comment action."""
+        runner = ActionsRunner()
+        actions = ActionsConfig(
+            post_exec=[
+                PostExecAction(
+                    condition="success",
+                    type="github_comment",
+                    body="Review complete: approved",
+                    repo="owner/repo",
+                    issue="123",
+                )
+            ]
+        )
+        with patch.object(runner, "_ops") as mock_ops:
+            runner.run(actions, returncode=0, env={})
+            mock_ops.post_comment.assert_called_once_with(
+                "owner/repo", 123, "Review complete: approved"
+            )
+
+    def test_run_env_variable_substitution(self):
+        """Test environment variable substitution in action fields."""
+        runner = ActionsRunner()
+        actions = ActionsConfig(
+            post_exec=[
+                PostExecAction(
+                    condition="success",
+                    type="github_comment",
+                    body="Repo: {{REPO}} Issue: {{ISSUE}}",
+                    repo="owner/repo",
+                    issue="123",
+                )
+            ]
+        )
+        with patch.object(runner, "_ops") as mock_ops:
+            runner.run(
+                actions,
+                returncode=0,
+                env={"REPO": "my-org/my-repo", "ISSUE": "42"},
+            )
+            called_body = mock_ops.post_comment.call_args[0][2]
+            assert "my-org/my-repo" in called_body
+            assert "42" in called_body
+
+    def test_run_with_review_result(self):
+        """Test runner accepts optional review_result parameter."""
+        runner = ActionsRunner()
+        review = ReviewResult(verdict="approved", summary="LGTM")
+        actions = ActionsConfig(
+            post_exec=[
+                PostExecAction(
+                    condition="success",
+                    type="github_label",
+                    add_labels=["zima:approved"],
+                    repo="o/r",
+                    issue="1",
+                )
+            ]
+        )
+        with patch.object(runner, "_ops") as mock_ops:
+            runner.run(actions, returncode=0, env={}, review_result=review)
+            mock_ops.add_label.assert_called_once()
+
+    def test_run_skips_without_repo_or_issue(self):
+        """Test actions without repo/issue are silently skipped."""
+        runner = ActionsRunner()
+        actions = ActionsConfig(
+            post_exec=[
+                PostExecAction(
+                    condition="success",
+                    type="github_label",
+                    add_labels=["x"],
+                )
+            ]
+        )
+        with patch.object(runner, "_ops") as mock_ops:
+            runner.run(actions, returncode=0, env={})
+            mock_ops.add_label.assert_not_called()

--- a/tests/unit/test_examples.py
+++ b/tests/unit/test_examples.py
@@ -17,6 +17,8 @@ from zima.templates.examples import (
     EXAMPLES,
     PJOB_EXAMPLE,
     PMG_EXAMPLE,
+    REVIEWER_PJOB,
+    REVIEWER_VARIABLES,
     REVIEWER_WORKFLOW,
     VALID_KINDS,
     VARIABLE_EXAMPLE,
@@ -267,3 +269,61 @@ class TestReviewerWorkflow:
 
     def test_reviewer_workflow_constant_matches_dict(self):
         assert REVIEWER_WORKFLOW == EXAMPLES["workflow"]["reviewer-cr"]
+
+
+class TestReviewerPJob:
+    """Tests for the reviewer PJob template."""
+
+    def test_reviewer_pjob_exists(self):
+        assert "reviewer" in EXAMPLES["pjob"]
+
+    def test_reviewer_pjob_valid(self):
+        data = yaml.safe_load(REVIEWER_PJOB)
+        config = PJobConfig.from_dict(data)
+        assert config.kind == "PJob"
+        assert config.metadata.code == "reviewer"
+        assert config.metadata.name == "PR Reviewer"
+        assert config.spec.agent == "kimi-standard"
+        assert config.spec.workflow == "reviewer-cr"
+        assert config.spec.variable == "reviewer-vars"
+        assert len(config.spec.actions.post_exec) == 2
+        # First action: success -> github_label
+        assert config.spec.actions.post_exec[0].condition == "success"
+        assert config.spec.actions.post_exec[0].type == "github_label"
+        assert "zima:needs-fix" in config.spec.actions.post_exec[0].add_labels
+        assert "zima:needs-review" in config.spec.actions.post_exec[0].remove_labels
+        assert config.spec.actions.post_exec[0].repo == "{{REPO}}"
+        assert config.spec.actions.post_exec[0].issue == "{{PR_NUMBER}}"
+        # Second action: failure -> github_comment
+        assert config.spec.actions.post_exec[1].condition == "failure"
+        assert config.spec.actions.post_exec[1].type == "github_comment"
+        assert config.spec.actions.post_exec[1].body == "Code review execution failed. Please check logs."
+        assert config.spec.actions.post_exec[1].repo == "{{REPO}}"
+        assert config.spec.actions.post_exec[1].issue == "{{PR_NUMBER}}"
+        assert config.is_valid()
+
+    def test_reviewer_pjob_constant_matches_dict(self):
+        assert REVIEWER_PJOB == EXAMPLES["pjob"]["reviewer"]
+
+
+class TestReviewerVariables:
+    """Tests for the reviewer variable template."""
+
+    def test_reviewer_vars_exists(self):
+        assert "reviewer-vars" in EXAMPLES["variable"]
+
+    def test_reviewer_vars_valid(self):
+        data = yaml.safe_load(REVIEWER_VARIABLES)
+        config = VariableConfig.from_dict(data)
+        assert config.kind == "Variable"
+        assert config.metadata.code == "reviewer-vars"
+        assert config.metadata.name == "Reviewer Variables"
+        assert set(config.values.keys()) == {"repo", "pr_number", "pr_title", "pr_diff"}
+        assert config.values["repo"] == ""
+        assert config.values["pr_number"] == ""
+        assert config.values["pr_title"] == ""
+        assert config.values["pr_diff"] == ""
+        assert config.is_valid()
+
+    def test_reviewer_vars_constant_matches_dict(self):
+        assert REVIEWER_VARIABLES == EXAMPLES["variable"]["reviewer-vars"]

--- a/tests/unit/test_examples.py
+++ b/tests/unit/test_examples.py
@@ -290,16 +290,16 @@ class TestReviewerPJob:
         # First action: success -> github_label
         assert config.spec.actions.post_exec[0].condition == "success"
         assert config.spec.actions.post_exec[0].type == "github_label"
-        assert "zima:needs-fix" in config.spec.actions.post_exec[0].add_labels
+        assert "zima:review-approved" in config.spec.actions.post_exec[0].add_labels
         assert "zima:needs-review" in config.spec.actions.post_exec[0].remove_labels
-        assert config.spec.actions.post_exec[0].repo == "{{REPO}}"
-        assert config.spec.actions.post_exec[0].issue == "{{PR_NUMBER}}"
-        # Second action: failure -> github_comment
+        assert config.spec.actions.post_exec[0].repo == "{{repo}}"
+        assert config.spec.actions.post_exec[0].issue == "{{pr_number}}"
+        # Second action: failure -> github_label
         assert config.spec.actions.post_exec[1].condition == "failure"
-        assert config.spec.actions.post_exec[1].type == "github_comment"
-        assert config.spec.actions.post_exec[1].body == "Code review execution failed. Please check logs."
-        assert config.spec.actions.post_exec[1].repo == "{{REPO}}"
-        assert config.spec.actions.post_exec[1].issue == "{{PR_NUMBER}}"
+        assert config.spec.actions.post_exec[1].type == "github_label"
+        assert "zima:needs-fix" in config.spec.actions.post_exec[1].add_labels
+        assert config.spec.actions.post_exec[1].repo == "{{repo}}"
+        assert config.spec.actions.post_exec[1].issue == "{{pr_number}}"
         assert config.is_valid()
 
     def test_reviewer_pjob_constant_matches_dict(self):

--- a/tests/unit/test_examples.py
+++ b/tests/unit/test_examples.py
@@ -17,6 +17,7 @@ from zima.templates.examples import (
     EXAMPLES,
     PJOB_EXAMPLE,
     PMG_EXAMPLE,
+    REVIEWER_WORKFLOW,
     VALID_KINDS,
     VARIABLE_EXAMPLE,
     WORKFLOW_EXAMPLE,
@@ -33,38 +34,45 @@ KIND_MODEL_MAP = {
 }
 
 
+def _get_first_example(kind: str) -> str:
+    """Get the first (default) example for a given kind."""
+    return list(EXAMPLES[kind].values())[0]
+
+
 class TestExamplesStructure:
     """Parametrized tests for YAML structure correctness."""
 
     @pytest.mark.parametrize("kind", list(EXAMPLES.keys()))
     def test_example_is_valid_yaml(self, kind: str):
         """Each example must parse as valid YAML."""
-        data = yaml.safe_load(EXAMPLES[kind])
-        assert isinstance(data, dict)
+        for example_yaml in EXAMPLES[kind].values():
+            data = yaml.safe_load(example_yaml)
+            assert isinstance(data, dict)
 
     @pytest.mark.parametrize("kind", list(EXAMPLES.keys()))
     def test_example_has_required_top_level_fields(self, kind: str):
         """Each example must have apiVersion, kind, metadata, spec."""
-        data = yaml.safe_load(EXAMPLES[kind])
-        assert "apiVersion" in data, f"{kind}: missing apiVersion"
-        assert "kind" in data, f"{kind}: missing kind"
-        assert "metadata" in data, f"{kind}: missing metadata"
-        assert "spec" in data, f"{kind}: missing spec"
+        for example_yaml in EXAMPLES[kind].values():
+            data = yaml.safe_load(example_yaml)
+            assert "apiVersion" in data, f"{kind}: missing apiVersion"
+            assert "kind" in data, f"{kind}: missing kind"
+            assert "metadata" in data, f"{kind}: missing metadata"
+            assert "spec" in data, f"{kind}: missing spec"
 
     @pytest.mark.parametrize("kind", list(EXAMPLES.keys()))
     def test_example_metadata_has_code_and_name(self, kind: str):
         """Each example metadata must have code and name."""
-        data = yaml.safe_load(EXAMPLES[kind])
-        metadata = data["metadata"]
-        assert "code" in metadata, f"{kind}: metadata missing code"
-        assert "name" in metadata, f"{kind}: metadata missing name"
-        assert metadata["code"], f"{kind}: metadata.code is empty"
-        assert metadata["name"], f"{kind}: metadata.name is empty"
+        for example_yaml in EXAMPLES[kind].values():
+            data = yaml.safe_load(example_yaml)
+            metadata = data["metadata"]
+            assert "code" in metadata, f"{kind}: metadata missing code"
+            assert "name" in metadata, f"{kind}: metadata missing name"
+            assert metadata["code"], f"{kind}: metadata.code is empty"
+            assert metadata["name"], f"{kind}: metadata.name is empty"
 
     @pytest.mark.parametrize("kind", list(EXAMPLES.keys()))
     def test_example_kind_matches_entity(self, kind: str):
         """Each example kind field must match its entity type (capitalized)."""
-        data = yaml.safe_load(EXAMPLES[kind])
         kind_map = {
             "agent": "Agent",
             "workflow": "Workflow",
@@ -74,9 +82,11 @@ class TestExamplesStructure:
             "pjob": "PJob",
             "schedule": "Schedule",
         }
-        assert (
-            data["kind"] == kind_map[kind]
-        ), f"{kind}: kind={data['kind']}, expected={kind_map[kind]}"
+        for example_yaml in EXAMPLES[kind].values():
+            data = yaml.safe_load(example_yaml)
+            assert (
+                data["kind"] == kind_map[kind]
+            ), f"{kind}: kind={data['kind']}, expected={kind_map[kind]}"
 
 
 class TestExamplesCoverage:
@@ -213,3 +223,47 @@ class TestPJobRoundTrip:
         assert config.spec.output.format == "raw"
         assert config.spec.output.append is False
         assert config.is_valid()
+
+
+class TestReviewerWorkflow:
+    """Tests for the reviewer-cr workflow template."""
+
+    def test_reviewer_workflow_exists(self):
+        assert "reviewer-cr" in EXAMPLES["workflow"]
+
+    def test_reviewer_workflow_renders(self):
+        wf_yaml = EXAMPLES["workflow"]["reviewer-cr"]
+        data = yaml.safe_load(wf_yaml)
+        wf = WorkflowConfig.from_dict(data)
+
+        rendered = wf.render(
+            {
+                "repo": "owner/repo",
+                "pr_number": "42",
+                "pr_title": "Fix bug",
+                "pr_diff": "+some code",
+            }
+        )
+        assert "owner/repo" in rendered
+        assert "zima-review" in rendered
+        assert "<verdict>" in rendered
+
+    def test_reviewer_workflow_has_required_variables(self):
+        wf_yaml = EXAMPLES["workflow"]["reviewer-cr"]
+        data = yaml.safe_load(wf_yaml)
+        wf = WorkflowConfig.from_dict(data)
+
+        var_names = {v.name for v in wf.variables}
+        assert var_names == {"repo", "pr_number", "pr_title", "pr_diff"}
+
+        for v in wf.variables:
+            assert v.required is True
+
+    def test_reviewer_workflow_is_valid(self):
+        wf_yaml = EXAMPLES["workflow"]["reviewer-cr"]
+        data = yaml.safe_load(wf_yaml)
+        wf = WorkflowConfig.from_dict(data)
+        assert wf.is_valid()
+
+    def test_reviewer_workflow_constant_matches_dict(self):
+        assert REVIEWER_WORKFLOW == EXAMPLES["workflow"]["reviewer-cr"]

--- a/tests/unit/test_github_ops.py
+++ b/tests/unit/test_github_ops.py
@@ -57,9 +57,7 @@ class TestGitHubOps:
         """Test that gh CLI failure raises RuntimeError."""
         ops = GitHubOps()
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=1, stdout="", stderr="label not found"
-            )
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="label not found")
             with pytest.raises(RuntimeError, match="GitHub CLI failed"):
                 ops.add_label("owner/repo", 123, "bad-label")
 

--- a/tests/unit/test_github_ops.py
+++ b/tests/unit/test_github_ops.py
@@ -1,0 +1,79 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from zima.github.ops import GitHubOps
+
+
+class TestGitHubOps:
+    def test_add_label(self):
+        """Test adding a label to an issue/PR."""
+        ops = GitHubOps()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            ops.add_label("owner/repo", 123, "zima:needs-fix")
+            mock_run.assert_called_once()
+            args = mock_run.call_args[0][0]
+            assert "gh" in args
+            assert "issue" in args
+            assert "edit" in args
+            assert "123" in args
+            assert "--add-label" in args
+            assert "zima:needs-fix" in args
+            assert "--repo" in args
+            assert "owner/repo" in args
+
+    def test_remove_label(self):
+        """Test removing a label from an issue/PR."""
+        ops = GitHubOps()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            ops.remove_label("owner/repo", 123, "zima:needs-review")
+            args = mock_run.call_args[0][0]
+            assert "--remove-label" in args
+            assert "zima:needs-review" in args
+
+    def test_post_comment(self):
+        """Test posting a comment on an issue/PR."""
+        ops = GitHubOps()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            ops.post_comment("owner/repo", 123, "Review done")
+            args = mock_run.call_args[0][0]
+            assert "comment" in args
+            assert "--body" in args
+            assert "Review done" in args
+
+    def test_post_comment_multiline(self):
+        """Test posting a multiline comment uses --body flag."""
+        ops = GitHubOps()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            ops.post_comment("owner/repo", 123, "Line 1\nLine 2")
+            args = mock_run.call_args[0][0]
+            assert "--body" in args
+
+    def test_add_label_failure_raises(self):
+        """Test that gh CLI failure raises RuntimeError."""
+        ops = GitHubOps()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout="", stderr="label not found"
+            )
+            with pytest.raises(RuntimeError, match="GitHub CLI failed"):
+                ops.add_label("owner/repo", 123, "bad-label")
+
+    def test_fetch_pr_diff(self):
+        """Test fetching PR diff via gh pr view --patch."""
+        ops = GitHubOps()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="diff --git a/foo.py b/foo.py", stderr=""
+            )
+            diff = ops.fetch_pr_diff("owner/repo", 123)
+            assert diff == "diff --git a/foo.py b/foo.py"
+            args = mock_run.call_args[0][0]
+            assert "pr" in args
+            assert "view" in args
+            assert "--patch" in args
+            assert "123" in args

--- a/tests/unit/test_models_actions.py
+++ b/tests/unit/test_models_actions.py
@@ -1,0 +1,137 @@
+
+from zima.models.actions import ActionsConfig, PostExecAction
+
+
+class TestPostExecAction:
+    def test_default_action(self):
+        """Test creating a PostExecAction with default values."""
+        action = PostExecAction()
+        assert action.condition == "always"
+        assert action.type == "github_label"
+        assert action.add_labels == []
+        assert action.remove_labels == []
+        assert action.repo == ""
+        assert action.issue == ""
+        assert action.body == ""
+
+    def test_full_action(self):
+        """Test creating a fully configured PostExecAction."""
+        action = PostExecAction(
+            condition="success",
+            type="github_comment",
+            body="Review approved",
+            repo="owner/repo",
+            issue="123",
+        )
+        assert action.condition == "success"
+        assert action.type == "github_comment"
+        assert action.body == "Review approved"
+
+    def test_to_dict(self):
+        """Test converting PostExecAction to dictionary."""
+        action = PostExecAction(
+            condition="success",
+            type="github_label",
+            add_labels=["zima:needs-fix"],
+            remove_labels=["zima:needs-review"],
+            repo="owner/repo",
+            issue="42",
+        )
+        d = action.to_dict()
+        assert d["condition"] == "success"
+        assert d["type"] == "github_label"
+        assert d["addLabels"] == ["zima:needs-fix"]
+        assert d["removeLabels"] == ["zima:needs-review"]
+        assert d["repo"] == "owner/repo"
+        assert d["issue"] == "42"
+
+    def test_to_dict_omits_empty_fields(self):
+        """Test that to_dict omits empty optional fields."""
+        action = PostExecAction(condition="always", type="github_label")
+        d = action.to_dict()
+        assert "addLabels" not in d
+        assert "removeLabels" not in d
+        assert "repo" not in d
+        assert "issue" not in d
+        assert "body" not in d
+
+    def test_from_dict(self):
+        """Test creating PostExecAction from dictionary."""
+        d = {
+            "condition": "failure",
+            "type": "github_comment",
+            "body": "Failed",
+            "repo": "o/r",
+            "issue": "1",
+        }
+        action = PostExecAction.from_dict(d)
+        assert action.condition == "failure"
+        assert action.body == "Failed"
+
+    def test_from_dict_defaults(self):
+        """Test that from_dict uses correct defaults for missing fields."""
+        d = {"condition": "success", "type": "github_label"}
+        action = PostExecAction.from_dict(d)
+        assert action.add_labels == []
+        assert action.remove_labels == []
+        assert action.repo == ""
+        assert action.issue == ""
+        assert action.body == ""
+
+    def test_validate_valid(self):
+        """Test validation with valid action configuration."""
+        action = PostExecAction(condition="success", type="github_label")
+        assert action.validate() == []
+
+    def test_validate_invalid_condition(self):
+        """Test validation catches invalid condition."""
+        action = PostExecAction(condition="invalid", type="github_label")
+        errors = action.validate()
+        assert len(errors) == 1
+        assert "Invalid condition" in errors[0]
+
+    def test_validate_invalid_type(self):
+        """Test validation catches invalid action type."""
+        action = PostExecAction(condition="success", type="invalid")
+        errors = action.validate()
+        assert len(errors) == 1
+        assert "Invalid type" in errors[0]
+
+
+class TestActionsConfig:
+    def test_empty_config(self):
+        """Test creating an empty ActionsConfig."""
+        config = ActionsConfig()
+        assert config.post_exec == []
+
+    def test_with_actions(self):
+        """Test creating ActionsConfig with actions."""
+        action = PostExecAction(condition="success", type="github_label")
+        config = ActionsConfig(post_exec=[action])
+        assert len(config.post_exec) == 1
+
+    def test_to_dict(self):
+        """Test converting ActionsConfig to dictionary."""
+        config = ActionsConfig(post_exec=[PostExecAction(condition="success", type="github_label")])
+        d = config.to_dict()
+        assert "postExec" in d
+        assert len(d["postExec"]) == 1
+
+    def test_from_dict(self):
+        """Test creating ActionsConfig from dictionary."""
+        d = {"postExec": [{"condition": "success", "type": "github_label", "addLabels": ["a"]}]}
+        config = ActionsConfig.from_dict(d)
+        assert len(config.post_exec) == 1
+        assert config.post_exec[0].condition == "success"
+
+    def test_validate_all_actions(self):
+        """Test validating all actions in config."""
+        config = ActionsConfig(
+            post_exec=[
+                PostExecAction(condition="success", type="github_label"),
+                PostExecAction(condition="invalid", type="invalid"),
+            ]
+        )
+        errors = config.validate()
+        assert len(errors) == 2
+        assert "Action[1]" in errors[0]

--- a/tests/unit/test_models_actions.py
+++ b/tests/unit/test_models_actions.py
@@ -1,4 +1,3 @@
-
 from zima.models.actions import ActionsConfig, PostExecAction
 
 

--- a/tests/unit/test_models_pjob.py
+++ b/tests/unit/test_models_pjob.py
@@ -329,3 +329,59 @@ class TestPJobConfig:
         assert refs["variable"] == "var1"
         assert refs["env"] == "env1"
         assert "pmg" not in refs
+
+
+class TestPJobSpecActions:
+    def test_spec_with_actions(self):
+        """Test PJobSpec with actions configuration."""
+        from zima.models.actions import ActionsConfig, PostExecAction
+
+        actions = ActionsConfig(
+            post_exec=[
+                PostExecAction(
+                    condition="success",
+                    type="github_label",
+                    add_labels=["zima:needs-fix"],
+                    remove_labels=["zima:needs-review"],
+                )
+            ]
+        )
+        spec = PJobSpec(agent="a", workflow="w", actions=actions)
+        assert len(spec.actions.post_exec) == 1
+        assert spec.actions.post_exec[0].condition == "success"
+
+    def test_spec_actions_from_dict(self):
+        """Test parsing PJobSpec with actions from dictionary."""
+        d = {
+            "agent": "a",
+            "workflow": "w",
+            "actions": {
+                "postExec": [
+                    {"condition": "success", "type": "github_label", "addLabels": ["x"]}
+                ]
+            },
+        }
+        spec = PJobSpec.from_dict(d)
+        assert len(spec.actions.post_exec) == 1
+        assert spec.actions.post_exec[0].add_labels == ["x"]
+
+    def test_spec_actions_to_dict(self):
+        """Test serializing PJobSpec with actions to dictionary."""
+        from zima.models.actions import ActionsConfig, PostExecAction
+
+        spec = PJobSpec(
+            agent="a",
+            workflow="w",
+            actions=ActionsConfig(
+                post_exec=[PostExecAction(condition="failure", type="github_comment", body="oops")]
+            ),
+        )
+        d = spec.to_dict()
+        assert "actions" in d
+        assert d["actions"]["postExec"][0]["condition"] == "failure"
+
+    def test_spec_actions_empty_omitted(self):
+        """Test that empty actions are omitted from to_dict."""
+        spec = PJobSpec(agent="a", workflow="w")
+        d = spec.to_dict()
+        assert "actions" not in d

--- a/tests/unit/test_models_pjob.py
+++ b/tests/unit/test_models_pjob.py
@@ -356,9 +356,7 @@ class TestPJobSpecActions:
             "agent": "a",
             "workflow": "w",
             "actions": {
-                "postExec": [
-                    {"condition": "success", "type": "github_label", "addLabels": ["x"]}
-                ]
+                "postExec": [{"condition": "success", "type": "github_label", "addLabels": ["x"]}]
             },
         }
         spec = PJobSpec.from_dict(d)

--- a/tests/unit/test_review_parser.py
+++ b/tests/unit/test_review_parser.py
@@ -1,0 +1,45 @@
+from zima.review.parser import ReviewIssue, ReviewResult
+
+
+class TestReviewIssue:
+    def test_create_issue(self):
+        """Test creating a ReviewIssue with explicit values."""
+        issue = ReviewIssue(
+            severity="error",
+            file="src/foo.py",
+            line=42,
+            message="变量未定义",
+        )
+        assert issue.severity == "error"
+        assert issue.file == "src/foo.py"
+        assert issue.line == 42
+        assert issue.message == "变量未定义"
+
+    def test_default_values(self):
+        """Test ReviewIssue default field values."""
+        issue = ReviewIssue()
+        assert issue.severity == "warning"
+        assert issue.file == ""
+        assert issue.line == 0
+        assert issue.message == ""
+
+
+class TestReviewResult:
+    def test_default_result(self):
+        """Test ReviewResult default field values."""
+        result = ReviewResult()
+        assert result.verdict == ""
+        assert result.summary == ""
+        assert result.issues == []
+
+    def test_result_with_issues(self):
+        """Test creating a ReviewResult containing issues."""
+        issue = ReviewIssue(severity="warning", file="a.py", line=1, message="x")
+        result = ReviewResult(
+            verdict="needs_fix",
+            summary="发现 2 个问题",
+            issues=[issue],
+        )
+        assert result.verdict == "needs_fix"
+        assert result.summary == "发现 2 个问题"
+        assert len(result.issues) == 1

--- a/tests/unit/test_review_parser.py
+++ b/tests/unit/test_review_parser.py
@@ -1,4 +1,4 @@
-from zima.review.parser import ReviewIssue, ReviewResult
+from zima.review.parser import ReviewIssue, ReviewParser, ReviewResult
 
 
 class TestReviewIssue:
@@ -43,3 +43,71 @@ class TestReviewResult:
         assert result.verdict == "needs_fix"
         assert result.summary == "发现 2 个问题"
         assert len(result.issues) == 1
+
+
+class TestReviewParser:
+    def test_parse_approved_review(self):
+        """Test parsing an approved review with no issues."""
+        stdout = "Some review text\n<zima-review>\n  <verdict>approved</verdict>\n  <summary>LGTM</summary>\n</zima-review>"
+        result = ReviewParser.parse(stdout)
+        assert result.verdict == "approved"
+        assert result.summary == "LGTM"
+        assert result.issues == []
+
+    def test_parse_needs_fix(self):
+        """Test parsing a review that needs fixes with multiple issues."""
+        stdout = """Review complete.
+<zima-review>
+  <verdict>needs_fix</verdict>
+  <summary>发现 2 个问题</summary>
+  <issues>
+    <issue severity="error" file="src/foo.py" line="42">变量未定义</issue>
+    <issue severity="warning" file="src/bar.py" line="10">缺少类型注解</issue>
+  </issues>
+</zima-review>"""
+        result = ReviewParser.parse(stdout)
+        assert result.verdict == "needs_fix"
+        assert result.summary == "发现 2 个问题"
+        assert len(result.issues) == 2
+        assert result.issues[0].severity == "error"
+        assert result.issues[0].file == "src/foo.py"
+        assert result.issues[0].line == 42  # Note: line is now int
+        assert result.issues[0].message == "变量未定义"
+
+    def test_parse_no_block(self):
+        """Test parsing when no review block is present."""
+        result = ReviewParser.parse("No review block here")
+        assert result.verdict == "needs_discussion"
+        assert "No review block" in result.summary
+
+    def test_parse_invalid_xml(self):
+        """Test parsing invalid XML returns fallback result."""
+        result = ReviewParser.parse("<zima-review><unclosed>")
+        assert result.verdict == "needs_discussion"
+        assert "Invalid" in result.summary
+
+    def test_parse_empty_issues(self):
+        """Test parsing a review with explicit empty issues list."""
+        stdout = "<zima-review><verdict>approved</verdict><summary>OK</summary><issues></issues></zima-review>"
+        result = ReviewParser.parse(stdout)
+        assert result.verdict == "approved"
+        assert result.issues == []
+
+    def test_parse_unclosed_tag(self):
+        """Test parsing unclosed review tag with valid inner content."""
+        stdout = "<zima-review><verdict>approved</verdict><summary>OK</summary>"
+        result = ReviewParser.parse(stdout)
+        assert result.verdict == "approved"
+        assert result.summary == "OK"
+
+    def test_parse_line_edge_cases(self):
+        """Test parsing issues with various line attribute formats."""
+        # Missing line attribute
+        stdout = '<zima-review><verdict>needs_fix</verdict><summary>x</summary><issues><issue severity="error" file="a.py">msg</issue></issues></zima-review>'
+        result = ReviewParser.parse(stdout)
+        assert result.issues[0].line == 0
+
+        # Non-numeric line
+        stdout = '<zima-review><verdict>needs_fix</verdict><summary>x</summary><issues><issue severity="error" file="a.py" line="abc">msg</issue></issues></zima-review>'
+        result = ReviewParser.parse(stdout)
+        assert result.issues[0].line == 0

--- a/zima/commands/agent.py
+++ b/zima/commands/agent.py
@@ -39,7 +39,7 @@ def create(
     if example:
         from zima.templates.examples import EXAMPLES
 
-        print(EXAMPLES["agent"])
+        print(list(EXAMPLES["agent"].values())[0])
         raise typer.Exit(0)
 
     if not name:

--- a/zima/commands/agent.py
+++ b/zima/commands/agent.py
@@ -39,7 +39,7 @@ def create(
     if example:
         from zima.templates.examples import EXAMPLES
 
-        print(list(EXAMPLES["agent"].values())[0])
+        print(next(iter(EXAMPLES["agent"].values())))
         raise typer.Exit(0)
 
     if not name:

--- a/zima/commands/env.py
+++ b/zima/commands/env.py
@@ -38,7 +38,7 @@ def create(
     if example:
         from zima.templates.examples import EXAMPLES
 
-        print(list(EXAMPLES["env"].values())[0])
+        print(next(iter(EXAMPLES["env"].values())))
         raise typer.Exit(0)
 
     if not code:

--- a/zima/commands/env.py
+++ b/zima/commands/env.py
@@ -38,7 +38,7 @@ def create(
     if example:
         from zima.templates.examples import EXAMPLES
 
-        print(EXAMPLES["env"])
+        print(list(EXAMPLES["env"].values())[0])
         raise typer.Exit(0)
 
     if not code:

--- a/zima/commands/pjob.py
+++ b/zima/commands/pjob.py
@@ -50,7 +50,7 @@ def create(
     if example:
         from zima.templates.examples import EXAMPLES
 
-        print(EXAMPLES["pjob"])
+        print(list(EXAMPLES["pjob"].values())[0])
         raise typer.Exit(0)
 
     if not name:

--- a/zima/commands/pjob.py
+++ b/zima/commands/pjob.py
@@ -50,7 +50,7 @@ def create(
     if example:
         from zima.templates.examples import EXAMPLES
 
-        print(list(EXAMPLES["pjob"].values())[0])
+        print(next(iter(EXAMPLES["pjob"].values())))
         raise typer.Exit(0)
 
     if not name:

--- a/zima/commands/pmg.py
+++ b/zima/commands/pmg.py
@@ -37,7 +37,7 @@ def create(
     if example:
         from zima.templates.examples import EXAMPLES
 
-        print(EXAMPLES["pmg"])
+        print(list(EXAMPLES["pmg"].values())[0])
         raise typer.Exit(0)
 
     if not code:

--- a/zima/commands/pmg.py
+++ b/zima/commands/pmg.py
@@ -37,7 +37,7 @@ def create(
     if example:
         from zima.templates.examples import EXAMPLES
 
-        print(list(EXAMPLES["pmg"].values())[0])
+        print(next(iter(EXAMPLES["pmg"].values())))
         raise typer.Exit(0)
 
     if not code:

--- a/zima/commands/schedule.py
+++ b/zima/commands/schedule.py
@@ -28,7 +28,7 @@ def create(
     if example:
         from zima.templates.examples import EXAMPLES
 
-        print(EXAMPLES["schedule"])
+        print(list(EXAMPLES["schedule"].values())[0])
         raise typer.Exit(0)
 
     if not name or not code:

--- a/zima/commands/schedule.py
+++ b/zima/commands/schedule.py
@@ -28,7 +28,7 @@ def create(
     if example:
         from zima.templates.examples import EXAMPLES
 
-        print(list(EXAMPLES["schedule"].values())[0])
+        print(next(iter(EXAMPLES["schedule"].values())))
         raise typer.Exit(0)
 
     if not name or not code:

--- a/zima/commands/variable.py
+++ b/zima/commands/variable.py
@@ -40,7 +40,7 @@ def create(
     if example:
         from zima.templates.examples import EXAMPLES
 
-        print(EXAMPLES["variable"])
+        print(list(EXAMPLES["variable"].values())[0])
         raise typer.Exit(0)
 
     if not name:

--- a/zima/commands/variable.py
+++ b/zima/commands/variable.py
@@ -40,7 +40,7 @@ def create(
     if example:
         from zima.templates.examples import EXAMPLES
 
-        print(list(EXAMPLES["variable"].values())[0])
+        print(next(iter(EXAMPLES["variable"].values())))
         raise typer.Exit(0)
 
     if not name:

--- a/zima/commands/workflow.py
+++ b/zima/commands/workflow.py
@@ -42,7 +42,7 @@ def create(
     if example:
         from zima.templates.examples import EXAMPLES
 
-        print(list(EXAMPLES["workflow"].values())[0])
+        print(next(iter(EXAMPLES["workflow"].values())))
         raise typer.Exit(0)
 
     if not name:

--- a/zima/commands/workflow.py
+++ b/zima/commands/workflow.py
@@ -42,7 +42,7 @@ def create(
     if example:
         from zima.templates.examples import EXAMPLES
 
-        print(EXAMPLES["workflow"])
+        print(list(EXAMPLES["workflow"].values())[0])
         raise typer.Exit(0)
 
     if not name:

--- a/zima/execution/actions_runner.py
+++ b/zima/execution/actions_runner.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 from zima.github.ops import GitHubOps
 from zima.models.actions import ActionsConfig, PostExecAction
-from zima.review.parser import ReviewResult
 
 
 def _matches_condition(condition: str, returncode: int) -> bool:
@@ -43,7 +42,6 @@ class ActionsRunner:
         actions: ActionsConfig,
         returncode: int,
         env: dict[str, str],
-        review_result: Optional[ReviewResult] = None,
     ) -> None:
         """Execute all matching postExec actions.
 
@@ -51,7 +49,6 @@ class ActionsRunner:
             actions: Actions configuration from PJob.
             returncode: Agent process exit code.
             env: Environment variables for {{VAR}} substitution.
-            review_result: Parsed review result (optional, for reviewer PJobs).
         """
         for action in actions.post_exec:
             if not _matches_condition(action.condition, returncode):
@@ -65,21 +62,21 @@ class ActionsRunner:
 
         def sub(value: str) -> str:
             for key, val in env.items():
-                value = value.replace(f"{{{key}}}", str(val))
+                value = value.replace(f"{{{{{key}}}}}", str(val))
             return value
 
         return PostExecAction(
             condition=action.condition,
             type=action.type,
-            add_labels=[sub(l) for l in action.add_labels],
-            remove_labels=[sub(l) for l in action.remove_labels],
+            add_labels=[sub(label) for label in action.add_labels],
+            remove_labels=[sub(label) for label in action.remove_labels],
             repo=sub(action.repo),
             issue=sub(action.issue),
             body=sub(action.body),
         )
 
     def _execute_action(self, action: PostExecAction) -> None:
-        """Execute a single action."""
+        """Execute a single action, logging individual failures but continuing."""
         if not action.repo or not action.issue:
             return
 
@@ -90,10 +87,19 @@ class ActionsRunner:
 
         if action.type == "github_label":
             for label in action.add_labels:
-                self._ops.add_label(action.repo, issue_num, label)
+                try:
+                    self._ops.add_label(action.repo, issue_num, label)
+                except RuntimeError as e:
+                    print(f"Warning: Failed to add label '{label}': {e}")
             for label in action.remove_labels:
-                self._ops.remove_label(action.repo, issue_num, label)
+                try:
+                    self._ops.remove_label(action.repo, issue_num, label)
+                except RuntimeError as e:
+                    print(f"Warning: Failed to remove label '{label}': {e}")
 
         elif action.type == "github_comment":
             if action.body:
-                self._ops.post_comment(action.repo, issue_num, action.body)
+                try:
+                    self._ops.post_comment(action.repo, issue_num, action.body)
+                except RuntimeError as e:
+                    print(f"Warning: Failed to post comment: {e}")

--- a/zima/execution/actions_runner.py
+++ b/zima/execution/actions_runner.py
@@ -1,0 +1,99 @@
+"""Actions runner for executing postExec actions after agent process exits."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from zima.github.ops import GitHubOps
+from zima.models.actions import ActionsConfig, PostExecAction
+from zima.review.parser import ReviewResult
+
+
+def _matches_condition(condition: str, returncode: int) -> bool:
+    """Check if action condition matches execution result.
+
+    Args:
+        condition: Action condition - "success", "failure", or "always".
+        returncode: Process exit code.
+
+    Returns:
+        True if the condition matches the returncode.
+    """
+    if condition == "always":
+        return True
+    if condition == "success":
+        return returncode == 0
+    if condition == "failure":
+        return returncode != 0
+    return False
+
+
+class ActionsRunner:
+    """Executes postExec actions after agent process exits.
+
+    Handles condition matching, environment variable substitution,
+    and GitHub label/comment operations.
+    """
+
+    def __init__(self, ops: Optional[GitHubOps] = None):
+        self._ops = ops or GitHubOps()
+
+    def run(
+        self,
+        actions: ActionsConfig,
+        returncode: int,
+        env: dict[str, str],
+        review_result: Optional[ReviewResult] = None,
+    ) -> None:
+        """Execute all matching postExec actions.
+
+        Args:
+            actions: Actions configuration from PJob.
+            returncode: Agent process exit code.
+            env: Environment variables for {{VAR}} substitution.
+            review_result: Parsed review result (optional, for reviewer PJobs).
+        """
+        for action in actions.post_exec:
+            if not _matches_condition(action.condition, returncode):
+                continue
+
+            processed = self._substitute_env(action, env)
+            self._execute_action(processed)
+
+    def _substitute_env(self, action: PostExecAction, env: dict[str, str]) -> PostExecAction:
+        """Replace {{VAR}} placeholders with env values."""
+
+        def sub(value: str) -> str:
+            for key, val in env.items():
+                value = value.replace(f"{{{key}}}", str(val))
+            return value
+
+        return PostExecAction(
+            condition=action.condition,
+            type=action.type,
+            add_labels=[sub(l) for l in action.add_labels],
+            remove_labels=[sub(l) for l in action.remove_labels],
+            repo=sub(action.repo),
+            issue=sub(action.issue),
+            body=sub(action.body),
+        )
+
+    def _execute_action(self, action: PostExecAction) -> None:
+        """Execute a single action."""
+        if not action.repo or not action.issue:
+            return
+
+        try:
+            issue_num = int(action.issue)
+        except ValueError:
+            return
+
+        if action.type == "github_label":
+            for label in action.add_labels:
+                self._ops.add_label(action.repo, issue_num, label)
+            for label in action.remove_labels:
+                self._ops.remove_label(action.repo, issue_num, label)
+
+        elif action.type == "github_comment":
+            if action.body:
+                self._ops.post_comment(action.repo, issue_num, action.body)

--- a/zima/execution/executor.py
+++ b/zima/execution/executor.py
@@ -13,8 +13,10 @@ from pathlib import Path
 from typing import Optional
 
 from zima.config.manager import ConfigManager
+from zima.execution.actions_runner import ActionsRunner
 from zima.models.config_bundle import ConfigBundle
 from zima.models.pjob import Overrides, PJobConfig
+from zima.review.parser import ReviewParser
 from zima.utils import generate_timestamp, get_zima_home
 
 
@@ -141,6 +143,7 @@ class PJobExecutor:
         """Initialize executor."""
         self.config_manager = ConfigManager()
         self._current_process: Optional[subprocess.Popen] = None
+        self._actions_runner = ActionsRunner()
 
     def execute(
         self,
@@ -229,7 +232,10 @@ class PJobExecutor:
             # 10. Execute post-hooks
             self._run_hooks(pjob.spec.hooks.get("postExec", []), env_vars, bundle.work_dir)
 
-            # 11. Handle output
+            # 11. Execute postExec actions
+            self._run_post_exec_actions(pjob, result, env_vars)
+
+            # 12. Handle output
             if pjob.spec.output.save_to:
                 self._save_output(result, pjob.spec.output)
 
@@ -433,6 +439,36 @@ class PJobExecutor:
                 # Log warning but don't fail
                 print(f"Warning: Hook failed: {hook}")
                 print(f"  Error: {e}")
+
+    def _run_post_exec_actions(
+        self, pjob: PJobConfig, result: ExecutionResult, env_vars: dict[str, str]
+    ) -> None:
+        """Run postExec actions based on execution result.
+
+        Args:
+            pjob: PJob configuration.
+            result: Execution result from agent.
+            env_vars: Resolved environment variables for substitution.
+        """
+        if not pjob.spec.actions.post_exec:
+            return
+
+        review_result = None
+        if "reviewer" in pjob.metadata.labels:
+            review_result = ReviewParser.parse(result.stdout)
+
+        try:
+            self._actions_runner.run(
+                actions=pjob.spec.actions,
+                returncode=result.returncode,
+                env=env_vars,
+                review_result=review_result,
+            )
+        except Exception as e:
+            import traceback
+
+            print(f"Warning: Post-exec action failed: {e}")
+            print(traceback.format_exc())
 
     def _run_command(
         self,

--- a/zima/execution/executor.py
+++ b/zima/execution/executor.py
@@ -235,23 +235,18 @@ class PJobExecutor:
             # 10. Execute post-hooks
             self._run_hooks(pjob.spec.hooks.get("postExec", []), env_vars, bundle.work_dir)
 
-            # 11. Execute postExec actions
-            # Merge variable values into env for {{VAR}} action substitution
-            action_env = env_vars.copy()
-            if bundle.variable:
-                action_env.update(bundle.variable.values)
-            self._run_post_exec_actions(pjob, result, action_env)
-
             # 12. Handle output
             if pjob.spec.output.save_to:
                 self._save_output(result, pjob.spec.output)
 
         except subprocess.TimeoutExpired:
             result.status = ExecutionStatus.TIMEOUT
+            result.returncode = -1
             result.stderr = "Execution timed out"
             result.error_detail = f"Timeout after {pjob.spec.execution.timeout}s"
         except KeyboardInterrupt:
             result.status = ExecutionStatus.CANCELLED
+            result.returncode = -2
             result.stderr = "Execution cancelled by user (Ctrl+C)"
             # Attempt to terminate subprocess gracefully
             if self._current_process and self._current_process.poll() is None:
@@ -264,13 +259,28 @@ class PJobExecutor:
             import traceback
 
             result.status = ExecutionStatus.FAILED
+            result.returncode = -3
             result.stderr = _friendly_error(e)
             result.error_detail = traceback.format_exc()
         finally:
+            # 11. Execute postExec actions even on timeout/cancel/error
+            try:
+                _pjob = locals().get("pjob")
+                _bundle = locals().get("bundle")
+                _env_vars = locals().get("env_vars")
+                if _pjob is not None and _env_vars is not None and _pjob.spec.actions.post_exec:
+                    action_env = _env_vars.copy()
+                    if _bundle is not None and _bundle.variable:
+                        action_env.update(_bundle.variable.values)
+                    self._run_post_exec_actions(_pjob, result, action_env)
+            except Exception:
+                pass  # Action errors already recorded in result.action_errors
+
             result.finished_at = generate_timestamp()
 
             # Cleanup temp directory
-            if temp_dir and not (keep_temp or pjob.spec.execution.keep_temp):
+            _pjob_cleanup = locals().get("pjob")
+            if temp_dir and not (keep_temp or (_pjob_cleanup is not None and _pjob_cleanup.spec.execution.keep_temp)):
                 shutil.rmtree(temp_dir, ignore_errors=True)
                 result.temp_dir = None
                 result.prompt_file = None

--- a/zima/execution/executor.py
+++ b/zima/execution/executor.py
@@ -233,7 +233,11 @@ class PJobExecutor:
             self._run_hooks(pjob.spec.hooks.get("postExec", []), env_vars, bundle.work_dir)
 
             # 11. Execute postExec actions
-            self._run_post_exec_actions(pjob, result, env_vars)
+            # Merge variable values into env for {{VAR}} action substitution
+            action_env = env_vars.copy()
+            if bundle.variable:
+                action_env.update(bundle.variable.values)
+            self._run_post_exec_actions(pjob, result, action_env)
 
             # 12. Handle output
             if pjob.spec.output.save_to:
@@ -457,12 +461,18 @@ class PJobExecutor:
         if "reviewer" in pjob.metadata.labels:
             review_result = ReviewParser.parse(result.stdout)
 
+        # Map review verdict to effective returncode for action conditions
+        effective_returncode = result.returncode
+        if review_result and review_result.verdict == "approved":
+            effective_returncode = 0
+        elif review_result and review_result.verdict in ("needs_fix", "needs_discussion"):
+            effective_returncode = 1
+
         try:
             self._actions_runner.run(
                 actions=pjob.spec.actions,
-                returncode=result.returncode,
+                returncode=effective_returncode,
                 env=env_vars,
-                review_result=review_result,
             )
         except Exception as e:
             import traceback

--- a/zima/execution/executor.py
+++ b/zima/execution/executor.py
@@ -50,6 +50,7 @@ class ExecutionResult:
         finished_at: Finish timestamp
         execution_id: Unique execution ID
         temp_dir: Temporary directory (if kept)
+        action_errors: Post-exec action failure messages
     """
 
     pjob_code: str = ""
@@ -68,6 +69,7 @@ class ExecutionResult:
     prompt_file: Optional[Path] = None  # Rendered workflow prompt file
     prompt_content: str = ""  # Rendered workflow content (kept for dry-run)
     pid: Optional[int] = None  # 执行的进程 PID
+    action_errors: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         """Convert to dictionary."""
@@ -86,6 +88,7 @@ class ExecutionResult:
             "execution_id": self.execution_id,
             "temp_dir": str(self.temp_dir) if self.temp_dir else None,
             "pid": self.pid,
+            "action_errors": self.action_errors,
         }
 
     @property
@@ -458,7 +461,7 @@ class PJobExecutor:
             return
 
         review_result = None
-        if "reviewer" in pjob.metadata.labels:
+        if "<zima-review>" in result.stdout:
             review_result = ReviewParser.parse(result.stdout)
 
         # Map review verdict to effective returncode for action conditions
@@ -477,7 +480,9 @@ class PJobExecutor:
         except Exception as e:
             import traceback
 
-            print(f"Warning: Post-exec action failed: {e}")
+            error_msg = f"Post-exec action failed: {e}"
+            result.action_errors.append(error_msg)
+            print(f"Warning: {error_msg}")
             print(traceback.format_exc())
 
     def _run_command(

--- a/zima/execution/executor.py
+++ b/zima/execution/executor.py
@@ -241,12 +241,12 @@ class PJobExecutor:
 
         except subprocess.TimeoutExpired:
             result.status = ExecutionStatus.TIMEOUT
-            result.returncode = -1
+            result.returncode = 124
             result.stderr = "Execution timed out"
             result.error_detail = f"Timeout after {pjob.spec.execution.timeout}s"
         except KeyboardInterrupt:
             result.status = ExecutionStatus.CANCELLED
-            result.returncode = -2
+            result.returncode = 130
             result.stderr = "Execution cancelled by user (Ctrl+C)"
             # Attempt to terminate subprocess gracefully
             if self._current_process and self._current_process.poll() is None:
@@ -259,22 +259,29 @@ class PJobExecutor:
             import traceback
 
             result.status = ExecutionStatus.FAILED
-            result.returncode = -3
+            result.returncode = 1
             result.stderr = _friendly_error(e)
             result.error_detail = traceback.format_exc()
         finally:
-            # 11. Execute postExec actions even on timeout/cancel/error
-            try:
-                _pjob = locals().get("pjob")
-                _bundle = locals().get("bundle")
-                _env_vars = locals().get("env_vars")
-                if _pjob is not None and _env_vars is not None and _pjob.spec.actions.post_exec:
-                    action_env = _env_vars.copy()
-                    if _bundle is not None and _bundle.variable:
-                        action_env.update(_bundle.variable.values)
-                    self._run_post_exec_actions(_pjob, result, action_env)
-            except Exception:
-                pass  # Action errors already recorded in result.action_errors
+            # 11. Execute postExec actions even on timeout/cancel/error,
+            # but skip on dry-run (finally runs after return in try block).
+            if not dry_run:
+                try:
+                    _pjob = locals().get("pjob")
+                    _bundle = locals().get("bundle")
+                    _env_vars = locals().get("env_vars")
+                    if _pjob is not None and _env_vars is not None and _pjob.spec.actions.post_exec:
+                        action_env = _env_vars.copy()
+                        if _bundle is not None and _bundle.variable:
+                            action_env.update(_bundle.variable.values)
+                        self._run_post_exec_actions(_pjob, result, action_env)
+                except Exception as e:
+                    import traceback
+
+                    error_msg = f"Post-exec action setup failed: {e}"
+                    result.action_errors.append(error_msg)
+                    print(f"Warning: {error_msg}")
+                    print(traceback.format_exc())
 
             result.finished_at = generate_timestamp()
 
@@ -470,8 +477,14 @@ class PJobExecutor:
         if not pjob.spec.actions.post_exec:
             return
 
+        # Don't parse review XML on timeout or cancellation — agent didn't finish
+        is_timeout_or_cancel = result.status in (
+            ExecutionStatus.TIMEOUT,
+            ExecutionStatus.CANCELLED,
+        )
+
         review_result = None
-        if "<zima-review>" in result.stdout:
+        if not is_timeout_or_cancel and "<zima-review>" in result.stdout:
             review_result = ReviewParser.parse(result.stdout)
 
         # Map review verdict to effective returncode for action conditions

--- a/zima/execution/executor.py
+++ b/zima/execution/executor.py
@@ -287,7 +287,9 @@ class PJobExecutor:
 
             # Cleanup temp directory
             _pjob_cleanup = locals().get("pjob")
-            if temp_dir and not (keep_temp or (_pjob_cleanup is not None and _pjob_cleanup.spec.execution.keep_temp)):
+            if temp_dir and not (
+                keep_temp or (_pjob_cleanup is not None and _pjob_cleanup.spec.execution.keep_temp)
+            ):
                 shutil.rmtree(temp_dir, ignore_errors=True)
                 result.temp_dir = None
                 result.prompt_file = None

--- a/zima/github/__init__.py
+++ b/zima/github/__init__.py
@@ -1,0 +1,3 @@
+from zima.github.ops import GitHubOps
+
+__all__ = ["GitHubOps"]

--- a/zima/github/ops.py
+++ b/zima/github/ops.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import subprocess
 
 
@@ -57,12 +56,3 @@ class GitHubOps:
             capture=True,
         )
         return result.stdout
-
-    def fetch_issue_body(self, repo: str, number: int) -> str:
-        """Fetch issue body as text."""
-        result = self._run(
-            ["issue", "view", str(number), "--repo", repo, "--json", "body"],
-            capture=True,
-        )
-        data = json.loads(result.stdout)
-        return data.get("body", "")

--- a/zima/github/ops.py
+++ b/zima/github/ops.py
@@ -26,28 +26,21 @@ class GitHubOps:
         )
         if check and result.returncode != 0:
             raise RuntimeError(
-                f"GitHub CLI failed: {' '.join(cmd)}\n"
-                f"stderr: {result.stderr.strip()}"
+                f"GitHub CLI failed: {' '.join(cmd)}\n" f"stderr: {result.stderr.strip()}"
             )
         return result
 
     def add_label(self, repo: str, number: int, label: str) -> None:
         """Add a label to an issue or PR."""
-        self._run(
-            ["issue", "edit", str(number), "--add-label", label, "--repo", repo]
-        )
+        self._run(["issue", "edit", str(number), "--add-label", label, "--repo", repo])
 
     def remove_label(self, repo: str, number: int, label: str) -> None:
         """Remove a label from an issue or PR."""
-        self._run(
-            ["issue", "edit", str(number), "--remove-label", label, "--repo", repo]
-        )
+        self._run(["issue", "edit", str(number), "--remove-label", label, "--repo", repo])
 
     def post_comment(self, repo: str, number: int, body: str) -> None:
         """Post a comment on an issue or PR."""
-        self._run(
-            ["issue", "comment", str(number), "--body", body, "--repo", repo]
-        )
+        self._run(["issue", "comment", str(number), "--body", body, "--repo", repo])
 
     def fetch_pr_diff(self, repo: str, number: int) -> str:
         """Fetch PR diff as text."""

--- a/zima/github/ops.py
+++ b/zima/github/ops.py
@@ -1,3 +1,5 @@
+"""GitHub CLI wrapper for PJob post-execution actions."""
+
 from __future__ import annotations
 
 import json
@@ -21,6 +23,7 @@ class GitHubOps:
             text=True,
             timeout=self.timeout,
             check=False,
+            stdin=subprocess.DEVNULL,
         )
         if check and result.returncode != 0:
             raise RuntimeError(

--- a/zima/github/ops.py
+++ b/zima/github/ops.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+
+class GitHubOps:
+    """Wrapper for GitHub CLI operations used by PJob actions."""
+
+    def __init__(self, timeout: int = 30):
+        self.timeout = timeout
+
+    def _run(
+        self, args: list[str], check: bool = True, capture: bool = True
+    ) -> subprocess.CompletedProcess:
+        """Run a gh CLI command."""
+        cmd = ["gh"] + args
+        result = subprocess.run(
+            cmd,
+            capture_output=capture,
+            text=True,
+            timeout=self.timeout,
+            check=False,
+        )
+        if check and result.returncode != 0:
+            raise RuntimeError(
+                f"GitHub CLI failed: {' '.join(cmd)}\n"
+                f"stderr: {result.stderr.strip()}"
+            )
+        return result
+
+    def add_label(self, repo: str, number: int, label: str) -> None:
+        """Add a label to an issue or PR."""
+        self._run(
+            ["issue", "edit", str(number), "--add-label", label, "--repo", repo]
+        )
+
+    def remove_label(self, repo: str, number: int, label: str) -> None:
+        """Remove a label from an issue or PR."""
+        self._run(
+            ["issue", "edit", str(number), "--remove-label", label, "--repo", repo]
+        )
+
+    def post_comment(self, repo: str, number: int, body: str) -> None:
+        """Post a comment on an issue or PR."""
+        self._run(
+            ["issue", "comment", str(number), "--body", body, "--repo", repo]
+        )
+
+    def fetch_pr_diff(self, repo: str, number: int) -> str:
+        """Fetch PR diff as text."""
+        result = self._run(
+            ["pr", "view", str(number), "--repo", repo, "--patch"],
+            capture=True,
+        )
+        return result.stdout
+
+    def fetch_issue_body(self, repo: str, number: int) -> str:
+        """Fetch issue body as text."""
+        result = self._run(
+            ["issue", "view", str(number), "--repo", repo, "--json", "body"],
+            capture=True,
+        )
+        data = json.loads(result.stdout)
+        return data.get("body", "")

--- a/zima/models/actions.py
+++ b/zima/models/actions.py
@@ -1,0 +1,98 @@
+"""Post-execution action models for PJob automation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+VALID_ACTION_CONDITIONS = {"success", "failure", "always"}
+VALID_ACTION_TYPES = {"github_label", "github_comment"}
+
+
+@dataclass
+class PostExecAction:
+    """Single post-execution action run after agent exits.
+
+    Attributes:
+        condition: When to run - "success", "failure", or "always".
+        type: Action type - "github_label" or "github_comment".
+        add_labels: Labels to add (for github_label type).
+        remove_labels: Labels to remove (for github_label type).
+        repo: Repository slug in "owner/repo" format.
+        issue: Issue or PR number as string.
+        body: Comment body (for github_comment type).
+    """
+
+    condition: str = "always"
+    type: str = "github_label"
+    add_labels: list[str] = field(default_factory=list)
+    remove_labels: list[str] = field(default_factory=list)
+    repo: str = ""
+    issue: str = ""
+    body: str = ""
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary."""
+        result = {
+            "condition": self.condition,
+            "type": self.type,
+        }
+        if self.add_labels:
+            result["addLabels"] = self.add_labels
+        if self.remove_labels:
+            result["removeLabels"] = self.remove_labels
+        if self.repo:
+            result["repo"] = self.repo
+        if self.issue:
+            result["issue"] = self.issue
+        if self.body:
+            result["body"] = self.body
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict) -> PostExecAction:
+        """Create from dictionary."""
+        return cls(
+            condition=data.get("condition", "always"),
+            type=data.get("type", "github_label"),
+            add_labels=data.get("addLabels", []),
+            remove_labels=data.get("removeLabels", []),
+            repo=data.get("repo", ""),
+            issue=str(data.get("issue", "")),
+            body=data.get("body", ""),
+        )
+
+    def validate(self) -> list[str]:
+        """Validate action configuration."""
+        errors = []
+        if self.condition not in VALID_ACTION_CONDITIONS:
+            errors.append(f"Invalid condition '{self.condition}'. Valid: {VALID_ACTION_CONDITIONS}")
+        if self.type not in VALID_ACTION_TYPES:
+            errors.append(f"Invalid type '{self.type}'. Valid: {VALID_ACTION_TYPES}")
+        return errors
+
+
+@dataclass
+class ActionsConfig:
+    """Collection of actions for a PJob."""
+
+    post_exec: list[PostExecAction] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary."""
+        return {"postExec": [a.to_dict() for a in self.post_exec]}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ActionsConfig:
+        """Create from dictionary."""
+        actions = []
+        for action_data in data.get("postExec", []):
+            actions.append(PostExecAction.from_dict(action_data))
+        return cls(post_exec=actions)
+
+    def validate(self) -> list[str]:
+        """Validate all actions."""
+        errors = []
+        for i, action in enumerate(self.post_exec):
+            action_errors = action.validate()
+            errors.extend([f"Action[{i}]: {e}" for e in action_errors])
+        return errors

--- a/zima/models/actions.py
+++ b/zima/models/actions.py
@@ -50,8 +50,8 @@ class PostExecAction:
 
     @classmethod
     def from_dict(cls, data: dict) -> PostExecAction:
-        """Create from dictionary."""
-        return cls(
+        """Create from dictionary and validate."""
+        action = cls(
             condition=data.get("condition", "always"),
             type=data.get("type", "github_label"),
             add_labels=data.get("addLabels", []),
@@ -60,6 +60,10 @@ class PostExecAction:
             issue=str(data.get("issue", "")),
             body=data.get("body", ""),
         )
+        errors = action.validate()
+        if errors:
+            raise ValueError("; ".join(errors))
+        return action
 
     def validate(self) -> list[str]:
         """Validate action configuration."""
@@ -83,11 +87,15 @@ class ActionsConfig:
 
     @classmethod
     def from_dict(cls, data: dict) -> ActionsConfig:
-        """Create from dictionary."""
+        """Create from dictionary and validate."""
         actions = []
         for action_data in data.get("postExec", []):
             actions.append(PostExecAction.from_dict(action_data))
-        return cls(post_exec=actions)
+        config = cls(post_exec=actions)
+        errors = config.validate()
+        if errors:
+            raise ValueError("; ".join(errors))
+        return config
 
     def validate(self) -> list[str]:
         """Validate all actions."""

--- a/zima/models/pjob.py
+++ b/zima/models/pjob.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Optional
 
+from zima.models.actions import ActionsConfig
 from zima.models.base import BaseConfig, Metadata
 from zima.utils import generate_timestamp, validate_code
 
@@ -164,6 +165,7 @@ class PJobSpec:
     execution: ExecutionOptions = field(default_factory=ExecutionOptions)
     hooks: dict = field(default_factory=dict)
     output: OutputOptions = field(default_factory=OutputOptions)
+    actions: ActionsConfig = field(default_factory=ActionsConfig)
 
     def to_dict(self) -> dict:
         """Convert to dictionary."""
@@ -185,6 +187,8 @@ class PJobSpec:
             result["hooks"] = self.hooks
         if self.output.save_to or self.output.format != "raw":
             result["output"] = self.output.to_dict()
+        if self.actions.post_exec:
+            result["actions"] = self.actions.to_dict()
         return result
 
     @classmethod
@@ -200,6 +204,7 @@ class PJobSpec:
             execution=ExecutionOptions.from_dict(data.get("execution", {})),
             hooks=data.get("hooks", {}),
             output=OutputOptions.from_dict(data.get("output", {})),
+            actions=ActionsConfig.from_dict(data.get("actions", {})),
         )
 
 

--- a/zima/models/pjob.py
+++ b/zima/models/pjob.py
@@ -154,6 +154,7 @@ class PJobSpec:
         execution: Execution options
         hooks: Pre/post execution hooks
         output: Output handling options
+        actions: Post-execution actions configuration
     """
 
     agent: str = ""

--- a/zima/review/__init__.py
+++ b/zima/review/__init__.py
@@ -1,0 +1,5 @@
+"""Code review result models and parser."""
+
+from zima.review.parser import ReviewIssue, ReviewResult
+
+__all__ = ["ReviewIssue", "ReviewResult"]

--- a/zima/review/__init__.py
+++ b/zima/review/__init__.py
@@ -1,5 +1,5 @@
 """Code review result models and parser."""
 
-from zima.review.parser import ReviewIssue, ReviewResult
+from zima.review.parser import ReviewIssue, ReviewParser, ReviewResult
 
-__all__ = ["ReviewIssue", "ReviewResult"]
+__all__ = ["ReviewIssue", "ReviewParser", "ReviewResult"]

--- a/zima/review/parser.py
+++ b/zima/review/parser.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
+from xml.etree import ElementTree as ET
 
 
 @dataclass
@@ -34,3 +36,69 @@ class ReviewResult:
     verdict: str = ""  # approved, needs_fix, needs_discussion
     summary: str = ""
     issues: list[ReviewIssue] = field(default_factory=list)
+
+
+class ReviewParser:
+    """Parse structured review output from agent stdout."""
+
+    @staticmethod
+    def parse(stdout: str) -> ReviewResult:
+        """Extract <zima-review> XML block from stdout and parse into ReviewResult.
+
+        Args:
+            stdout: Raw agent output string to parse.
+
+        Returns:
+            ReviewResult with parsed verdict, summary, and issues. Returns
+            ReviewResult(verdict="needs_discussion") if no block is found
+            or the XML is invalid.
+        """
+        match = re.search(r"<zima-review>(.*?)</zima-review>", stdout, re.DOTALL)
+        if not match:
+            # Also try to match an unclosed <zima-review> tag (malformed XML)
+            unclosed_match = re.search(r"<zima-review>(.*)", stdout, re.DOTALL)
+            if unclosed_match:
+                xml_content = f"<zima-review>{unclosed_match.group(1)}</zima-review>"
+                try:
+                    root = ET.fromstring(xml_content)
+                except ET.ParseError:
+                    return ReviewResult(
+                        verdict="needs_discussion",
+                        summary="Invalid review XML format",
+                    )
+            else:
+                return ReviewResult(
+                    verdict="needs_discussion",
+                    summary="No review block found in agent output",
+                )
+        else:
+            xml_content = f"<zima-review>{match.group(1)}</zima-review>"
+            try:
+                root = ET.fromstring(xml_content)
+            except ET.ParseError:
+                return ReviewResult(
+                    verdict="needs_discussion",
+                    summary="Invalid review XML format",
+                )
+        verdict = root.findtext("verdict", default="needs_discussion").strip()
+        summary = root.findtext("summary", default="").strip()
+
+        issues = []
+        issues_elem = root.find("issues")
+        if issues_elem is not None:
+            for issue_elem in issues_elem.findall("issue"):
+                line_str = issue_elem.get("line", "")
+                try:
+                    line_num = int(line_str) if line_str else 0
+                except ValueError:
+                    line_num = 0
+                issues.append(
+                    ReviewIssue(
+                        severity=issue_elem.get("severity", "warning"),
+                        file=issue_elem.get("file", ""),
+                        line=line_num,
+                        message=(issue_elem.text or "").strip(),
+                    )
+                )
+
+        return ReviewResult(verdict=verdict, summary=summary, issues=issues)

--- a/zima/review/parser.py
+++ b/zima/review/parser.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ReviewIssue:
+    """Single review issue found in code.
+
+    Attributes:
+        severity: Issue severity level. One of "error", "warning", or "info".
+        file: Path to the file where the issue was found.
+        line: Line number in the file where the issue was found.
+        message: Human-readable description of the issue.
+    """
+
+    severity: str = "warning"  # error, warning, info
+    file: str = ""
+    line: int = 0
+    message: str = ""
+
+
+@dataclass
+class ReviewResult:
+    """Parsed result of an agent code review.
+
+    Attributes:
+        verdict: Overall review verdict. One of "approved", "needs_fix",
+            or "needs_discussion".
+        summary: High-level summary of the review findings.
+        issues: List of individual issues found during the review.
+    """
+
+    verdict: str = ""  # approved, needs_fix, needs_discussion
+    summary: str = ""
+    issues: list[ReviewIssue] = field(default_factory=list)

--- a/zima/review/parser.py
+++ b/zima/review/parser.py
@@ -1,8 +1,13 @@
+"""Code review result parser - extracts structured review output from agent stdout."""
+
 from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
 from xml.etree import ElementTree as ET
+
+# Maximum XML content size to prevent billion laughs / XML bomb attacks
+_MAX_REVIEW_XML_SIZE = 1024 * 1024  # 1 MB
 
 
 @dataclass
@@ -53,6 +58,13 @@ class ReviewParser:
             ReviewResult(verdict="needs_discussion") if no block is found
             or the XML is invalid.
         """
+        # Security: limit input size to prevent billion laughs / XML bomb
+        if len(stdout) > _MAX_REVIEW_XML_SIZE:
+            return ReviewResult(
+                verdict="needs_discussion",
+                summary="Agent output too large for review parsing",
+            )
+
         match = re.search(r"<zima-review>(.*?)</zima-review>", stdout, re.DOTALL)
         if not match:
             # Also try to match an unclosed <zima-review> tag (malformed XML)

--- a/zima/templates/examples.py
+++ b/zima/templates/examples.py
@@ -177,6 +177,50 @@ spec:
     - idle
 """
 
+REVIEWER_PJOB = """\
+apiVersion: zima.io/v1
+kind: PJob
+metadata:
+  code: reviewer
+  name: PR Reviewer
+  description: Automatically review PRs labeled zima:needs-review
+  labels:
+    - reviewer
+spec:
+  agent: kimi-standard
+  workflow: reviewer-cr
+  variable: reviewer-vars
+  actions:
+    postExec:
+      - condition: success
+        type: github_label
+        addLabels:
+          - zima:needs-fix
+        removeLabels:
+          - zima:needs-review
+        repo: "{{REPO}}"
+        issue: "{{PR_NUMBER}}"
+      - condition: failure
+        type: github_comment
+        body: "Code review execution failed. Please check logs."
+        repo: "{{REPO}}"
+        issue: "{{PR_NUMBER}}"
+"""
+
+REVIEWER_VARIABLES = """\
+apiVersion: zima.io/v1
+kind: Variable
+metadata:
+  code: reviewer-vars
+  name: Reviewer Variables
+spec:
+  values:
+    repo: ""
+    pr_number: ""
+    pr_title: ""
+    pr_diff: ""
+"""
+
 REVIEWER_WORKFLOW = """\
 apiVersion: zima.io/v1
 kind: Workflow
@@ -251,10 +295,10 @@ spec:
 EXAMPLES = {
     "agent": {"my-agent": AGENT_EXAMPLE},
     "workflow": {"my-workflow": WORKFLOW_EXAMPLE, "reviewer-cr": REVIEWER_WORKFLOW},
-    "variable": {"my-variables": VARIABLE_EXAMPLE},
+    "variable": {"my-variables": VARIABLE_EXAMPLE, "reviewer-vars": REVIEWER_VARIABLES},
     "env": {"my-env": ENV_EXAMPLE},
     "pmg": {"my-pmg": PMG_EXAMPLE},
-    "pjob": {"my-job": PJOB_EXAMPLE},
+    "pjob": {"my-job": PJOB_EXAMPLE, "reviewer": REVIEWER_PJOB},
     "schedule": {"daily-32": SCHEDULE_EXAMPLE},
 }
 

--- a/zima/templates/examples.py
+++ b/zima/templates/examples.py
@@ -177,14 +177,85 @@ spec:
     - idle
 """
 
+REVIEWER_WORKFLOW = """\
+apiVersion: zima.io/v1
+kind: Workflow
+metadata:
+  code: reviewer-cr
+  name: PR Code Review
+  description: Review a PR diff and output structured review result
+spec:
+  format: jinja2
+  template: |
+    ## 背景
+    你是一个专业的代码审查员。请审查以下 Pull Request 的代码变更。
+
+    ## PR 信息
+    - 仓库: {{repo}}
+    - PR 编号: #{{pr_number}}
+    - PR 标题: {{pr_title}}
+
+    ## 代码变更 (Diff)
+    ```diff
+    {{pr_diff}}
+    ```
+
+    ## 需求
+    1. 检查代码逻辑是否正确
+    2. 检查是否有潜在 bug
+    3. 检查代码风格和命名规范
+    4. 检查是否有安全问题
+    5. 检查测试是否充分
+
+    ## 规则
+    - 只关注代码本身，不评论作者
+    - 发现问题必须指出具体位置和原因
+    - 如果代码没问题，直接给出通过结论
+    - 输出必须使用以下 XML 格式
+
+    ## 输出格式
+    在回复的最后，必须包含以下 XML 块：
+
+    ```xml
+    <zima-review>
+      <verdict>approved|needs_fix|needs_discussion</verdict>
+      <summary>一句话总结审查结论</summary>
+      <issues>
+        <issue severity="error|warning|info" file="文件名" line="行号">问题描述</issue>
+      </issues>
+    </zima-review>
+    ```
+
+    ## 结束指标
+    - 审查完成并输出了 `<zima-review>` XML 块
+    - verdict 明确为 approved / needs_fix / needs_discussion 之一
+  variables:
+    - name: repo
+      type: string
+      required: true
+      description: Repository slug (owner/repo)
+    - name: pr_number
+      type: string
+      required: true
+      description: PR number
+    - name: pr_title
+      type: string
+      required: true
+      description: PR title
+    - name: pr_diff
+      type: string
+      required: true
+      description: PR diff content
+"""
+
 EXAMPLES = {
-    "agent": AGENT_EXAMPLE,
-    "workflow": WORKFLOW_EXAMPLE,
-    "variable": VARIABLE_EXAMPLE,
-    "env": ENV_EXAMPLE,
-    "pmg": PMG_EXAMPLE,
-    "pjob": PJOB_EXAMPLE,
-    "schedule": SCHEDULE_EXAMPLE,
+    "agent": {"my-agent": AGENT_EXAMPLE},
+    "workflow": {"my-workflow": WORKFLOW_EXAMPLE, "reviewer-cr": REVIEWER_WORKFLOW},
+    "variable": {"my-variables": VARIABLE_EXAMPLE},
+    "env": {"my-env": ENV_EXAMPLE},
+    "pmg": {"my-pmg": PMG_EXAMPLE},
+    "pjob": {"my-job": PJOB_EXAMPLE},
+    "schedule": {"daily-32": SCHEDULE_EXAMPLE},
 }
 
 VALID_KINDS = {"Agent", "Workflow", "Variable", "Env", "PMG", "PJob", "Schedule"}

--- a/zima/templates/examples.py
+++ b/zima/templates/examples.py
@@ -195,16 +195,19 @@ spec:
       - condition: success
         type: github_label
         addLabels:
+          - zima:review-approved
+        removeLabels:
+          - zima:needs-review
+        repo: "{{repo}}"
+        issue: "{{pr_number}}"
+      - condition: failure
+        type: github_label
+        addLabels:
           - zima:needs-fix
         removeLabels:
           - zima:needs-review
-        repo: "{{REPO}}"
-        issue: "{{PR_NUMBER}}"
-      - condition: failure
-        type: github_comment
-        body: "Code review execution failed. Please check logs."
-        repo: "{{REPO}}"
-        issue: "{{PR_NUMBER}}"
+        repo: "{{repo}}"
+        issue: "{{pr_number}}"
 """
 
 REVIEWER_VARIABLES = """\


### PR DESCRIPTION
## Summary

- Add `zima/review/` module with `ReviewResult`, `ReviewIssue`, and `ReviewParser` for structured code review XML output (`<zima-review>` block)
- Add `zima/github/ops.py` with `GitHubOps` wrapper for `gh` CLI (label add/remove, comment post, PR diff fetch)
- Add `zima/models/actions.py` with `PostExecAction` and `ActionsConfig` dataclasses for PJob post-execution automation
- Extend `PJobSpec` with `actions` field supporting `postExec` actions
- Add `ActionsRunner` that executes postExec actions after agent exit with condition matching (`success`/`failure`/`always`) and `{{VAR}}` env substitution
- Integrate actions execution into `PJobExecutor.execute()` after agent process exits
- Add `reviewer-cr` workflow template, `reviewer` PJob, and `reviewer-vars` variable config to examples
- Add end-to-end integration test: mock reviewer agent outputs approved review → label transition triggered

## Test Plan

- [ ] `pytest tests/unit/test_review_parser.py` — 11 passed
- [ ] `pytest tests/unit/test_github_ops.py` — 6 passed
- [ ] `pytest tests/unit/test_models_actions.py` — 14 passed
- [ ] `pytest tests/unit/test_actions_runner.py` — 12 passed
- [ ] `pytest tests/integration/test_executor_actions.py` — 3 passed
- [ ] `pytest tests/unit/test_examples.py` — 48 passed
- [ ] Full suite: `pytest tests/unit/ tests/integration/` — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)