### PR TITLE
refactor: unify camelCase/snake_case serialization across all models (#14)

### DIFF
--- a/docs/superpowers/plans/2026-04-23-issue-14-camel-snake-case-mapping.md
+++ b/docs/superpowers/plans/2026-04-23-issue-14-camel-snake-case-mapping.md
@@ -1,0 +1,935 @@
+# Issue #14: camelCase/snake_case 统一映射 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 将所有 dataclass 的 YAML 键名映射从分散硬编码改为集中声明 + 自动处理，消灭死代码。
+
+**Architecture:** 新建 `YamlSerializable` mixin + `serialize()`/`deserialize()`/`serialize_spec()`/`deserialize_spec()` 工具函数。`BaseConfig` 子类声明 `SPEC_FIELD_ALIASES` 即可，无需手写 to_dict/from_dict。嵌套类继承 `YamlSerializable` 声明 `FIELD_ALIASES`。
+
+**Tech Stack:** Python 3.10+, dataclasses, pytest
+
+---
+
+## File Structure
+
+| 文件 | 职责 |
+|------|------|
+| `zima/models/serialization.py` (new) | `YamlSerializable`, `serialize()`, `deserialize()`, `serialize_spec()`, `deserialize_spec()`, `omit_empty()`, `convert_to_camel_case()`, `convert_to_snake_case()` |
+| `zima/models/base.py` (modify) | `BaseConfig`/`Metadata` 继承 `YamlSerializable`，删除死代码 |
+| `zima/models/env.py` (modify) | `EnvConfig` 声明 `SPEC_FIELD_ALIASES` |
+| `zima/models/variable.py` (modify) | `VariableConfig` 声明 `SPEC_FIELD_ALIASES` |
+| `zima/models/pmg.py` (modify) | `PMGConfig` 声明 `SPEC_FIELD_ALIASES` |
+| `zima/models/workflow.py` (modify) | `WorkflowConfig` 声明 `SPEC_FIELD_ALIASES` |
+| `zima/models/agent.py` (modify) | `AgentConfig` 声明 `SPEC_FIELD_ALIASES` |
+| `zima/models/pjob.py` (modify) | 嵌套类继承 `YamlSerializable` + 声明别名；`PJobConfig` 声明 `SPEC_FIELD_ALIASES`；`PJobSpec` 覆盖 `to_dict` 用 `omit_empty` |
+| `zima/models/actions.py` (modify) | `PostExecAction`/`ActionsConfig` 继承 `YamlSerializable` + 声明别名；`ActionsConfig` 覆盖 `to_dict` 用 `omit_empty` |
+| `zima/models/schedule.py` (modify) | `ScheduleConfig`/`ScheduleStage`/`ScheduleCycleType` 继承/声明别名 |
+| `tests/unit/test_serialization.py` (new) | 通用序列化测试 + 所有模型 round-trip 测试 |
+| `tests/unit/test_models_base.py` (modify) | 删除 `test_convert_to_*` 测试 |
+
+---
+
+## Task 1: serialization.py 核心模块
+
+**Files:**
+- Create: `zima/models/serialization.py`
+- Test: `tests/unit/test_serialization.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Write `tests/unit/test_serialization.py`:
+
+```python
+"""Tests for generic YAML serialization utilities."""
+
+import pytest
+from dataclasses import dataclass, field
+
+from zima.models.serialization import (
+    YamlSerializable,
+    serialize,
+    deserialize,
+    omit_empty,
+    convert_to_camel_case,
+    convert_to_snake_case,
+)
+
+
+class TestConvertFunctions:
+    def test_camel_case(self):
+        assert convert_to_camel_case("snake_case") == "snakeCase"
+        assert convert_to_camel_case("my_var_name") == "myVarName"
+        assert convert_to_camel_case("simple") == "simple"
+
+    def test_snake_case(self):
+        assert convert_to_snake_case("camelCase") == "camel_case"
+        assert convert_to_snake_case("myVarName") == "my_var_name"
+        assert convert_to_snake_case("simple") == "simple"
+
+
+class TestSerialize:
+    def test_basic(self):
+        @dataclass
+        class Demo(YamlSerializable):
+            FIELD_ALIASES = {"my_field": "myField"}
+            my_field: str = ""
+            other_field: int = 0
+
+        obj = Demo(my_field="hello", other_field=42)
+        assert obj.to_dict() == {"myField": "hello", "otherField": 42}
+
+    def test_nested_dataclass(self):
+        @dataclass
+        class Inner(YamlSerializable):
+            value: str = ""
+
+        @dataclass
+        class Outer(YamlSerializable):
+            inner: Inner = field(default_factory=Inner)
+
+        obj = Outer(inner=Inner(value="x"))
+        assert obj.to_dict() == {"inner": {"value": "x"}}
+
+    def test_list_of_dataclasses(self):
+        @dataclass
+        class Item(YamlSerializable):
+            name: str = ""
+
+        @dataclass
+        class Container(YamlSerializable):
+            items: list = field(default_factory=list)
+
+        obj = Container(items=[Item(name="a"), Item(name="b")])
+        assert obj.to_dict() == {"items": [{"name": "a"}, {"name": "b"}]}
+
+
+class TestDeserialize:
+    def test_basic(self):
+        @dataclass
+        class Demo(YamlSerializable):
+            FIELD_ALIASES = {"my_field": "myField"}
+            my_field: str = ""
+            other_field: int = 0
+
+        obj = Demo.from_dict({"myField": "hello", "otherField": 42})
+        assert obj.my_field == "hello"
+        assert obj.other_field == 42
+
+    def test_nested(self):
+        @dataclass
+        class Inner(YamlSerializable):
+            value: str = ""
+
+        @dataclass
+        class Outer(YamlSerializable):
+            inner: Inner = field(default_factory=Inner)
+
+        obj = Outer.from_dict({"inner": {"value": "x"}})
+        assert obj.inner.value == "x"
+
+    def test_defaults_on_missing(self):
+        @dataclass
+        class Demo(YamlSerializable):
+            name: str = ""
+            count: int = 5
+
+        obj = Demo.from_dict({})
+        assert obj.name == ""
+        assert obj.count == 5
+
+
+class TestOmitEmpty:
+    def test_filters_none_empty(self):
+        data = {"a": "hello", "b": None, "c": "", "d": [], "e": {}}
+        assert omit_empty(data) == {"a": "hello"}
+
+    def test_keeps_false_and_zero(self):
+        assert omit_empty({"flag": False, "count": 0}) == {"flag": False, "count": 0}
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+```bash
+pytest tests/unit/test_serialization.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'zima.models.serialization'`
+
+- [ ] **Step 3: Write serialization.py**
+
+Create `zima/models/serialization.py`:
+
+```python
+"""Generic YAML serialization utilities for dataclasses."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import MISSING, fields, is_dataclass
+from typing import Union, get_args, get_origin
+
+
+def convert_to_camel_case(snake_str: str) -> str:
+    """Convert snake_case to camelCase."""
+    components = snake_str.split("_")
+    return components[0] + "".join(x.capitalize() for x in components[1:])
+
+
+def convert_to_snake_case(camel_str: str) -> str:
+    """Convert camelCase to snake_case."""
+    s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", camel_str)
+    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+
+def _unwrap_optional(t):
+    """Unwrap Optional[T] or T | None."""
+    origin = get_origin(t)
+    if origin is not None:
+        args = get_args(t)
+        if origin is Union and len(args) == 2 and type(None) in args:
+            return args[0] if args[1] is type(None) else args[1]
+    return t
+
+
+def _is_list_of_dataclasses(t):
+    """Check if type is list[T] where T is a dataclass."""
+    origin = get_origin(t)
+    if origin is list:
+        args = get_args(t)
+        return bool(args and is_dataclass(args[0]))
+    return False
+
+
+def _get_item_type_from_list(t):
+    """Get T from list[T]."""
+    args = get_args(t)
+    return args[0] if args else None
+
+
+BASE_CONFIG_FIELDS = {"api_version", "kind", "metadata", "created_at", "updated_at"}
+
+
+class YamlSerializable:
+    """Mixin for dataclasses that support YAML serialization."""
+
+    FIELD_ALIASES: dict[str, str] = {}
+
+    def to_dict(self) -> dict:
+        return serialize(self, self.FIELD_ALIASES)
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        return deserialize(cls, data, cls.FIELD_ALIASES)
+
+
+def serialize(obj, aliases: dict[str, str] | None = None) -> dict:
+    """Serialize a dataclass instance to a dictionary."""
+    if not is_dataclass(obj):
+        raise TypeError(f"Expected dataclass instance, got {type(obj)}")
+
+    result = {}
+    aliases = aliases or {}
+
+    for f in fields(obj):
+        value = getattr(obj, f.name)
+        yaml_key = aliases.get(f.name, convert_to_camel_case(f.name))
+        if is_dataclass(value):
+            result[yaml_key] = value.to_dict()
+        elif isinstance(value, list):
+            result[yaml_key] = [
+                item.to_dict() if is_dataclass(item) else item for item in value
+            ]
+        else:
+            result[yaml_key] = value
+
+    return result
+
+
+def deserialize(cls, data: dict, aliases: dict[str, str] | None = None):
+    """Deserialize a dictionary into a dataclass instance."""
+    if not is_dataclass(cls):
+        raise TypeError(f"Expected dataclass type, got {type(cls)}")
+
+    aliases = aliases or {}
+    kwargs = {}
+    for f in fields(cls):
+        yaml_key = aliases.get(f.name, convert_to_camel_case(f.name))
+        value = data.get(yaml_key)
+
+        if value is None:
+            if f.default is not MISSING:
+                kwargs[f.name] = f.default
+            elif f.default_factory is not MISSING:
+                kwargs[f.name] = f.default_factory()
+            else:
+                kwargs[f.name] = None
+            continue
+
+        field_type = _unwrap_optional(f.type)
+        if is_dataclass(field_type):
+            kwargs[f.name] = field_type.from_dict(value)
+        elif _is_list_of_dataclasses(field_type):
+            item_cls = _get_item_type_from_list(field_type)
+            kwargs[f.name] = [item_cls.from_dict(item) for item in value]
+        else:
+            kwargs[f.name] = value
+
+    return cls(**kwargs)
+
+
+def serialize_spec(obj, aliases: dict[str, str] | None = None) -> dict:
+    """Serialize non-base fields into a spec dict (for BaseConfig subclasses)."""
+    if not is_dataclass(obj):
+        raise TypeError(f"Expected dataclass instance, got {type(obj)}")
+
+    result = {}
+    aliases = aliases or {}
+    for f in fields(obj):
+        if f.name in BASE_CONFIG_FIELDS:
+            continue
+        value = getattr(obj, f.name)
+        yaml_key = aliases.get(f.name, convert_to_camel_case(f.name))
+        if is_dataclass(value):
+            result[yaml_key] = value.to_dict()
+        elif isinstance(value, list):
+            result[yaml_key] = [
+                item.to_dict() if is_dataclass(item) else item for item in value
+            ]
+        else:
+            result[yaml_key] = value
+
+    return result
+
+
+def deserialize_spec(cls, spec_data: dict, aliases: dict[str, str] | None = None) -> dict:
+    """Deserialize spec fields from a dict into kwargs (for BaseConfig subclasses)."""
+    if not is_dataclass(cls):
+        raise TypeError(f"Expected dataclass type, got {type(cls)}")
+
+    aliases = aliases or {}
+    kwargs = {}
+    for f in fields(cls):
+        if f.name in BASE_CONFIG_FIELDS:
+            continue
+        yaml_key = aliases.get(f.name, convert_to_camel_case(f.name))
+        value = spec_data.get(yaml_key)
+
+        if value is None:
+            if f.default is not MISSING:
+                kwargs[f.name] = f.default
+            elif f.default_factory is not MISSING:
+                kwargs[f.name] = f.default_factory()
+            else:
+                kwargs[f.name] = None
+            continue
+
+        field_type = _unwrap_optional(f.type)
+        if is_dataclass(field_type):
+            kwargs[f.name] = field_type.from_dict(value)
+        elif _is_list_of_dataclasses(field_type):
+            item_cls = _get_item_type_from_list(field_type)
+            kwargs[f.name] = [item_cls.from_dict(item) for item in value]
+        else:
+            kwargs[f.name] = value
+
+    return kwargs
+
+
+def omit_empty(data: dict) -> dict:
+    """Remove entries whose value is None, empty string, empty list, or empty dict."""
+    return {k: v for k, v in data.items() if v not in (None, "", [], {})}
+```
+
+- [ ] **Step 4: Run test — expect PASS**
+
+```bash
+pytest tests/unit/test_serialization.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add zima/models/serialization.py tests/unit/test_serialization.py
+git commit -m "feat: add YamlSerializable mixin and generic serialize/deserialize utilities (#14)"
+```
+
+---
+
+## Task 2: base.py 重构
+
+**Files:**
+- Modify: `zima/models/base.py`
+- Modify: `tests/unit/test_models_base.py`
+
+- [ ] **Step 1: Update base.py**
+
+Replace imports at top:
+```python
+from zima.models.serialization import YamlSerializable
+```
+
+Replace `Metadata`:
+```python
+@dataclass
+class Metadata(YamlSerializable):
+    code: str = ""
+    name: str = ""
+    description: str = ""
+
+    def to_dict(self) -> dict:
+        return {"code": self.code, "name": self.name, "description": self.description}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Metadata:
+        return cls(
+            code=data.get("code", ""),
+            name=data.get("name", ""),
+            description=data.get("description", ""),
+        )
+```
+
+Replace `BaseConfig`:
+```python
+@dataclass
+class BaseConfig(YamlSerializable):
+    FIELD_ALIASES = {
+        "api_version": "apiVersion",
+        "created_at": "createdAt",
+        "updated_at": "updatedAt",
+    }
+
+    api_version: str = "zima.io/v1"
+    kind: str = ""
+    metadata: Metadata = field(default_factory=Metadata)
+    created_at: str = ""
+    updated_at: str = ""
+
+    def __post_init__(self):
+        if not self.created_at:
+            self.created_at = generate_timestamp()
+        if not self.updated_at:
+            self.updated_at = self.created_at
+
+    def to_dict(self) -> dict:
+        from zima.models.serialization import serialize_spec
+        result = super().to_dict()
+        result["spec"] = serialize_spec(self, getattr(self, "SPEC_FIELD_ALIASES", None))
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        from zima.models.serialization import deserialize_spec
+        spec_data = data.get("spec", {})
+        kwargs = {
+            "api_version": data.get("apiVersion", "zima.io/v1"),
+            "kind": data.get("kind", ""),
+            "metadata": Metadata.from_dict(data.get("metadata", {})),
+            "created_at": data.get("createdAt", ""),
+            "updated_at": data.get("updatedAt", ""),
+        }
+        kwargs.update(deserialize_spec(cls, spec_data, getattr(cls, "SPEC_FIELD_ALIASES", None)))
+        return cls(**kwargs)
+```
+
+Delete `convert_to_camel_case()` and `convert_to_snake_case()` at bottom of file.
+
+- [ ] **Step 2: Remove old tests**
+
+In `tests/unit/test_models_base.py`, delete `test_convert_to_camel_case` and `test_convert_to_snake_case`.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+pytest tests/unit/test_models_base.py -v
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add zima/models/base.py tests/unit/test_models_base.py
+git commit -m "refactor: BaseConfig and Metadata use YamlSerializable with auto spec mapping (#14)"
+```
+
+---
+
+## Task 3: 简单模型迁移
+
+**Files:** Modify `env.py`, `variable.py`, `pmg.py`, `workflow.py`, `agent.py`
+
+对每个文件，做以下操作：
+
+1. 在类定义中添加 `SPEC_FIELD_ALIASES`
+2. 删除手动 `to_dict()` 和 `from_dict()` 方法（保留 `from_yaml_file`）
+3. 保留 `create()` 工厂方法不变
+4. 保留所有业务方法不变
+
+- [ ] **Step 1: env.py — EnvConfig**
+
+```python
+class EnvConfig(BaseConfig):
+    SPEC_FIELD_ALIASES = {
+        "for_type": "forType",
+        "override_existing": "overrideExisting",
+    }
+    # ... existing fields ...
+```
+
+Delete `to_dict()` and `from_dict()` methods.
+
+- [ ] **Step 2: variable.py — VariableConfig**
+
+```python
+class VariableConfig(BaseConfig):
+    SPEC_FIELD_ALIASES = {
+        "for_workflow": "forWorkflow",
+    }
+```
+
+Delete `to_dict()` and `from_dict()`.
+
+- [ ] **Step 3: pmg.py — PMGConfig**
+
+```python
+class PMGConfig(BaseConfig):
+    SPEC_FIELD_ALIASES = {
+        "for_types": "forTypes",
+    }
+```
+
+Delete `to_dict()` and `from_dict()`.
+
+- [ ] **Step 4: workflow.py — WorkflowConfig**
+
+```python
+class WorkflowConfig(BaseConfig):
+    SPEC_FIELD_ALIASES = {}
+```
+
+Delete `to_dict()` and `from_dict()`.
+
+- [ ] **Step 5: agent.py — AgentConfig**
+
+```python
+class AgentConfig(BaseConfig):
+    SPEC_FIELD_ALIASES = {}
+```
+
+Delete `to_dict()` and `from_dict()`.
+
+- [ ] **Step 6: Run all model tests**
+
+```bash
+pytest tests/unit/test_models_env.py tests/unit/test_models_variable.py tests/unit/test_models_pmg.py tests/unit/test_models_workflow.py tests/unit/test_models_agent.py -v
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add zima/models/env.py zima/models/variable.py zima/models/pmg.py zima/models/workflow.py zima/models/agent.py
+git commit -m "refactor: migrate Env/Variable/PMG/Workflow/Agent configs to auto spec mapping (#14)"
+```
+
+---
+
+## Task 4: PJob 嵌套类迁移
+
+**Files:** Modify `zima/models/pjob.py`
+
+- [ ] **Step 1: ExecutionOptions**
+
+Add `YamlSerializable` import and inheritance:
+
+```python
+from zima.models.serialization import YamlSerializable, omit_empty
+
+@dataclass
+class ExecutionOptions(YamlSerializable):
+    FIELD_ALIASES = {
+        "work_dir": "workDir",
+        "keep_temp": "keepTemp",
+        "async_": "async",
+    }
+    # existing fields unchanged
+```
+
+Delete `to_dict()` and `from_dict()`.
+
+- [ ] **Step 2: OutputOptions**
+
+```python
+@dataclass
+class OutputOptions(YamlSerializable):
+    FIELD_ALIASES = {"save_to": "saveTo"}
+    # existing fields unchanged
+```
+
+Delete `to_dict()` and `from_dict()`.
+
+- [ ] **Step 3: Overrides**
+
+```python
+@dataclass
+class Overrides(YamlSerializable):
+    FIELD_ALIASES = {
+        "agent_params": "agentParams",
+        "variable_values": "variableValues",
+        "env_vars": "envVars",
+        "pmg_params": "pmgParams",
+    }
+    # existing fields unchanged
+```
+
+Delete `to_dict()` and `from_dict()`.
+
+- [ ] **Step 4: PJobSpec — 条件输出**
+
+```python
+@dataclass
+class PJobSpec(YamlSerializable):
+    # no FIELD_ALIASES needed (field names match)
+    # existing fields unchanged
+
+    def to_dict(self) -> dict:
+        return omit_empty(super().to_dict())
+```
+
+Delete old `to_dict()` and `from_dict()`.
+
+- [ ] **Step 5: PJobMetadata**
+
+```python
+@dataclass
+class PJobMetadata(Metadata):
+    # inherits YamlSerializable from Metadata
+    labels: list[str] = field(default_factory=list)
+    annotations: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        result = super().to_dict()
+        if self.labels:
+            result["labels"] = self.labels
+        if self.annotations:
+            result["annotations"] = self.annotations
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict) -> PJobMetadata:
+        return cls(
+            code=data.get("code", ""),
+            name=data.get("name", ""),
+            description=data.get("description", ""),
+            labels=data.get("labels", []),
+            annotations=data.get("annotations", {}),
+        )
+```
+
+- [ ] **Step 6: PJobConfig**
+
+```python
+class PJobConfig(BaseConfig):
+    SPEC_FIELD_ALIASES = {}
+    # existing fields unchanged
+```
+
+Delete `to_dict()` and `from_dict()` (the generic BaseConfig ones handle metadata + spec).
+
+Wait — `PJobConfig` currently uses `PJobMetadata` not `Metadata`. The generic `BaseConfig.from_dict()` does `Metadata.from_dict(...)`. We need `PJobMetadata.from_dict(...)`.
+
+Override in PJobConfig:
+
+```python
+    @classmethod
+    def from_dict(cls, data: dict) -> PJobConfig:
+        from zima.models.serialization import deserialize_spec
+        spec_data = data.get("spec", {})
+        kwargs = {
+            "api_version": data.get("apiVersion", "zima.io/v1"),
+            "kind": data.get("kind", "PJob"),
+            "metadata": PJobMetadata.from_dict(data.get("metadata", {})),
+            "created_at": data.get("createdAt", ""),
+            "updated_at": data.get("updatedAt", ""),
+        }
+        kwargs.update(deserialize_spec(cls, spec_data, getattr(cls, "SPEC_FIELD_ALIASES", None)))
+        return cls(**kwargs)
+```
+
+- [ ] **Step 7: Run pjob tests**
+
+```bash
+pytest tests/unit/test_models_pjob.py -v
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add zima/models/pjob.py
+git commit -m "refactor: migrate PJob nested classes to YamlSerializable with auto mapping (#14)"
+```
+
+---
+
+## Task 5: ActionsConfig + PostExecAction 迁移
+
+**Files:** Modify `zima/models/actions.py`
+
+- [ ] **Step 1: PostExecAction**
+
+```python
+from zima.models.serialization import YamlSerializable, omit_empty
+
+@dataclass
+class PostExecAction(YamlSerializable):
+    FIELD_ALIASES = {
+        "add_labels": "addLabels",
+        "remove_labels": "removeLabels",
+    }
+    # existing fields unchanged
+
+    def to_dict(self) -> dict:
+        return omit_empty(super().to_dict())
+```
+
+Delete old `to_dict()` and `from_dict()`.
+
+- [ ] **Step 2: ActionsConfig**
+
+```python
+@dataclass
+class ActionsConfig(YamlSerializable):
+    FIELD_ALIASES = {"post_exec": "postExec"}
+    # existing fields unchanged
+
+    def to_dict(self) -> dict:
+        return omit_empty(super().to_dict())
+```
+
+Delete old `to_dict()` and `from_dict()`.
+
+- [ ] **Step 3: Run actions tests**
+
+```bash
+pytest tests/unit/test_models_actions.py -v
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add zima/models/actions.py
+git commit -m "refactor: migrate Actions models to YamlSerializable with auto mapping (#14)"
+```
+
+---
+
+## Task 6: Schedule 模型迁移
+
+**Files:** Modify `zima/models/schedule.py`
+
+- [ ] **Step 1: ScheduleStage**
+
+```python
+from zima.models.serialization import YamlSerializable
+
+@dataclass
+class ScheduleStage(YamlSerializable):
+    FIELD_ALIASES = {
+        "offset_minutes": "offsetMinutes",
+        "duration_minutes": "durationMinutes",
+    }
+    # existing fields unchanged
+```
+
+Delete `to_dict()` and `from_dict()`.
+
+- [ ] **Step 2: ScheduleCycleType**
+
+```python
+@dataclass
+class ScheduleCycleType(YamlSerializable):
+    FIELD_ALIASES = {"type_id": "typeId"}
+    # existing fields unchanged
+```
+
+Delete `to_dict()` and `from_dict()`.
+
+- [ ] **Step 3: ScheduleConfig**
+
+```python
+class ScheduleConfig(BaseConfig):
+    SPEC_FIELD_ALIASES = {
+        "cycle_minutes": "cycleMinutes",
+        "daily_cycles": "dailyCycles",
+        "cycle_types": "cycleTypes",
+        "cycle_mapping": "cycleMapping",
+    }
+    # existing fields unchanged
+```
+
+Delete `to_dict()` and `from_dict()`.
+
+- [ ] **Step 4: Run schedule tests**
+
+```bash
+pytest tests/unit/test_models_schedule.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add zima/models/schedule.py
+git commit -m "refactor: migrate Schedule models to YamlSerializable with auto mapping (#14)"
+```
+
+---
+
+## Task 7: 全面 round-trip 测试
+
+**Files:**
+- Modify: `tests/unit/test_serialization.py`
+- Test: all model test files
+
+- [ ] **Step 1: Add round-trip tests**
+
+Append to `tests/unit/test_serialization.py`:
+
+```python
+class TestRoundTrip:
+    """Round-trip tests: from_dict(to_dict(obj)) == obj for all model classes."""
+
+    def test_metadata(self):
+        from zima.models.base import Metadata
+        original = Metadata(code="test", name="Test", description="desc")
+        restored = Metadata.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_agent_config(self):
+        from zima.models.agent import AgentConfig
+        original = AgentConfig.create("test", "Test", agent_type="claude")
+        restored = AgentConfig.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_env_config(self):
+        from zima.models.env import EnvConfig
+        original = EnvConfig.create("test", "Test", for_type="kimi", override_existing=True)
+        restored = EnvConfig.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_variable_config(self):
+        from zima.models.variable import VariableConfig
+        original = VariableConfig.create("test", "Test", for_workflow="wf1", values={"k": "v"})
+        restored = VariableConfig.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_pmg_config(self):
+        from zima.models.pmg import PMGConfig
+        original = PMGConfig.create("test", "Test", for_types=["kimi"])
+        restored = PMGConfig.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_workflow_config(self):
+        from zima.models.workflow import WorkflowConfig
+        original = WorkflowConfig.create("test", "Test", template="Hello")
+        restored = WorkflowConfig.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_pjob_config(self):
+        from zima.models.pjob import PJobConfig
+        original = PJobConfig.create("test", "Test", agent="a1", workflow="w1")
+        restored = PJobConfig.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_pjob_with_overrides(self):
+        from zima.models.pjob import PJobConfig, Overrides, ExecutionOptions
+        original = PJobConfig.create(
+            "test", "Test", agent="a1", workflow="w1",
+            overrides={"agentParams": {"model": "sonnet"}},
+            execution={"workDir": "/tmp", "timeout": 60},
+        )
+        restored = PJobConfig.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_actions_config(self):
+        from zima.models.actions import ActionsConfig, PostExecAction
+        original = ActionsConfig(post_exec=[
+            PostExecAction(condition="success", type="github_label", repo="o/r", add_labels=["done"])
+        ])
+        restored = ActionsConfig.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_schedule_config(self):
+        from zima.models.schedule import ScheduleConfig
+        original = ScheduleConfig.create("test", "Test")
+        restored = ScheduleConfig.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_special_alias_async(self):
+        from zima.models.pjob import ExecutionOptions
+        original = ExecutionOptions(work_dir="/tmp", async_=True)
+        data = original.to_dict()
+        assert "async" in data
+        assert "async_" not in data
+        restored = ExecutionOptions.from_dict(data)
+        assert restored.async_ is True
+```
+
+- [ ] **Step 2: Run all tests**
+
+```bash
+pytest tests/unit/ -v --tb=short
+```
+
+Expected: ALL PASS
+
+- [ ] **Step 3: Run lint and format**
+
+```bash
+black zima/ tests/ --line-length 100
+ruff check zima/ tests/
+```
+
+Fix any issues.
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+pytest --cov=zima --cov-fail-under=60
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/test_serialization.py
+git commit -m "test: add round-trip tests for all models with auto serialization (#14)"
+```
+
+---
+
+## Self-Review Checklist
+
+After completing all tasks, verify:
+
+- [ ] `convert_to_camel_case` / `convert_to_snake_case` deleted from `base.py`
+- [ ] All model `to_dict` / `from_dict` methods either deleted or use `YamlSerializable`
+- [ ] No hardcoded camelCase strings remain in model files (except template/examples)
+- [ ] All round-trip tests pass
+- [ ] Coverage ≥ 60%
+- [ ] No ruff errors
+- [ ] Black formatting applied
+
+## Spec Coverage Check
+
+| Spec Section | Implementing Task |
+|--------------|-------------------|
+| YamlSerializable mixin | Task 1 |
+| serialize() / deserialize() | Task 1 |
+| serialize_spec() / deserialize_spec() | Task 1 |
+| omit_empty() | Task 1 |
+| BaseConfig + Metadata | Task 2 |
+| EnvConfig / VariableConfig / PMGConfig | Task 3 |
+| WorkflowConfig / AgentConfig | Task 3 |
+| ExecutionOptions / OutputOptions / Overrides | Task 4 |
+| PJobSpec (omit_empty) | Task 4 |
+| PJobMetadata / PJobConfig | Task 4 |
+| PostExecAction / ActionsConfig (omit_empty) | Task 5 |
+| ScheduleStage / ScheduleCycleType / ScheduleConfig | Task 6 |
+| Round-trip tests | Task 7 |
+| Delete dead code | Tasks 1-2 |

--- a/docs/superpowers/specs/2026-04-23-issue-14-camel-snake-case-mapping-design.md
+++ b/docs/superpowers/specs/2026-04-23-issue-14-camel-snake-case-mapping-design.md
@@ -1,0 +1,202 @@
+# Issue #14: 配置字段 camelCase/snake_case 统一映射 — 设计方案
+
+## 背景
+
+当前代码中，YAML 配置使用 camelCase（如 `apiVersion`、`workDir`、`saveTo`），Python dataclass 模型使用 snake_case（如 `api_version`、`work_dir`、`save_to`）。每个模型在 `to_dict()`/`from_dict()` 中手动维护键名映射，共涉及约 25 处分散在 8 个文件中的硬编码。
+
+`base.py` 中已实现的 `convert_to_camel_case()` / `convert_to_snake_case()` 从未被调用，属于死代码。
+
+## 目标
+
+1. 将所有 dataclass（顶层模型 + 嵌套类）的键名映射从分散硬编码改为**集中声明 + 自动处理**
+2. 激活 `convert_to_camel_case()` / `convert_to_snake_case()`，消灭死代码
+3. 保证 round-trip 一致性：`from_dict(to_dict(obj)) == obj`
+4. 不破坏现有 YAML 输出格式（键名、结构不变）
+
+## 架构
+
+### 新建模块：`zima/models/serialization.py`
+
+提供通用序列化/反序列化 API，所有 dataclass 复用。
+
+```python
+# 核心 API
+serialize(obj, aliases=None) -> dict
+deserialize(cls, data, aliases=None) -> T
+omit_empty(data: dict) -> dict
+```
+
+### `YamlSerializable` mixin
+
+所有需要 YAML 序列化的 dataclass（包括不继承 `BaseConfig` 的嵌套类）统一使用此 mixin：
+
+```python
+class YamlSerializable:
+    FIELD_ALIASES: dict[str, str] = {}
+
+    def to_dict(self) -> dict:
+        return serialize(self, self.FIELD_ALIASES)
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        return deserialize(cls, data, cls.FIELD_ALIASES)
+```
+
+### `BaseConfig` 增强
+
+```python
+class BaseConfig(YamlSerializable):
+    FIELD_ALIASES = {
+        "api_version": "apiVersion",
+        "created_at": "createdAt",
+        "updated_at": "updatedAt",
+    }
+```
+
+`Metadata` 也继承 `YamlSerializable`（字段名一致，`FIELD_ALIASES` 为空）：
+
+```python
+@dataclass
+class Metadata(YamlSerializable):
+    code: str = ""
+    name: str = ""
+    description: str = ""
+```
+
+### 嵌套对象自动递归
+
+`serialize()` 自动检测字段类型：
+- 字段值是 dataclass → 递归调用 `value.to_dict()`
+- 字段值是 `list[dataclass]` → 递归序列化每个元素
+- 普通字段 → 直接取值
+
+`deserialize()` 自动检测字段类型注解：
+- 字段类型是 dataclass → 递归调用 `cls.from_dict(value)`
+- 字段类型是 `list[T]` 且 T 是 dataclass → 递归反序列化
+- 普通字段 → 直接取值
+
+### 条件输出处理
+
+默认序列化输出所有字段。需要条件输出（空值 omit）的类覆盖 `to_dict()`：
+
+```python
+def to_dict(self) -> dict:
+    return omit_empty(serialize(self, self.FIELD_ALIASES))
+```
+
+需要覆盖的类共 3 个：
+- `PJobSpec` — `overrides`/`execution`/`hooks`/`output`/`actions` 空时 omit
+- `PostExecAction` — `body`/`repo`/`issue`/`addLabels`/`removeLabels` 空时 omit
+- `ActionsConfig` — `postExec` 空时 omit
+
+其余所有类使用默认 `BaseConfig.to_dict()`。
+
+## 各模型 FIELD_ALIASES 映射表
+
+### 继承 BaseConfig 的顶层模型
+
+| 类 | 额外映射 |
+|----|----------|
+| `EnvConfig` | `for_type` → `forType`, `override_existing` → `overrideExisting` |
+| `PMGConfig` | `for_types` → `forTypes` |
+| `VariableConfig` | `for_workflow` → `forWorkflow` |
+| `WorkflowConfig` | 无（字段名一致） |
+| `ScheduleConfig` | `cycle_minutes` → `cycleMinutes`, `daily_cycles` → `dailyCycles`, `cycle_types` → `cycleTypes`, `cycle_mapping` → `cycleMapping` |
+| `PJobConfig` | 无（映射在嵌套类中） |
+| `AgentConfig` | 无（字段名一致） |
+
+### 不继承 BaseConfig 的嵌套模型（均继承 YamlSerializable）
+
+| 类 | 映射 |
+|----|------|
+| `ExecutionOptions` | `work_dir` → `workDir`, `keep_temp` → `keepTemp`, `async_` → `async` |
+| `OutputOptions` | `save_to` → `saveTo` |
+| `Overrides` | `agent_params` → `agentParams`, `variable_values` → `variableValues`, `env_vars` → `envVars`, `pmg_params` → `pmgParams` |
+| `PostExecAction` | `add_labels` → `addLabels`, `remove_labels` → `removeLabels` |
+| `ActionsConfig` | `post_exec` → `postExec` |
+| `ScheduleStage` | `offset_minutes` → `offsetMinutes`, `duration_minutes` → `durationMinutes` |
+| `ScheduleCycleType` | `type_id` → `typeId` |
+| `PJobMetadata` | 无（继承 Metadata，labels/annotations 无映射） |
+| `PJobSpec` | 无（字段名一致） |
+| `Metadata` | 无（字段名一致） |
+
+### 映射统计
+
+- **显式声明**（`FIELD_ALIASES`）：23 个映射
+- **特殊映射**（非简单 snake→camel）：1 个（`async_` → `async`）
+- **自动推断**（`snake_to_camel` 自动处理）：约 30+ 个字段无需声明
+
+## 删除的代码
+
+### 死代码删除
+
+- `base.py` 中的 `convert_to_camel_case()` / `convert_to_snake_case()` 函数 → 迁移到 `serialization.py`
+- 各模型文件中约 500 行手动 `to_dict()`/`from_dict()` 映射代码 → 替换为 `FIELD_ALIASES` 声明 + 调用 `serialize()`/`deserialize()`
+
+### 测试迁移
+
+- `tests/unit/test_models_base.py` 中的 `test_convert_to_camel_case` / `test_convert_to_snake_case` → 迁移到 `tests/unit/test_serialization.py`
+- 删除模型文件中的孤立测试（如果有）
+
+## 测试策略
+
+### 新测试文件：`tests/unit/test_serialization.py`
+
+| 测试 | 内容 |
+|------|------|
+| `test_serialize_basic` | 基本序列化：键名自动转换 + 别名覆盖 |
+| `test_deserialize_basic` | 基本反序列化：键名反向映射 + 默认值填充 |
+| `test_serialize_nested` | 嵌套对象递归序列化 |
+| `test_deserialize_nested` | 嵌套对象递归反序列化 |
+| `test_omit_empty` | 空值过滤功能 |
+| `test_round_trip_all_models` | 所有模型类的 `from_dict(to_dict(obj)) == obj` |
+| `test_special_alias_async` | `async_` → `async` 特殊映射 |
+
+### round-trip 覆盖的模型
+
+- `BaseConfig`
+- `Metadata` / `PJobMetadata`
+- `AgentConfig`
+- `EnvConfig`
+- `VariableConfig`
+- `PMGConfig`
+- `WorkflowConfig`
+- `PJobConfig`（含所有嵌套对象）
+- `ActionsConfig` / `PostExecAction`
+- `ScheduleConfig`（含 `ScheduleStage`、`ScheduleCycleType`）
+
+## 向后兼容
+
+当前 Zima 仅作者个人使用且尚未正式启用，不强制要求 YAML 输出格式完全一致。设计保证：
+
+- **键名完全一致**：所有 YAML 键名与当前手动映射相同
+- **条件输出差异**：此前部分字段（如 `labels`、`annotations`、`description`）在空值时被 omit，现在会显式写出空值。这不影响反序列化（`from_dict` 会正确处理默认值）
+- **现有 YAML 可读**：`~/.zima/configs/` 下的现有文件正常读取
+
+若未来需要恢复严格的条件输出，可扩展 `omit_empty` 的字段白名单机制。
+
+## 风险与缓解
+
+| 风险 | 缓解措施 |
+|------|----------|
+| 自动序列化引入嵌套递归 bug | 所有模型类均有 round-trip 测试覆盖 |
+| 条件输出覆盖遗漏导致 YAML 膨胀 | 仅 3 个类使用 `omit_empty`，范围可控 |
+| `convert_to_camel_case` 边缘 case（如连续大写） | 保留现有实现，行为不变；补充单元测试 |
+| `__post_init__` 与自动反序列化冲突 | `deserialize()` 通过 `cls(**kwargs)` 构造，触发 `__post_init__`；验证 timestamp 行为正确 |
+
+## 文件变更清单
+
+### 新增
+- `zima/models/serialization.py` — 通用序列化模块
+- `tests/unit/test_serialization.py` — 序列化单元测试
+
+### 修改
+- `zima/models/base.py` — `BaseConfig` 增强，删除死代码
+- `zima/models/env.py` — `EnvConfig` 添加 `FIELD_ALIASES`
+- `zima/models/pmg.py` — `PMGConfig` 添加 `FIELD_ALIASES`
+- `zima/models/variable.py` — `VariableConfig` 添加 `FIELD_ALIASES`
+- `zima/models/workflow.py` — `WorkflowConfig` 使用默认序列化
+- `zima/models/pjob.py` — `ExecutionOptions`/`OutputOptions`/`Overrides`/`PJobSpec` 添加映射
+- `zima/models/actions.py` — `PostExecAction`/`ActionsConfig` 添加映射
+- `zima/models/schedule.py` — `ScheduleConfig`/`ScheduleStage`/`ScheduleCycleType` 添加映射
+- `tests/unit/test_models_base.py` — 迁移 `convert_to_*` 测试

--- a/tests/unit/test_models_base.py
+++ b/tests/unit/test_models_base.py
@@ -250,23 +250,3 @@ class TestBaseConfigInheritance:
         assert result["kind"] == "Custom"
         assert result["metadata"]["code"] == "test"
         # Note: custom_field won't be in result unless we override to_dict
-
-
-class TestHelperFunctions:
-    """Test helper functions in base module."""
-
-    def test_convert_to_camel_case(self):
-        """Test snake_case to camelCase conversion."""
-        from zima.models.base import convert_to_camel_case
-
-        assert convert_to_camel_case("snake_case") == "snakeCase"
-        assert convert_to_camel_case("my_var_name") == "myVarName"
-        assert convert_to_camel_case("simple") == "simple"
-
-    def test_convert_to_snake_case(self):
-        """Test camelCase to snake_case conversion."""
-        from zima.models.base import convert_to_snake_case
-
-        assert convert_to_snake_case("camelCase") == "camel_case"
-        assert convert_to_snake_case("myVarName") == "my_var_name"
-        assert convert_to_snake_case("simple") == "simple"

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -1,0 +1,230 @@
+"""Unit tests for serialization utilities."""
+
+from dataclasses import dataclass, field
+
+from zima.models.serialization import (
+    YamlSerializable,
+    convert_to_camel_case,
+    convert_to_snake_case,
+    deserialize_spec,
+    omit_empty,
+    serialize_spec,
+)
+
+
+class TestConvertFunctions:
+    """Test case conversion helpers."""
+
+    def test_camel_case(self):
+        """Test convert_to_camel_case."""
+        assert convert_to_camel_case("snake_case") == "snakeCase"
+        assert convert_to_camel_case("api_version") == "apiVersion"
+        assert convert_to_camel_case("simple") == "simple"
+        assert convert_to_camel_case("a_b_c") == "aBC"
+        assert convert_to_camel_case("created_at") == "createdAt"
+        assert convert_to_camel_case("") == ""
+
+    def test_snake_case(self):
+        """Test convert_to_snake_case."""
+        assert convert_to_snake_case("camelCase") == "camel_case"
+        assert convert_to_snake_case("apiVersion") == "api_version"
+        assert convert_to_snake_case("simple") == "simple"
+        assert convert_to_snake_case("ABC") == "abc"
+        assert convert_to_snake_case("createdAt") == "created_at"
+        assert convert_to_snake_case("") == ""
+
+
+@dataclass
+class InnerItem(YamlSerializable):
+    """Simple inner dataclass for testing."""
+
+    item_name: str = ""
+    item_value: int = 0
+
+
+@dataclass
+class OuterItem(YamlSerializable):
+    """Outer dataclass with nested and list fields."""
+
+    my_name: str = ""
+    inner_obj: InnerItem = field(default_factory=InnerItem)
+    inner_list: list[InnerItem] = field(default_factory=list)
+
+
+@dataclass
+class AliasItem(YamlSerializable):
+    """Dataclass with explicit field aliases."""
+
+    FIELD_ALIASES = {"special_field": "customKey"}
+
+    normal_field: str = ""
+    special_field: str = ""
+
+
+class TestSerialize:
+    """Test serialize function."""
+
+    def test_basic(self):
+        """Test basic serialization with alias override."""
+        item = AliasItem(normal_field="hello", special_field="world")
+        result = item.to_dict()
+
+        assert result["normalField"] == "hello"
+        assert result["customKey"] == "world"
+
+    def test_nested_dataclass(self):
+        """Test nested object recursive serialization."""
+        outer = OuterItem(
+            my_name="outer",
+            inner_obj=InnerItem(item_name="inner", item_value=42),
+        )
+        result = outer.to_dict()
+
+        assert result["myName"] == "outer"
+        assert result["innerObj"] == {"itemName": "inner", "itemValue": 42}
+
+    def test_list_of_dataclasses(self):
+        """Test list of objects recursive serialization."""
+        outer = OuterItem(
+            my_name="outer",
+            inner_list=[
+                InnerItem(item_name="a", item_value=1),
+                InnerItem(item_name="b", item_value=2),
+            ],
+        )
+        result = outer.to_dict()
+
+        assert result["myName"] == "outer"
+        assert result["innerList"] == [
+            {"itemName": "a", "itemValue": 1},
+            {"itemName": "b", "itemValue": 2},
+        ]
+
+
+class TestDeserialize:
+    """Test deserialize function."""
+
+    def test_basic(self):
+        """Test basic deserialization with alias override."""
+        data = {"normalField": "hello", "customKey": "world"}
+        item = AliasItem.from_dict(data)
+
+        assert item.normal_field == "hello"
+        assert item.special_field == "world"
+
+    def test_nested(self):
+        """Test nested object recursive deserialization."""
+        data = {
+            "myName": "outer",
+            "innerObj": {"itemName": "inner", "itemValue": 42},
+            "innerList": [],
+        }
+        outer = OuterItem.from_dict(data)
+
+        assert outer.my_name == "outer"
+        assert outer.inner_obj.item_name == "inner"
+        assert outer.inner_obj.item_value == 42
+
+    def test_defaults_on_missing(self):
+        """Test missing fields use defaults."""
+        data = {"myName": "partial"}
+        outer = OuterItem.from_dict(data)
+
+        assert outer.my_name == "partial"
+        assert outer.inner_obj == InnerItem()
+        assert outer.inner_list == []
+
+    def test_list_of_dataclasses(self):
+        """Test list of objects recursive deserialization."""
+        data = {
+            "myName": "outer",
+            "innerObj": {"itemName": "", "itemValue": 0},
+            "innerList": [
+                {"itemName": "a", "itemValue": 1},
+                {"itemName": "b", "itemValue": 2},
+            ],
+        }
+        outer = OuterItem.from_dict(data)
+
+        assert len(outer.inner_list) == 2
+        assert outer.inner_list[0].item_name == "a"
+        assert outer.inner_list[1].item_value == 2
+
+
+class TestOmitEmpty:
+    """Test omit_empty function."""
+
+    def test_filters_none_empty(self):
+        """Test filtering None, '', [], {}."""
+        data = {
+            "a": None,
+            "b": "",
+            "c": [],
+            "d": {},
+            "e": "keep",
+        }
+        result = omit_empty(data)
+        assert result == {"e": "keep"}
+
+    def test_keeps_false_and_zero(self):
+        """Test keeping False and 0."""
+        data = {
+            "a": False,
+            "b": 0,
+            "c": None,
+            "d": "",
+        }
+        result = omit_empty(data)
+        assert result == {"a": False, "b": 0}
+
+
+@dataclass
+class SpecModel(YamlSerializable):
+    """Model with BaseConfig-like fields for spec testing."""
+
+    api_version: str = "zima.io/v1"
+    kind: str = "Test"
+    metadata: str = "meta"
+    created_at: str = "now"
+    updated_at: str = "then"
+    spec_field_one: str = ""
+    spec_field_two: int = 0
+
+
+class TestSerializeSpec:
+    """Test serialize_spec function."""
+
+    def test_skips_base_fields(self):
+        """Test that BASE_CONFIG_FIELDS are excluded from spec."""
+        obj = SpecModel(spec_field_one="hello", spec_field_two=42)
+        result = serialize_spec(obj)
+
+        assert "apiVersion" not in result
+        assert "kind" not in result
+        assert "metadata" not in result
+        assert "createdAt" not in result
+        assert "updatedAt" not in result
+        assert result["specFieldOne"] == "hello"
+        assert result["specFieldTwo"] == 42
+
+
+class TestDeserializeSpec:
+    """Test deserialize_spec function."""
+
+    def test_skips_base_fields(self):
+        """Test that BASE_CONFIG_FIELDS are excluded from deserialization."""
+        spec_data = {"specFieldOne": "hello", "specFieldTwo": 42}
+        kwargs = deserialize_spec(SpecModel, spec_data)
+
+        assert "api_version" not in kwargs
+        assert "kind" not in kwargs
+        assert kwargs["spec_field_one"] == "hello"
+        assert kwargs["spec_field_two"] == 42
+
+    def test_uses_defaults_for_missing(self):
+        """Test missing spec fields use defaults."""
+        spec_data = {"specFieldOne": "hello"}
+        kwargs = deserialize_spec(SpecModel, spec_data)
+
+        assert kwargs["spec_field_one"] == "hello"
+        assert kwargs["spec_field_two"] == 0

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -228,3 +228,90 @@ class TestDeserializeSpec:
 
         assert kwargs["spec_field_one"] == "hello"
         assert kwargs["spec_field_two"] == 0
+
+
+class TestRoundTrip:
+    """Round-trip tests for all model classes."""
+
+    def test_metadata(self):
+        from zima.models.base import Metadata
+
+        original = Metadata(code="test", name="Test", description="desc")
+        assert Metadata.from_dict(original.to_dict()) == original
+
+    def test_agent_config(self):
+        from zima.models.agent import AgentConfig
+
+        original = AgentConfig.create("test", "Test", agent_type="claude")
+        assert AgentConfig.from_dict(original.to_dict()) == original
+
+    def test_env_config(self):
+        from zima.models.env import EnvConfig
+
+        original = EnvConfig.create("test", "Test", for_type="kimi", override_existing=True)
+        assert EnvConfig.from_dict(original.to_dict()) == original
+
+    def test_variable_config(self):
+        from zima.models.variable import VariableConfig
+
+        original = VariableConfig.create("test", "Test", for_workflow="wf1", values={"k": "v"})
+        assert VariableConfig.from_dict(original.to_dict()) == original
+
+    def test_pmg_config(self):
+        from zima.models.pmg import PMGConfig
+
+        original = PMGConfig.create("test", "Test", for_types=["kimi"])
+        assert PMGConfig.from_dict(original.to_dict()) == original
+
+    def test_workflow_config(self):
+        from zima.models.workflow import WorkflowConfig
+
+        original = WorkflowConfig.create("test", "Test", template="Hello")
+        assert WorkflowConfig.from_dict(original.to_dict()) == original
+
+    def test_pjob_config(self):
+        from zima.models.pjob import PJobConfig
+
+        original = PJobConfig.create("test", "Test", agent="a1", workflow="w1")
+        assert PJobConfig.from_dict(original.to_dict()) == original
+
+    def test_pjob_with_nested_objects(self):
+        from zima.models.pjob import PJobConfig
+
+        original = PJobConfig.create(
+            "test",
+            "Test",
+            agent="a1",
+            workflow="w1",
+            overrides={"agentParams": {"model": "sonnet"}},
+            execution={"workDir": "/tmp", "timeout": 60},
+        )
+        assert PJobConfig.from_dict(original.to_dict()) == original
+
+    def test_actions_config(self):
+        from zima.models.actions import ActionsConfig, PostExecAction
+
+        original = ActionsConfig(
+            post_exec=[
+                PostExecAction(
+                    condition="success", type="github_label", repo="o/r", add_labels=["done"]
+                )
+            ]
+        )
+        assert ActionsConfig.from_dict(original.to_dict()) == original
+
+    def test_schedule_config(self):
+        from zima.models.schedule import ScheduleConfig
+
+        original = ScheduleConfig.create("test", "Test")
+        assert ScheduleConfig.from_dict(original.to_dict()) == original
+
+    def test_special_alias_async(self):
+        from zima.models.pjob import ExecutionOptions
+
+        original = ExecutionOptions(work_dir="/tmp", async_=True)
+        data = original.to_dict()
+        assert "async" in data
+        assert "async_" not in data
+        restored = ExecutionOptions.from_dict(data)
+        assert restored.async_ is True

--- a/zima/models/actions.py
+++ b/zima/models/actions.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from zima.models.serialization import YamlSerializable, omit_empty
+
 VALID_ACTION_CONDITIONS = {"success", "failure", "always"}
 VALID_ACTION_TYPES = {"github_label", "github_comment"}
 
 
 @dataclass
-class PostExecAction:
+class PostExecAction(YamlSerializable):
     """Single post-execution action run after agent exits.
 
     Attributes:
@@ -22,6 +24,11 @@ class PostExecAction:
         body: Comment body (for github_comment type).
     """
 
+    FIELD_ALIASES = {
+        "add_labels": "addLabels",
+        "remove_labels": "removeLabels",
+    }
+
     condition: str = "always"
     type: str = "github_label"
     add_labels: list[str] = field(default_factory=list)
@@ -31,35 +38,12 @@ class PostExecAction:
     body: str = ""
 
     def to_dict(self) -> dict:
-        """Convert to dictionary."""
-        result = {
-            "condition": self.condition,
-            "type": self.type,
-        }
-        if self.add_labels:
-            result["addLabels"] = self.add_labels
-        if self.remove_labels:
-            result["removeLabels"] = self.remove_labels
-        if self.repo:
-            result["repo"] = self.repo
-        if self.issue:
-            result["issue"] = self.issue
-        if self.body:
-            result["body"] = self.body
-        return result
+        return omit_empty(super().to_dict())
 
     @classmethod
     def from_dict(cls, data: dict) -> PostExecAction:
         """Create from dictionary and validate."""
-        action = cls(
-            condition=data.get("condition", "always"),
-            type=data.get("type", "github_label"),
-            add_labels=data.get("addLabels", []),
-            remove_labels=data.get("removeLabels", []),
-            repo=data.get("repo", ""),
-            issue=str(data.get("issue", "")),
-            body=data.get("body", ""),
-        )
+        action = super().from_dict(data)
         errors = action.validate()
         if errors:
             raise ValueError("; ".join(errors))
@@ -76,22 +60,20 @@ class PostExecAction:
 
 
 @dataclass
-class ActionsConfig:
+class ActionsConfig(YamlSerializable):
     """Collection of actions for a PJob."""
+
+    FIELD_ALIASES = {"post_exec": "postExec"}
 
     post_exec: list[PostExecAction] = field(default_factory=list)
 
     def to_dict(self) -> dict:
-        """Convert to dictionary."""
-        return {"postExec": [a.to_dict() for a in self.post_exec]}
+        return omit_empty(super().to_dict())
 
     @classmethod
     def from_dict(cls, data: dict) -> ActionsConfig:
         """Create from dictionary and validate."""
-        actions = []
-        for action_data in data.get("postExec", []):
-            actions.append(PostExecAction.from_dict(action_data))
-        config = cls(post_exec=actions)
+        config = super().from_dict(data)
         errors = config.validate()
         if errors:
             raise ValueError("; ".join(errors))

--- a/zima/models/actions.py
+++ b/zima/models/actions.py
@@ -37,6 +37,17 @@ class PostExecAction(YamlSerializable):
     issue: str = ""
     body: str = ""
 
+    def __post_init__(self):
+        if self.issue is None:
+            self.issue = ""
+        elif not isinstance(self.issue, str):
+            if isinstance(self.issue, (int, float)):
+                self.issue = str(self.issue)
+            else:
+                raise TypeError(
+                    f"issue must be a string or number, got {type(self.issue).__name__}"
+                )
+
     def to_dict(self) -> dict:
         return omit_empty(super().to_dict())
 

--- a/zima/models/agent.py
+++ b/zima/models/agent.py
@@ -57,6 +57,7 @@ class AgentConfig(BaseConfig):
     """
 
     kind: str = "Agent"
+    SPEC_FIELD_ALIASES = {}
     type: str = "kimi"
     parameters: dict = field(default_factory=dict)
     defaults: dict = field(default_factory=dict)
@@ -146,37 +147,6 @@ class AgentConfig(BaseConfig):
     def is_valid(self) -> bool:
         """Check if configuration is valid."""
         return len(self.validate()) == 0
-
-    def to_dict(self) -> dict:
-        """Convert to dictionary."""
-        return {
-            "apiVersion": self.api_version,
-            "kind": self.kind,
-            "metadata": self.metadata.to_dict(),
-            "spec": {
-                "type": self.type,
-                "parameters": self.parameters,
-                "defaults": self.defaults,
-            },
-            "createdAt": self.created_at,
-            "updatedAt": self.updated_at,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> AgentConfig:
-        """Create from dictionary."""
-        spec = data.get("spec", {})
-
-        return cls(
-            api_version=data.get("apiVersion", "zima.io/v1"),
-            kind=data.get("kind", "Agent"),
-            metadata=Metadata.from_dict(data.get("metadata", {})),
-            type=spec.get("type", "kimi"),
-            parameters=spec.get("parameters", {}),
-            defaults=spec.get("defaults", {}),
-            created_at=data.get("createdAt", ""),
-            updated_at=data.get("updatedAt", ""),
-        )
 
     @classmethod
     def from_yaml_file(cls, path: Path) -> AgentConfig:

--- a/zima/models/base.py
+++ b/zima/models/base.py
@@ -7,11 +7,12 @@ from pathlib import Path
 
 import yaml
 
+from zima.models.serialization import YamlSerializable, deserialize_spec, serialize_spec
 from zima.utils import generate_timestamp
 
 
 @dataclass
-class Metadata:
+class Metadata(YamlSerializable):
     """
     Common metadata for all configurations.
 
@@ -44,7 +45,7 @@ class Metadata:
 
 
 @dataclass
-class BaseConfig:
+class BaseConfig(YamlSerializable):
     """
     Base configuration class.
 
@@ -58,6 +59,12 @@ class BaseConfig:
         created_at: Creation timestamp (ISO 8601)
         updated_at: Last update timestamp (ISO 8601)
     """
+
+    FIELD_ALIASES = {
+        "api_version": "apiVersion",
+        "created_at": "createdAt",
+        "updated_at": "updatedAt",
+    }
 
     api_version: str = "zima.io/v1"
     kind: str = ""
@@ -80,13 +87,10 @@ class BaseConfig:
         Returns:
             Dictionary representation
         """
-        return {
-            "apiVersion": self.api_version,
-            "kind": self.kind,
-            "metadata": self.metadata.to_dict(),
-            "createdAt": self.created_at,
-            "updatedAt": self.updated_at,
-        }
+        result = super().to_dict()
+        result["metadata"] = self.metadata.to_dict()
+        result["spec"] = serialize_spec(self, getattr(self, "SPEC_FIELD_ALIASES", None))
+        return result
 
     def to_yaml(self) -> str:
         """
@@ -110,13 +114,16 @@ class BaseConfig:
         Returns:
             Configuration instance
         """
-        return cls(
-            api_version=data.get("apiVersion", "zima.io/v1"),
-            kind=data.get("kind", ""),
-            metadata=Metadata.from_dict(data.get("metadata", {})),
-            created_at=data.get("createdAt", ""),
-            updated_at=data.get("updatedAt", ""),
-        )
+        spec_data = data.get("spec", {})
+        kwargs = {
+            "api_version": data.get("apiVersion", "zima.io/v1"),
+            "kind": data.get("kind", ""),
+            "metadata": Metadata.from_dict(data.get("metadata", {})),
+            "created_at": data.get("createdAt", ""),
+            "updated_at": data.get("updatedAt", ""),
+        }
+        kwargs.update(deserialize_spec(cls, spec_data, getattr(cls, "SPEC_FIELD_ALIASES", None)))
+        return cls(**kwargs)
 
     @classmethod
     def from_yaml(cls, yaml_content: str) -> BaseConfig:
@@ -194,26 +201,3 @@ class BaseConfig:
     def update_timestamp(self) -> None:
         """Update the updated_at timestamp to current time."""
         self.updated_at = generate_timestamp()
-
-
-# Type alias for config data
-def convert_to_camel_case(snake_str: str) -> str:
-    """
-    Convert snake_case to camelCase.
-
-    Used for YAML field name conversion.
-    """
-    components = snake_str.split("_")
-    return components[0] + "".join(x.capitalize() for x in components[1:])
-
-
-def convert_to_snake_case(camel_str: str) -> str:
-    """
-    Convert camelCase to snake_case.
-
-    Used for YAML field name conversion.
-    """
-    import re
-
-    s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", camel_str)
-    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()

--- a/zima/models/base.py
+++ b/zima/models/base.py
@@ -84,11 +84,19 @@ class BaseConfig(YamlSerializable):
         """
         Convert configuration to dictionary.
 
+        Kubernetes-style structure: apiVersion, kind, metadata, spec, createdAt, updatedAt.
+        Does NOT call super().to_dict() to avoid double-serializing spec fields.
+
         Returns:
             Dictionary representation
         """
-        result = super().to_dict()
-        result["metadata"] = self.metadata.to_dict()
+        result = {
+            "apiVersion": self.api_version,
+            "kind": self.kind,
+            "metadata": self.metadata.to_dict(),
+            "createdAt": self.created_at,
+            "updatedAt": self.updated_at,
+        }
         result["spec"] = serialize_spec(self, getattr(self, "SPEC_FIELD_ALIASES", None))
         return result
 

--- a/zima/models/base.py
+++ b/zima/models/base.py
@@ -114,7 +114,7 @@ class BaseConfig(YamlSerializable):
         Returns:
             Configuration instance
         """
-        spec_data = data.get("spec", {})
+        spec_data = data.get("spec", {}) if isinstance(data, dict) else {}
         kwargs = {
             "api_version": data.get("apiVersion", "zima.io/v1"),
             "kind": data.get("kind", ""),

--- a/zima/models/env.py
+++ b/zima/models/env.py
@@ -205,6 +205,10 @@ class EnvConfig(BaseConfig):
     """
 
     kind: str = "Env"
+    SPEC_FIELD_ALIASES = {
+        "for_type": "forType",
+        "override_existing": "overrideExisting",
+    }
     for_type: str = "kimi"
     variables: dict[str, str] = field(default_factory=dict)
     secrets: list[SecretDef] = field(default_factory=list)
@@ -328,47 +332,6 @@ class EnvConfig(BaseConfig):
     def is_valid(self) -> bool:
         """Check if configuration is valid."""
         return len(self.validate()) == 0
-
-    def to_dict(self) -> dict:
-        """Convert to dictionary."""
-        return {
-            "apiVersion": self.api_version,
-            "kind": self.kind,
-            "metadata": self.metadata.to_dict(),
-            "spec": {
-                "forType": self.for_type,
-                "variables": self.variables,
-                "secrets": [s.to_dict() for s in self.secrets],
-                "overrideExisting": self.override_existing,
-            },
-            "createdAt": self.created_at,
-            "updatedAt": self.updated_at,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> EnvConfig:
-        """Create from dictionary."""
-        spec = data.get("spec", {})
-
-        # Parse secret definitions
-        secret_data = spec.get("secrets", [])
-        secrets = []
-        if isinstance(secret_data, list):
-            for s in secret_data:
-                if isinstance(s, dict):
-                    secrets.append(SecretDef.from_dict(s))
-
-        return cls(
-            api_version=data.get("apiVersion", "zima.io/v1"),
-            kind=data.get("kind", "Env"),
-            metadata=Metadata.from_dict(data.get("metadata", {})),
-            for_type=spec.get("forType", "kimi"),
-            variables=spec.get("variables", {}),
-            secrets=secrets,
-            override_existing=spec.get("overrideExisting", False),
-            created_at=data.get("createdAt", ""),
-            updated_at=data.get("updatedAt", ""),
-        )
 
     @classmethod
     def from_yaml_file(cls, path: Path) -> EnvConfig:

--- a/zima/models/pjob.py
+++ b/zima/models/pjob.py
@@ -7,11 +7,12 @@ from typing import Optional
 
 from zima.models.actions import ActionsConfig
 from zima.models.base import BaseConfig, Metadata
+from zima.models.serialization import YamlSerializable, omit_empty
 from zima.utils import generate_timestamp, validate_code
 
 
 @dataclass
-class ExecutionOptions:
+class ExecutionOptions(YamlSerializable):
     """
     Execution options for PJob.
 
@@ -23,36 +24,21 @@ class ExecutionOptions:
         async_: Whether to execute asynchronously
     """
 
+    FIELD_ALIASES = {
+        "work_dir": "workDir",
+        "keep_temp": "keepTemp",
+        "async_": "async",
+    }
+
     work_dir: str = ""
     timeout: int = 0  # 0 means no timeout
     keep_temp: bool = False
     retries: int = 0
     async_: bool = False
 
-    def to_dict(self) -> dict:
-        """Convert to dictionary."""
-        return {
-            "workDir": self.work_dir,
-            "timeout": self.timeout,
-            "keepTemp": self.keep_temp,
-            "retries": self.retries,
-            "async": self.async_,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> ExecutionOptions:
-        """Create from dictionary."""
-        return cls(
-            work_dir=data.get("workDir", ""),
-            timeout=data.get("timeout", 0),
-            keep_temp=data.get("keepTemp", False),
-            retries=data.get("retries", 0),
-            async_=data.get("async", False),
-        )
-
 
 @dataclass
-class OutputOptions:
+class OutputOptions(YamlSerializable):
     """
     Output handling options for PJob.
 
@@ -62,31 +48,15 @@ class OutputOptions:
         format: Output format processing (raw, json, extract-code-blocks)
     """
 
+    FIELD_ALIASES = {"save_to": "saveTo"}
+
     save_to: str = ""
     append: bool = False
     format: str = "raw"
 
-    def to_dict(self) -> dict:
-        """Convert to dictionary."""
-        result = {"format": self.format}
-        if self.save_to:
-            result["saveTo"] = self.save_to
-        if self.append:
-            result["append"] = self.append
-        return result
-
-    @classmethod
-    def from_dict(cls, data: dict) -> OutputOptions:
-        """Create from dictionary."""
-        return cls(
-            save_to=data.get("saveTo", ""),
-            append=data.get("append", False),
-            format=data.get("format", "raw"),
-        )
-
 
 @dataclass
-class Overrides:
+class Overrides(YamlSerializable):
     """
     Runtime overrides for PJob execution.
 
@@ -99,33 +69,17 @@ class Overrides:
         pmg_params: Additional PMG parameters
     """
 
+    FIELD_ALIASES = {
+        "agent_params": "agentParams",
+        "variable_values": "variableValues",
+        "env_vars": "envVars",
+        "pmg_params": "pmgParams",
+    }
+
     agent_params: dict = field(default_factory=dict)
     variable_values: dict = field(default_factory=dict)
     env_vars: dict = field(default_factory=dict)
     pmg_params: list[dict] = field(default_factory=list)
-
-    def to_dict(self) -> dict:
-        """Convert to dictionary."""
-        result = {}
-        if self.agent_params:
-            result["agentParams"] = self.agent_params
-        if self.variable_values:
-            result["variableValues"] = self.variable_values
-        if self.env_vars:
-            result["envVars"] = self.env_vars
-        if self.pmg_params:
-            result["pmgParams"] = self.pmg_params
-        return result
-
-    @classmethod
-    def from_dict(cls, data: dict) -> Overrides:
-        """Create from dictionary."""
-        return cls(
-            agent_params=data.get("agentParams", {}),
-            variable_values=data.get("variableValues", {}),
-            env_vars=data.get("envVars", {}),
-            pmg_params=data.get("pmgParams", []),
-        )
 
     def is_empty(self) -> bool:
         """Check if overrides are empty."""
@@ -140,7 +94,7 @@ class Overrides:
 
 
 @dataclass
-class PJobSpec:
+class PJobSpec(YamlSerializable):
     """
     PJob specification containing config references.
 
@@ -169,44 +123,11 @@ class PJobSpec:
     actions: ActionsConfig = field(default_factory=ActionsConfig)
 
     def to_dict(self) -> dict:
-        """Convert to dictionary."""
-        result = {
-            "agent": self.agent,
-            "workflow": self.workflow,
-        }
-        if self.variable:
-            result["variable"] = self.variable
-        if self.env:
-            result["env"] = self.env
-        if self.pmg:
-            result["pmg"] = self.pmg
-        if not self.overrides.is_empty():
-            result["overrides"] = self.overrides.to_dict()
-        if self.execution.work_dir or self.execution.timeout != 0:
-            result["execution"] = self.execution.to_dict()
-        if self.hooks:
-            result["hooks"] = self.hooks
-        if self.output.save_to or self.output.format != "raw":
-            result["output"] = self.output.to_dict()
-        if self.actions.post_exec:
-            result["actions"] = self.actions.to_dict()
+        result = omit_empty(super().to_dict())
+        # ActionsConfig returns {"postExec": []} when empty; omit_empty won't catch it
+        if result.get("actions") == {"postExec": []}:
+            del result["actions"]
         return result
-
-    @classmethod
-    def from_dict(cls, data: dict) -> PJobSpec:
-        """Create from dictionary."""
-        return cls(
-            agent=data.get("agent", ""),
-            workflow=data.get("workflow", ""),
-            variable=data.get("variable", ""),
-            env=data.get("env", ""),
-            pmg=data.get("pmg", ""),
-            overrides=Overrides.from_dict(data.get("overrides", {})),
-            execution=ExecutionOptions.from_dict(data.get("execution", {})),
-            hooks=data.get("hooks", {}),
-            output=OutputOptions.from_dict(data.get("output", {})),
-            actions=ActionsConfig.from_dict(data.get("actions", {})),
-        )
 
 
 @dataclass
@@ -259,6 +180,8 @@ class PJobConfig(BaseConfig):
         metadata: PJob metadata with labels and annotations
         spec: PJob specification with config references
     """
+
+    SPEC_FIELD_ALIASES = {}
 
     kind: str = "PJob"
     metadata: PJobMetadata = field(default_factory=PJobMetadata)

--- a/zima/models/pjob.py
+++ b/zima/models/pjob.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from zima.models.actions import ActionsConfig
 from zima.models.base import BaseConfig, Metadata
-from zima.models.serialization import YamlSerializable, omit_empty
+from zima.models.serialization import YamlSerializable
 from zima.utils import generate_timestamp, validate_code
 
 

--- a/zima/models/pjob.py
+++ b/zima/models/pjob.py
@@ -36,6 +36,16 @@ class ExecutionOptions(YamlSerializable):
     retries: int = 0
     async_: bool = False
 
+    def is_default(self) -> bool:
+        """Check if all fields are at default values."""
+        return (
+            self.work_dir == ""
+            and self.timeout == 0
+            and not self.keep_temp
+            and self.retries == 0
+            and not self.async_
+        )
+
 
 @dataclass
 class OutputOptions(YamlSerializable):
@@ -123,10 +133,27 @@ class PJobSpec(YamlSerializable):
     actions: ActionsConfig = field(default_factory=ActionsConfig)
 
     def to_dict(self) -> dict:
-        result = omit_empty(super().to_dict())
-        # ActionsConfig returns {"postExec": []} when empty; omit_empty won't catch it
-        if result.get("actions") == {"postExec": []}:
-            del result["actions"]
+        result = {
+            "agent": self.agent,
+            "workflow": self.workflow,
+        }
+        if self.variable:
+            result["variable"] = self.variable
+        if self.env:
+            result["env"] = self.env
+        if self.pmg:
+            result["pmg"] = self.pmg
+        if not self.overrides.is_empty():
+            result["overrides"] = self.overrides.to_dict()
+        if not self.execution.is_default():
+            result["execution"] = self.execution.to_dict()
+        if self.hooks:
+            result["hooks"] = self.hooks
+        if self.output.save_to or self.output.format != "raw":
+            result["output"] = self.output.to_dict()
+        actions_dict = self.actions.to_dict()
+        if actions_dict:
+            result["actions"] = actions_dict
         return result
 
 

--- a/zima/models/pmg.py
+++ b/zima/models/pmg.py
@@ -272,6 +272,9 @@ class PMGConfig(BaseConfig):
     """
 
     kind: str = "PMG"
+    SPEC_FIELD_ALIASES = {
+        "for_types": "forTypes",
+    }
     for_types: list[str] = field(default_factory=list)
     parameters: list[ParameterDef] = field(default_factory=list)
     raw: str = ""
@@ -411,60 +414,6 @@ class PMGConfig(BaseConfig):
     def is_valid(self) -> bool:
         """Check if configuration is valid."""
         return len(self.validate()) == 0
-
-    def to_dict(self) -> dict:
-        """Convert to dictionary."""
-        return {
-            "apiVersion": self.api_version,
-            "kind": self.kind,
-            "metadata": self.metadata.to_dict(),
-            "spec": {
-                "forTypes": self.for_types,
-                "parameters": [p.to_dict() for p in self.parameters],
-                "raw": self.raw,
-                "extends": [e.to_dict() for e in self.extends],
-                "conditions": [c.to_dict() for c in self.conditions],
-            },
-            "createdAt": self.created_at,
-            "updatedAt": self.updated_at,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> PMGConfig:
-        """Create from dictionary."""
-        spec = data.get("spec", {})
-
-        # Parse parameters
-        param_data = spec.get("parameters", [])
-        parameters = [ParameterDef.from_dict(p) if isinstance(p, dict) else p for p in param_data]
-
-        # Parse extends
-        extend_data = spec.get("extends", [])
-        extends = []
-        for e in extend_data:
-            if isinstance(e, dict):
-                extends.append(ExtendDef.from_dict(e))
-            elif isinstance(e, str):
-                extends.append(ExtendDef(code=e))
-
-        # Parse conditions
-        condition_data = spec.get("conditions", [])
-        conditions = [
-            ConditionDef.from_dict(c) if isinstance(c, dict) else c for c in condition_data
-        ]
-
-        return cls(
-            api_version=data.get("apiVersion", "zima.io/v1"),
-            kind=data.get("kind", "PMG"),
-            metadata=Metadata.from_dict(data.get("metadata", {})),
-            for_types=spec.get("forTypes", []),
-            parameters=parameters,
-            raw=spec.get("raw", ""),
-            extends=extends,
-            conditions=conditions,
-            created_at=data.get("createdAt", ""),
-            updated_at=data.get("updatedAt", ""),
-        )
 
     @classmethod
     def from_yaml_file(cls, path: Path) -> PMGConfig:

--- a/zima/models/pmg.py
+++ b/zima/models/pmg.py
@@ -151,8 +151,8 @@ class ExtendDef:
         return result
 
     @classmethod
-    def from_dict(cls, data: dict) -> ExtendDef:
-        """Create from dictionary."""
+    def from_dict(cls, data: dict | str) -> ExtendDef:
+        """Create from dictionary or string shorthand."""
         if isinstance(data, str):
             return cls(code=data)
         return cls(code=data.get("code", ""), override=data.get("override", False))

--- a/zima/models/schedule.py
+++ b/zima/models/schedule.py
@@ -5,60 +5,34 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from zima.models.base import BaseConfig, Metadata
+from zima.models.serialization import YamlSerializable
 from zima.utils import generate_timestamp, validate_code
 
 
 @dataclass
-class ScheduleStage:
+class ScheduleStage(YamlSerializable):
     """A stage within a cycle (e.g., work, rest, dream)."""
+
+    FIELD_ALIASES = {
+        "offset_minutes": "offsetMinutes",
+        "duration_minutes": "durationMinutes",
+    }
 
     name: str = ""
     offset_minutes: int = 0
     duration_minutes: int = 0
 
-    def to_dict(self) -> dict:
-        return {
-            "name": self.name,
-            "offsetMinutes": self.offset_minutes,
-            "durationMinutes": self.duration_minutes,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> ScheduleStage:
-        return cls(
-            name=data.get("name", ""),
-            offset_minutes=data.get("offsetMinutes", 0),
-            duration_minutes=data.get("durationMinutes", 0),
-        )
-
 
 @dataclass
-class ScheduleCycleType:
+class ScheduleCycleType(YamlSerializable):
     """Mapping of stage names to PJob codes for one cycle type."""
+
+    FIELD_ALIASES = {"type_id": "typeId"}
 
     type_id: str = ""
     work: list[str] = field(default_factory=list)
     rest: list[str] = field(default_factory=list)
     dream: list[str] = field(default_factory=list)
-
-    def to_dict(self) -> dict:
-        result: dict = {"typeId": self.type_id}
-        if self.work:
-            result["work"] = self.work
-        if self.rest:
-            result["rest"] = self.rest
-        if self.dream:
-            result["dream"] = self.dream
-        return result
-
-    @classmethod
-    def from_dict(cls, data: dict) -> ScheduleCycleType:
-        return cls(
-            type_id=data.get("typeId", ""),
-            work=data.get("work", []),
-            rest=data.get("rest", []),
-            dream=data.get("dream", []),
-        )
 
     def get_stage_pjobs(self, stage_name: str) -> list[str]:
         return getattr(self, stage_name, [])
@@ -68,6 +42,13 @@ class ScheduleCycleType:
 class ScheduleConfig(BaseConfig):
     """Schedule configuration for daemon-mode 32-cycle scheduling."""
 
+    SPEC_FIELD_ALIASES = {
+        "cycle_minutes": "cycleMinutes",
+        "daily_cycles": "dailyCycles",
+        "cycle_types": "cycleTypes",
+        "cycle_mapping": "cycleMapping",
+    }
+
     kind: str = "Schedule"
     metadata: Metadata = field(default_factory=Metadata)
     cycle_minutes: int = 45
@@ -75,38 +56,6 @@ class ScheduleConfig(BaseConfig):
     stages: list[ScheduleStage] = field(default_factory=list)
     cycle_types: list[ScheduleCycleType] = field(default_factory=list)
     cycle_mapping: list[str] = field(default_factory=list)
-
-    def to_dict(self) -> dict:
-        return {
-            "apiVersion": self.api_version,
-            "kind": self.kind,
-            "metadata": self.metadata.to_dict(),
-            "spec": {
-                "cycleMinutes": self.cycle_minutes,
-                "dailyCycles": self.daily_cycles,
-                "stages": [s.to_dict() for s in self.stages],
-                "cycleTypes": [ct.to_dict() for ct in self.cycle_types],
-                "cycleMapping": self.cycle_mapping,
-            },
-            "createdAt": self.created_at,
-            "updatedAt": self.updated_at,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> ScheduleConfig:
-        spec = data.get("spec", {})
-        return cls(
-            api_version=data.get("apiVersion", "zima.io/v1"),
-            kind=data.get("kind", "Schedule"),
-            metadata=Metadata.from_dict(data.get("metadata", {})),
-            cycle_minutes=spec.get("cycleMinutes", 45),
-            daily_cycles=spec.get("dailyCycles", 32),
-            stages=[ScheduleStage.from_dict(s) for s in spec.get("stages", [])],
-            cycle_types=[ScheduleCycleType.from_dict(ct) for ct in spec.get("cycleTypes", [])],
-            cycle_mapping=spec.get("cycleMapping", []),
-            created_at=data.get("createdAt", ""),
-            updated_at=data.get("updatedAt", ""),
-        )
 
     @classmethod
     def create(

--- a/zima/models/serialization.py
+++ b/zima/models/serialization.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import types
 from dataclasses import MISSING, fields, is_dataclass
 from typing import Union, get_args, get_origin
 
@@ -20,9 +21,9 @@ def convert_to_snake_case(camel_str: str) -> str:
 
 
 def _unwrap_optional(t):
-    """Return the inner type if t is Optional[X], else None."""
+    """Return the inner type if t is Optional[X] or X | None, else None."""
     origin = get_origin(t)
-    if origin is Union:
+    if origin is Union or origin is types.UnionType:
         args = get_args(t)
         if len(args) == 2 and type(None) in args:
             return args[0] if args[1] is type(None) else args[1]
@@ -102,12 +103,17 @@ def serialize(obj, aliases=None) -> dict:
         value = getattr(obj, f.name)
         resolved_type = _resolve_type(f.type, f.name, cls)
 
+        # Unwrap Optional before checking is_dataclass
+        inner = _unwrap_optional(resolved_type)
+        if inner is not None:
+            resolved_type = inner
+
         if is_dataclass(resolved_type):
             if value is not None:
                 value = value.to_dict()
-        elif _is_list_of_dataclasses(resolved_type, cls, f.name):
+        elif _is_list_of_dataclasses(f.type, cls, f.name):
             if value is not None:
-                item_type = _get_item_type_from_list(resolved_type, cls, f.name)
+                item_type = _get_item_type_from_list(f.type, cls, f.name)
                 if item_type is not None and hasattr(item_type, "to_dict"):
                     value = [v.to_dict() if hasattr(v, "to_dict") else v for v in value]
 
@@ -154,18 +160,43 @@ def deserialize(cls, data, aliases=None):
                 continue
 
         resolved_type = _resolve_type(f.type, f.name, cls)
+        inner = _unwrap_optional(resolved_type)
+        if inner is not None:
+            resolved_type = inner
 
-        # Recursively deserialize nested dataclasses
+        # Recursively deserialize nested dataclasses via their from_dict()
         if is_dataclass(resolved_type):
-            inner = _unwrap_optional(resolved_type)
-            target_cls = inner if inner is not None else resolved_type
-            if value is not None and is_dataclass(target_cls):
-                if isinstance(value, dict):
-                    value = deserialize(target_cls, value)
-        elif _is_list_of_dataclasses(resolved_type, cls, f.name):
-            item_type = _get_item_type_from_list(resolved_type, cls, f.name)
+            if value is not None:
+                if isinstance(value, resolved_type):
+                    pass  # already the right type
+                elif isinstance(value, dict):
+                    if hasattr(resolved_type, "from_dict"):
+                        value = resolved_type.from_dict(value)
+                    else:
+                        value = deserialize(resolved_type, value)
+                else:
+                    raise TypeError(
+                        f"Expected dict or {resolved_type.__name__} for field '{f.name}', "
+                        f"got {type(value).__name__}"
+                    )
+        elif _is_list_of_dataclasses(f.type, cls, f.name):
+            item_type = _get_item_type_from_list(f.type, cls, f.name)
             if item_type is not None and value is not None:
-                value = [deserialize(item_type, v) if isinstance(v, dict) else v for v in value]
+                items = []
+                for v in value:
+                    if isinstance(v, item_type):
+                        items.append(v)
+                    elif isinstance(v, dict):
+                        if hasattr(item_type, "from_dict"):
+                            items.append(item_type.from_dict(v))
+                        else:
+                            items.append(deserialize(item_type, v))
+                    else:
+                        raise TypeError(
+                            f"Expected dict or {item_type.__name__} for item in '{f.name}', "
+                            f"got {type(v).__name__}"
+                        )
+                value = items
 
         kwargs[f.name] = value
 
@@ -191,12 +222,17 @@ def serialize_spec(obj, aliases=None) -> dict:
         value = getattr(obj, f.name)
         resolved_type = _resolve_type(f.type, f.name, cls)
 
+        # Unwrap Optional before checking is_dataclass
+        inner = _unwrap_optional(resolved_type)
+        if inner is not None:
+            resolved_type = inner
+
         if is_dataclass(resolved_type):
             if value is not None:
                 value = value.to_dict()
-        elif _is_list_of_dataclasses(resolved_type, cls, f.name):
+        elif _is_list_of_dataclasses(f.type, cls, f.name):
             if value is not None:
-                item_type = _get_item_type_from_list(resolved_type, cls, f.name)
+                item_type = _get_item_type_from_list(f.type, cls, f.name)
                 if item_type is not None and hasattr(item_type, "to_dict"):
                     value = [v.to_dict() if hasattr(v, "to_dict") else v for v in value]
 
@@ -241,18 +277,43 @@ def deserialize_spec(cls, spec_data, aliases=None) -> dict:
                 continue
 
         resolved_type = _resolve_type(f.type, f.name, cls)
+        inner = _unwrap_optional(resolved_type)
+        if inner is not None:
+            resolved_type = inner
 
-        # Recursively deserialize nested dataclasses
+        # Recursively deserialize nested dataclasses via their from_dict()
         if is_dataclass(resolved_type):
-            inner = _unwrap_optional(resolved_type)
-            target_cls = inner if inner is not None else resolved_type
-            if value is not None and is_dataclass(target_cls):
-                if isinstance(value, dict):
-                    value = deserialize(target_cls, value)
-        elif _is_list_of_dataclasses(resolved_type, cls, f.name):
-            item_type = _get_item_type_from_list(resolved_type, cls, f.name)
+            if value is not None:
+                if isinstance(value, resolved_type):
+                    pass  # already the right type
+                elif isinstance(value, dict):
+                    if hasattr(resolved_type, "from_dict"):
+                        value = resolved_type.from_dict(value)
+                    else:
+                        value = deserialize(resolved_type, value)
+                else:
+                    raise TypeError(
+                        f"Expected dict or {resolved_type.__name__} for field '{f.name}', "
+                        f"got {type(value).__name__}"
+                    )
+        elif _is_list_of_dataclasses(f.type, cls, f.name):
+            item_type = _get_item_type_from_list(f.type, cls, f.name)
             if item_type is not None and value is not None:
-                value = [deserialize(item_type, v) if isinstance(v, dict) else v for v in value]
+                items = []
+                for v in value:
+                    if isinstance(v, item_type):
+                        items.append(v)
+                    elif isinstance(v, dict):
+                        if hasattr(item_type, "from_dict"):
+                            items.append(item_type.from_dict(v))
+                        else:
+                            items.append(deserialize(item_type, v))
+                    else:
+                        raise TypeError(
+                            f"Expected dict or {item_type.__name__} for item in '{f.name}', "
+                            f"got {type(v).__name__}"
+                        )
+                value = items
 
         kwargs[f.name] = value
 

--- a/zima/models/serialization.py
+++ b/zima/models/serialization.py
@@ -88,10 +88,13 @@ class YamlSerializable:
 def serialize(obj, aliases=None) -> dict:
     """Serialize a dataclass instance to a dictionary.
 
-    For each field:
-    - Use alias override if present, else auto snake_to_camel.
-    - Recursively serialize nested dataclasses (call their to_dict()).
-    - Recursively serialize lists of dataclasses.
+    Args:
+        obj: Dataclass instance to serialize.
+        aliases: Optional dict mapping field names to YAML keys. Missing fields
+            are auto-converted from snake_case to camelCase.
+
+    Returns:
+        Dictionary with camelCase keys and recursively serialized values.
     """
     if aliases is None:
         aliases = getattr(obj, "FIELD_ALIASES", {}) if hasattr(obj, "FIELD_ALIASES") else {}
@@ -125,11 +128,17 @@ def serialize(obj, aliases=None) -> dict:
 def deserialize(cls, data, aliases=None):
     """Deserialize a dictionary to a dataclass instance.
 
-    For each field:
-    - Match YAML key: aliases override first, else auto camel_to_snake.
-    - Recursively deserialize nested dataclasses.
-    - Recursively deserialize lists of dataclasses.
-    - Use field defaults for missing values.
+    Args:
+        cls: Dataclass type to instantiate.
+        data: Dictionary with camelCase keys.
+        aliases: Optional dict mapping field names to YAML keys. Missing fields
+            are auto-converted from snake_case to camelCase.
+
+    Returns:
+        Instance of ``cls`` with fields populated from ``data``.
+
+    Raises:
+        TypeError: If a nested value or list item has the wrong type.
     """
     if aliases is None:
         aliases = getattr(cls, "FIELD_ALIASES", {}) if hasattr(cls, "FIELD_ALIASES") else {}
@@ -206,8 +215,16 @@ def deserialize(cls, data, aliases=None):
 def serialize_spec(obj, aliases=None) -> dict:
     """Serialize only non-BaseConfig fields into a spec dict.
 
-    Iterates over fields(obj), skips BASE_CONFIG_FIELDS, and uses the same
-    mapping/recursion logic as serialize.
+    Skips ``BASE_CONFIG_FIELDS`` (``apiVersion``, ``kind``, ``metadata``,
+    ``createdAt``, ``updatedAt``) and applies the same mapping/recursion
+    logic as :func:`serialize`.
+
+    Args:
+        obj: Dataclass instance to serialize.
+        aliases: Optional dict mapping field names to YAML keys.
+
+    Returns:
+        Dictionary with spec fields only, using camelCase keys.
     """
     if aliases is None:
         aliases = getattr(obj, "FIELD_ALIASES", {}) if hasattr(obj, "FIELD_ALIASES") else {}
@@ -244,9 +261,19 @@ def serialize_spec(obj, aliases=None) -> dict:
 def deserialize_spec(cls, spec_data, aliases=None) -> dict:
     """Deserialize spec fields from a dict into kwargs dict.
 
-    Iterates over fields(cls), skips BASE_CONFIG_FIELDS, and uses the same
-    mapping/recursion logic as deserialize. Returns a kwargs dict suitable
-    for passing to the class constructor.
+    Skips ``BASE_CONFIG_FIELDS`` and applies the same mapping/recursion
+    logic as :func:`deserialize`.
+
+    Args:
+        cls: Dataclass type to instantiate.
+        spec_data: Dictionary with spec data (camelCase keys).
+        aliases: Optional dict mapping field names to YAML keys.
+
+    Returns:
+        kwargs dict suitable for passing to the class constructor.
+
+    Raises:
+        TypeError: If a nested value or list item has the wrong type.
     """
     if aliases is None:
         aliases = getattr(cls, "FIELD_ALIASES", {}) if hasattr(cls, "FIELD_ALIASES") else {}
@@ -321,5 +348,15 @@ def deserialize_spec(cls, spec_data, aliases=None) -> dict:
 
 
 def omit_empty(data: dict) -> dict:
-    """Remove entries with None, '', [], or {}."""
+    """Remove entries with falsy sentinel values.
+
+    Removes entries where the value is exactly ``None``, ``""``, ``[]``,
+    or ``{}``. Preserves ``0`` and ``False`` since they are meaningful.
+
+    Args:
+        data: Dictionary to filter.
+
+    Returns:
+        Dictionary with sentinel-empty entries removed.
+    """
     return {k: v for k, v in data.items() if v not in (None, "", [], {})}

--- a/zima/models/serialization.py
+++ b/zima/models/serialization.py
@@ -195,16 +195,10 @@ def deserialize(cls, data, aliases=None):
                 for v in value:
                     if isinstance(v, item_type):
                         items.append(v)
-                    elif isinstance(v, dict):
-                        if hasattr(item_type, "from_dict"):
-                            items.append(item_type.from_dict(v))
-                        else:
-                            items.append(deserialize(item_type, v))
+                    elif hasattr(item_type, "from_dict"):
+                        items.append(item_type.from_dict(v))
                     else:
-                        raise TypeError(
-                            f"Expected dict or {item_type.__name__} for item in '{f.name}', "
-                            f"got {type(v).__name__}"
-                        )
+                        items.append(deserialize(item_type, v))
                 value = items
 
         kwargs[f.name] = value
@@ -330,16 +324,10 @@ def deserialize_spec(cls, spec_data, aliases=None) -> dict:
                 for v in value:
                     if isinstance(v, item_type):
                         items.append(v)
-                    elif isinstance(v, dict):
-                        if hasattr(item_type, "from_dict"):
-                            items.append(item_type.from_dict(v))
-                        else:
-                            items.append(deserialize(item_type, v))
+                    elif hasattr(item_type, "from_dict"):
+                        items.append(item_type.from_dict(v))
                     else:
-                        raise TypeError(
-                            f"Expected dict or {item_type.__name__} for item in '{f.name}', "
-                            f"got {type(v).__name__}"
-                        )
+                        items.append(deserialize(item_type, v))
                 value = items
 
         kwargs[f.name] = value

--- a/zima/models/serialization.py
+++ b/zima/models/serialization.py
@@ -1,0 +1,242 @@
+"""Generic YAML serialization utilities for dataclasses."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import MISSING, fields, is_dataclass
+from typing import Union, get_args, get_origin
+
+
+def convert_to_camel_case(snake_str: str) -> str:
+    """Convert snake_case to camelCase."""
+    components = snake_str.split("_")
+    return components[0] + "".join(x.capitalize() for x in components[1:])
+
+
+def convert_to_snake_case(camel_str: str) -> str:
+    """Convert camelCase to snake_case."""
+    s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", camel_str)
+    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+
+def _unwrap_optional(t):
+    """Return the inner type if t is Optional[X], else None."""
+    origin = get_origin(t)
+    if origin is Union:
+        args = get_args(t)
+        if len(args) == 2 and type(None) in args:
+            return args[0] if args[1] is type(None) else args[1]
+    return None
+
+
+def _is_list_of_dataclasses(t):
+    """Check if t is list[X] or Optional[list[X]] where X is a dataclass."""
+    inner = _unwrap_optional(t)
+    if inner is not None:
+        t = inner
+    origin = get_origin(t)
+    if origin is list:
+        args = get_args(t)
+        if args and is_dataclass(args[0]):
+            return True
+    return False
+
+
+def _get_item_type_from_list(t):
+    """Extract the dataclass type from list[X] or Optional[list[X]]."""
+    inner = _unwrap_optional(t)
+    if inner is not None:
+        t = inner
+    args = get_args(t)
+    return args[0] if args else None
+
+
+# Fields that are part of BaseConfig and should NOT go into spec dict
+BASE_CONFIG_FIELDS = {"api_version", "kind", "metadata", "created_at", "updated_at"}
+
+
+class YamlSerializable:
+    """Mixin class that provides to_dict/from_dict for dataclasses."""
+
+    FIELD_ALIASES: dict[str, str] = {}
+
+    def to_dict(self) -> dict:
+        """Serialize to dictionary with automatic case conversion."""
+        return serialize(self, self.FIELD_ALIASES)
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        """Deserialize from dictionary with automatic case conversion."""
+        return deserialize(cls, data, cls.FIELD_ALIASES)
+
+
+def serialize(obj, aliases=None) -> dict:
+    """Serialize a dataclass instance to a dictionary.
+
+    For each field:
+    - Use alias override if present, else auto snake_to_camel.
+    - Recursively serialize nested dataclasses (call their to_dict()).
+    - Recursively serialize lists of dataclasses.
+    """
+    if aliases is None:
+        aliases = getattr(obj, "FIELD_ALIASES", {}) if hasattr(obj, "FIELD_ALIASES") else {}
+
+    result = {}
+    for f in fields(obj):
+        key = aliases.get(f.name, convert_to_camel_case(f.name))
+        value = getattr(obj, f.name)
+
+        if is_dataclass(f.type):
+            if value is not None:
+                value = value.to_dict()
+        elif _is_list_of_dataclasses(f.type):
+            if value is not None:
+                item_type = _get_item_type_from_list(f.type)
+                if item_type is not None and hasattr(item_type, "to_dict"):
+                    value = [v.to_dict() if hasattr(v, "to_dict") else v for v in value]
+
+        result[key] = value
+
+    return result
+
+
+def deserialize(cls, data, aliases=None):
+    """Deserialize a dictionary to a dataclass instance.
+
+    For each field:
+    - Match YAML key: aliases override first, else auto camel_to_snake.
+    - Recursively deserialize nested dataclasses.
+    - Recursively deserialize lists of dataclasses.
+    - Use field defaults for missing values.
+    """
+    if aliases is None:
+        aliases = getattr(cls, "FIELD_ALIASES", {}) if hasattr(cls, "FIELD_ALIASES") else {}
+
+    kwargs = {}
+    for f in fields(cls):
+        # Determine the expected key in the input data
+        expected_key = aliases.get(f.name, convert_to_camel_case(f.name))
+
+        if expected_key in data:
+            value = data[expected_key]
+        else:
+            # Try reverse alias lookup or camel_to_snake fallback
+            snake_key = convert_to_snake_case(expected_key)
+            if snake_key in data:
+                value = data[snake_key]
+            elif f.name in data:
+                value = data[f.name]
+            else:
+                # Use default
+                if f.default is not MISSING:
+                    value = f.default
+                elif f.default_factory is not MISSING:
+                    value = f.default_factory()
+                else:
+                    value = None
+                kwargs[f.name] = value
+                continue
+
+        # Recursively deserialize nested dataclasses
+        if is_dataclass(f.type):
+            inner = _unwrap_optional(f.type)
+            target_cls = inner if inner is not None else f.type
+            if value is not None and is_dataclass(target_cls):
+                if isinstance(value, dict):
+                    value = deserialize(target_cls, value)
+        elif _is_list_of_dataclasses(f.type):
+            item_type = _get_item_type_from_list(f.type)
+            if item_type is not None and value is not None:
+                value = [deserialize(item_type, v) if isinstance(v, dict) else v for v in value]
+
+        kwargs[f.name] = value
+
+    return cls(**kwargs)
+
+
+def serialize_spec(obj, aliases=None) -> dict:
+    """Serialize only non-BaseConfig fields into a spec dict.
+
+    Iterates over fields(obj), skips BASE_CONFIG_FIELDS, and uses the same
+    mapping/recursion logic as serialize.
+    """
+    if aliases is None:
+        aliases = getattr(obj, "FIELD_ALIASES", {}) if hasattr(obj, "FIELD_ALIASES") else {}
+
+    result = {}
+    for f in fields(obj):
+        if f.name in BASE_CONFIG_FIELDS:
+            continue
+
+        key = aliases.get(f.name, convert_to_camel_case(f.name))
+        value = getattr(obj, f.name)
+
+        if is_dataclass(f.type):
+            if value is not None:
+                value = value.to_dict()
+        elif _is_list_of_dataclasses(f.type):
+            if value is not None:
+                item_type = _get_item_type_from_list(f.type)
+                if item_type is not None and hasattr(item_type, "to_dict"):
+                    value = [v.to_dict() if hasattr(v, "to_dict") else v for v in value]
+
+        result[key] = value
+
+    return result
+
+
+def deserialize_spec(cls, spec_data, aliases=None) -> dict:
+    """Deserialize spec fields from a dict into kwargs dict.
+
+    Iterates over fields(cls), skips BASE_CONFIG_FIELDS, and uses the same
+    mapping/recursion logic as deserialize. Returns a kwargs dict suitable
+    for passing to the class constructor.
+    """
+    if aliases is None:
+        aliases = getattr(cls, "FIELD_ALIASES", {}) if hasattr(cls, "FIELD_ALIASES") else {}
+
+    kwargs = {}
+    for f in fields(cls):
+        if f.name in BASE_CONFIG_FIELDS:
+            continue
+
+        expected_key = aliases.get(f.name, convert_to_camel_case(f.name))
+
+        if expected_key in spec_data:
+            value = spec_data[expected_key]
+        else:
+            snake_key = convert_to_snake_case(expected_key)
+            if snake_key in spec_data:
+                value = spec_data[snake_key]
+            elif f.name in spec_data:
+                value = spec_data[f.name]
+            else:
+                if f.default is not MISSING:
+                    value = f.default
+                elif f.default_factory is not MISSING:
+                    value = f.default_factory()
+                else:
+                    value = None
+                kwargs[f.name] = value
+                continue
+
+        # Recursively deserialize nested dataclasses
+        if is_dataclass(f.type):
+            inner = _unwrap_optional(f.type)
+            target_cls = inner if inner is not None else f.type
+            if value is not None and is_dataclass(target_cls):
+                if isinstance(value, dict):
+                    value = deserialize(target_cls, value)
+        elif _is_list_of_dataclasses(f.type):
+            item_type = _get_item_type_from_list(f.type)
+            if item_type is not None and value is not None:
+                value = [deserialize(item_type, v) if isinstance(v, dict) else v for v in value]
+
+        kwargs[f.name] = value
+
+    return kwargs
+
+
+def omit_empty(data: dict) -> dict:
+    """Remove entries with None, '', [], or {}."""
+    return {k: v for k, v in data.items() if v not in (None, "", [], {})}

--- a/zima/models/serialization.py
+++ b/zima/models/serialization.py
@@ -29,8 +29,21 @@ def _unwrap_optional(t):
     return None
 
 
-def _is_list_of_dataclasses(t):
+def _resolve_type(t, field_name, cls=None):
+    """Resolve a type annotation that may be a string (from PEP 563)."""
+    if isinstance(t, str) and cls is not None:
+        try:
+            import inspect
+
+            t = inspect.get_annotations(cls, eval_str=True).get(field_name, t)
+        except Exception:
+            pass
+    return t
+
+
+def _is_list_of_dataclasses(t, cls=None, field_name=None):
     """Check if t is list[X] or Optional[list[X]] where X is a dataclass."""
+    t = _resolve_type(t, field_name, cls)
     inner = _unwrap_optional(t)
     if inner is not None:
         t = inner
@@ -42,8 +55,9 @@ def _is_list_of_dataclasses(t):
     return False
 
 
-def _get_item_type_from_list(t):
+def _get_item_type_from_list(t, cls=None, field_name=None):
     """Extract the dataclass type from list[X] or Optional[list[X]]."""
+    t = _resolve_type(t, field_name, cls)
     inner = _unwrap_optional(t)
     if inner is not None:
         t = inner
@@ -81,17 +95,19 @@ def serialize(obj, aliases=None) -> dict:
     if aliases is None:
         aliases = getattr(obj, "FIELD_ALIASES", {}) if hasattr(obj, "FIELD_ALIASES") else {}
 
+    cls = type(obj)
     result = {}
     for f in fields(obj):
         key = aliases.get(f.name, convert_to_camel_case(f.name))
         value = getattr(obj, f.name)
+        resolved_type = _resolve_type(f.type, f.name, cls)
 
-        if is_dataclass(f.type):
+        if is_dataclass(resolved_type):
             if value is not None:
                 value = value.to_dict()
-        elif _is_list_of_dataclasses(f.type):
+        elif _is_list_of_dataclasses(resolved_type, cls, f.name):
             if value is not None:
-                item_type = _get_item_type_from_list(f.type)
+                item_type = _get_item_type_from_list(resolved_type, cls, f.name)
                 if item_type is not None and hasattr(item_type, "to_dict"):
                     value = [v.to_dict() if hasattr(v, "to_dict") else v for v in value]
 
@@ -137,15 +153,17 @@ def deserialize(cls, data, aliases=None):
                 kwargs[f.name] = value
                 continue
 
+        resolved_type = _resolve_type(f.type, f.name, cls)
+
         # Recursively deserialize nested dataclasses
-        if is_dataclass(f.type):
-            inner = _unwrap_optional(f.type)
-            target_cls = inner if inner is not None else f.type
+        if is_dataclass(resolved_type):
+            inner = _unwrap_optional(resolved_type)
+            target_cls = inner if inner is not None else resolved_type
             if value is not None and is_dataclass(target_cls):
                 if isinstance(value, dict):
                     value = deserialize(target_cls, value)
-        elif _is_list_of_dataclasses(f.type):
-            item_type = _get_item_type_from_list(f.type)
+        elif _is_list_of_dataclasses(resolved_type, cls, f.name):
+            item_type = _get_item_type_from_list(resolved_type, cls, f.name)
             if item_type is not None and value is not None:
                 value = [deserialize(item_type, v) if isinstance(v, dict) else v for v in value]
 
@@ -163,6 +181,7 @@ def serialize_spec(obj, aliases=None) -> dict:
     if aliases is None:
         aliases = getattr(obj, "FIELD_ALIASES", {}) if hasattr(obj, "FIELD_ALIASES") else {}
 
+    cls = type(obj)
     result = {}
     for f in fields(obj):
         if f.name in BASE_CONFIG_FIELDS:
@@ -170,13 +189,14 @@ def serialize_spec(obj, aliases=None) -> dict:
 
         key = aliases.get(f.name, convert_to_camel_case(f.name))
         value = getattr(obj, f.name)
+        resolved_type = _resolve_type(f.type, f.name, cls)
 
-        if is_dataclass(f.type):
+        if is_dataclass(resolved_type):
             if value is not None:
                 value = value.to_dict()
-        elif _is_list_of_dataclasses(f.type):
+        elif _is_list_of_dataclasses(resolved_type, cls, f.name):
             if value is not None:
-                item_type = _get_item_type_from_list(f.type)
+                item_type = _get_item_type_from_list(resolved_type, cls, f.name)
                 if item_type is not None and hasattr(item_type, "to_dict"):
                     value = [v.to_dict() if hasattr(v, "to_dict") else v for v in value]
 
@@ -220,15 +240,17 @@ def deserialize_spec(cls, spec_data, aliases=None) -> dict:
                 kwargs[f.name] = value
                 continue
 
+        resolved_type = _resolve_type(f.type, f.name, cls)
+
         # Recursively deserialize nested dataclasses
-        if is_dataclass(f.type):
-            inner = _unwrap_optional(f.type)
-            target_cls = inner if inner is not None else f.type
+        if is_dataclass(resolved_type):
+            inner = _unwrap_optional(resolved_type)
+            target_cls = inner if inner is not None else resolved_type
             if value is not None and is_dataclass(target_cls):
                 if isinstance(value, dict):
                     value = deserialize(target_cls, value)
-        elif _is_list_of_dataclasses(f.type):
-            item_type = _get_item_type_from_list(f.type)
+        elif _is_list_of_dataclasses(resolved_type, cls, f.name):
+            item_type = _get_item_type_from_list(resolved_type, cls, f.name)
             if item_type is not None and value is not None:
                 value = [deserialize(item_type, v) if isinstance(v, dict) else v for v in value]
 

--- a/zima/models/variable.py
+++ b/zima/models/variable.py
@@ -24,6 +24,9 @@ class VariableConfig(BaseConfig):
     """
 
     kind: str = "Variable"
+    SPEC_FIELD_ALIASES = {
+        "for_workflow": "forWorkflow",
+    }
     for_workflow: str = ""  # workflow code reference
     values: dict[str, Any] = field(default_factory=dict)
 
@@ -97,35 +100,6 @@ class VariableConfig(BaseConfig):
     def is_valid(self) -> bool:
         """Check if configuration is valid."""
         return len(self.validate()) == 0
-
-    def to_dict(self) -> dict:
-        """Convert to dictionary."""
-        return {
-            "apiVersion": self.api_version,
-            "kind": self.kind,
-            "metadata": self.metadata.to_dict(),
-            "spec": {
-                "forWorkflow": self.for_workflow,
-                "values": self.values,
-            },
-            "createdAt": self.created_at,
-            "updatedAt": self.updated_at,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> VariableConfig:
-        """Create from dictionary."""
-        spec = data.get("spec", {})
-
-        return cls(
-            api_version=data.get("apiVersion", "zima.io/v1"),
-            kind=data.get("kind", "Variable"),
-            metadata=Metadata.from_dict(data.get("metadata", {})),
-            for_workflow=spec.get("forWorkflow", ""),
-            values=spec.get("values", {}),
-            created_at=data.get("createdAt", ""),
-            updated_at=data.get("updatedAt", ""),
-        )
 
     @classmethod
     def from_yaml_file(cls, path: Path) -> VariableConfig:

--- a/zima/models/workflow.py
+++ b/zima/models/workflow.py
@@ -105,6 +105,7 @@ class WorkflowConfig(BaseConfig):
     """
 
     kind: str = "Workflow"
+    SPEC_FIELD_ALIASES = {}
     format: str = "jinja2"
     template: str = ""
     variables: list[VariableDef] = field(default_factory=list)
@@ -221,51 +222,6 @@ class WorkflowConfig(BaseConfig):
     def is_valid(self) -> bool:
         """Check if configuration is valid."""
         return len(self.validate()) == 0
-
-    def to_dict(self) -> dict:
-        """Convert to dictionary."""
-        return {
-            "apiVersion": self.api_version,
-            "kind": self.kind,
-            "metadata": self.metadata.to_dict(),
-            "spec": {
-                "format": self.format,
-                "template": self.template,
-                "variables": [v.to_dict() for v in self.variables],
-                "tags": self.tags,
-                "author": self.author,
-                "version": self.version,
-            },
-            "createdAt": self.created_at,
-            "updatedAt": self.updated_at,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> WorkflowConfig:
-        """Create from dictionary."""
-        spec = data.get("spec", {})
-
-        # Parse variable definitions
-        var_data = spec.get("variables", [])
-        variables = []
-        if isinstance(var_data, list):
-            for v in var_data:
-                if isinstance(v, dict):
-                    variables.append(VariableDef.from_dict(v))
-
-        return cls(
-            api_version=data.get("apiVersion", "zima.io/v1"),
-            kind=data.get("kind", "Workflow"),
-            metadata=Metadata.from_dict(data.get("metadata", {})),
-            format=spec.get("format", "jinja2"),
-            template=spec.get("template", ""),
-            variables=variables,
-            tags=spec.get("tags", []),
-            author=spec.get("author", ""),
-            version=spec.get("version", "1.0.0"),
-            created_at=data.get("createdAt", ""),
-            updated_at=data.get("updatedAt", ""),
-        )
 
     @classmethod
     def from_yaml_file(cls, path: Path) -> WorkflowConfig:


### PR DESCRIPTION
## Summary

- Introduce `YamlSerializable` mixin with auto `snake_case` ↔ `camelCase` key mapping
- Add `serialize()` / `deserialize()` / `serialize_spec()` / `deserialize_spec()` utilities in `zima/models/serialization.py`
- Migrate all 15+ model classes (BaseConfig, EnvConfig, PMGConfig, VariableConfig, WorkflowConfig, AgentConfig, PJob nested classes, Actions, Schedule) to use auto mapping
- Eliminate ~500 lines of scattered manual `to_dict()` / `from_dict()` mapping code
- Activate previously dead `convert_to_camel_case()` / `convert_to_snake_case()` functions
- Add comprehensive round-trip tests for all models (`from_dict(to_dict(obj)) == obj`)

## Test Plan

- [x] All unit tests pass (552 passed)
- [x] Coverage maintained at 69.18% (threshold 60%)
- [x] `black` + `ruff` clean
- [x] Special alias `async_` → `async` verified

Closes #14