### PR TITLE
chore: remove gemini agent type from codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Kimi Code agents when working with code in this r
 
 ## Project Overview
 
-**Zima Blue CLI** is a Python-based AI Agent orchestration platform. It manages execution of AI agents (Kimi, Claude, Gemini) through composable YAML configurations and Jinja2 prompt templates. Named after the sci-fi story about returning to simplicity.
+**Zima Blue CLI** is a Python-based AI Agent orchestration platform. It manages execution of AI agents (Kimi, Claude) through composable YAML configurations and Jinja2 prompt templates. Named after the sci-fi story about returning to simplicity.
 
 ## Development Commands
 
@@ -49,7 +49,7 @@ The core design is composability through seven YAML-based configuration types:
 
 | Entity | Model | Purpose |
 |--------|-------|---------|
-| Agent | `AgentConfig` | AI executor config (kimi/claude/gemini), builds CLI commands |
+| Agent | `AgentConfig` | AI executor config (kimi/claude), builds CLI commands |
 | Workflow | `WorkflowConfig` | Jinja2 prompt templates with typed variable definitions |
 | Variable | `VariableConfig` | Key-value data for template rendering |
 | Env | `EnvConfig` | Secrets and env vars (env/file/cmd/vault sources) |
@@ -82,7 +82,7 @@ zima pjob run <code>
   → Resolves referenced Agent/Workflow/Variable/Env/PMG
   → Renders Workflow template with Variables
   → Builds CLI command from Agent parameters
-  → Executes subprocess (kimi/claude/gemini)
+  → Executes subprocess (kimi/claude)
   → Captures output, stores execution history centrally
   → Returns ExecutionResult
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Zima Blue CLI** is a Python-based AI Agent orchestration platform. It manages execution of AI agents (Kimi, Claude, Gemini) through composable YAML configurations and Jinja2 prompt templates. Named after the sci-fi story about returning to simplicity.
+**Zima Blue CLI** is a Python-based AI Agent orchestration platform. It manages execution of AI agents (Kimi, Claude) through composable YAML configurations and Jinja2 prompt templates. Named after the sci-fi story about returning to simplicity.
 
 ## Development Commands
 
@@ -49,7 +49,7 @@ The core design is composability through seven YAML-based configuration types:
 
 | Entity | Model | Purpose |
 |--------|-------|---------|
-| Agent | `AgentConfig` | AI executor config (kimi/claude/gemini), builds CLI commands |
+| Agent | `AgentConfig` | AI executor config (kimi/claude), builds CLI commands |
 | Workflow | `WorkflowConfig` | Jinja2 prompt templates with typed variable definitions |
 | Variable | `VariableConfig` | Key-value data for template rendering |
 | Env | `EnvConfig` | Secrets and env vars (env/file/cmd/vault sources) |
@@ -86,7 +86,7 @@ zima pjob run <code>
   → Resolves referenced Agent/Workflow/Variable/Env/PMG
   → Renders Workflow template with Variables
   → Builds CLI command from Agent parameters
-  → Executes subprocess (kimi/claude/gemini)
+  → Executes subprocess (kimi/claude)
   → Runs postExec actions (e.g. GitHub label transition) in finally block
   → Captures output, stores execution history centrally
   → Returns ExecutionResult

--- a/tests/integration/test_agent_commands.py
+++ b/tests/integration/test_agent_commands.py
@@ -52,26 +52,6 @@ class TestAgentCreate(TestIsolator):
         assert "created successfully" in result.output
         assert "claude" in result.output
 
-    def test_create_gemini_agent(self):
-        """Test creating a Gemini agent."""
-        result = runner.invoke(
-            app,
-            [
-                "agent",
-                "create",
-                "--name",
-                "Test Gemini Agent",
-                "--code",
-                "test-gemini",
-                "--type",
-                "gemini",
-            ],
-        )
-
-        assert result.exit_code == 0
-        assert "created successfully" in result.output
-        assert "gemini" in result.output
-
     def test_create_with_description(self):
         """Test creating agent with description."""
         result = runner.invoke(

--- a/tests/integration/test_kimi_agent_integration.py
+++ b/tests/integration/test_kimi_agent_integration.py
@@ -133,24 +133,19 @@ class TestKimiAgentConfigLayer:
         """TC-3: Verify different agent types generate different commands."""
         kimi_agent = AgentConfig.create(code="k", name="K", agent_type="kimi")
         claude_agent = AgentConfig.create(code="c", name="C", agent_type="claude")
-        gemini_agent = AgentConfig.create(code="g", name="G", agent_type="gemini")
 
         kimi_cmd = kimi_agent.get_cli_command_template()
         claude_cmd = claude_agent.get_cli_command_template()
-        gemini_cmd = gemini_agent.get_cli_command_template()
 
         # Verify command differences
         assert kimi_cmd == ["kimi", "--print", "--yolo"]
         assert claude_cmd == ["claude", "-p"]
-        assert gemini_cmd == ["gemini", "--yolo"]
 
         # Verify work-dir parameter differences
         work_dir = Path("/tmp/test")
         kimi_full = kimi_agent.build_command(work_dir=work_dir)
-        gemini_full = gemini_agent.build_command(work_dir=work_dir)
 
         assert "--work-dir" in kimi_full
-        assert "--worktree" in gemini_full  # Gemini uses different flag
 
 
 class TestKimiAgentRunnerLayer:
@@ -483,12 +478,6 @@ class TestKimiAgentCLILayer:
         result = runner.invoke(app, ["agent", "test", "c-agent"])
         assert result.exit_code == 0
         assert "claude" in result.output
-
-        # Test Gemini agent
-        self.create_test_agent("g-agent", "gemini")
-        result = runner.invoke(app, ["agent", "test", "g-agent"])
-        assert result.exit_code == 0
-        assert "gemini" in result.output
 
     def test_pjob_run_with_kimi_agent_dry_run(self):
         """TC-11: Verify PJob dry-run with Kimi agent integration."""

--- a/tests/unit/test_models_agent.py
+++ b/tests/unit/test_models_agent.py
@@ -30,14 +30,6 @@ class TestAgentConfigCreation(TestIsolator):
         assert "model" not in config.parameters
         assert config.parameters["maxTurns"] == 100
 
-    def test_create_gemini_agent(self):
-        """Test creating Gemini agent."""
-        config = AgentConfig.create(code="gemini-agent", name="Gemini Agent", agent_type="gemini")
-
-        assert config.type == "gemini"
-        assert "model" not in config.parameters
-        assert config.parameters["approvalMode"] == "default"
-
     def test_create_with_custom_params(self):
         """Test creating with custom parameters."""
         config = AgentConfig.create(
@@ -101,12 +93,6 @@ class TestAgentConfigValidation(TestIsolator):
     def test_validate_valid_claude(self):
         """Test valid Claude config."""
         config = AgentConfig.create("test", "Test", "claude")
-        errors = config.validate()
-        assert errors == []
-
-    def test_validate_valid_gemini(self):
-        """Test valid Gemini config."""
-        config = AgentConfig.create("test", "Test", "gemini")
         errors = config.validate()
         assert errors == []
 
@@ -203,9 +189,9 @@ metadata:
   name: YAML Agent
   description: From YAML
 spec:
-  type: gemini
+  type: claude
   parameters:
-    model: gemini-pro
+    model: claude-sonnet
   defaults:
     workflow: wf1
 """
@@ -215,8 +201,8 @@ spec:
         config = AgentConfig.from_yaml_file(yaml_file)
 
         assert config.metadata.code == "yaml-agent"
-        assert config.type == "gemini"
-        assert config.parameters["model"] == "gemini-pro"
+        assert config.type == "claude"
+        assert config.parameters["model"] == "claude-sonnet"
 
     def test_from_yaml_file_not_found(self, tmp_path):
         """Test loading from non-existent file."""
@@ -243,14 +229,6 @@ class TestAgentConfigCommandBuilding(TestIsolator):
 
         assert "claude" in template
         assert "-p" in template
-
-    def test_get_cli_template_gemini(self):
-        """Test getting Gemini command template."""
-        config = AgentConfig.create("test", "Test", "gemini")
-        template = config.get_cli_command_template()
-
-        assert "gemini" in template
-        assert "--yolo" in template
 
     def test_build_kimi_command(self):
         """Test building Kimi command."""
@@ -285,20 +263,6 @@ class TestAgentConfigCommandBuilding(TestIsolator):
         assert "--work-dir" in cmd
         assert "--max-turns" in cmd
         assert "50" in cmd
-
-    def test_build_gemini_command(self):
-        """Test building Gemini command."""
-        config = AgentConfig.create("test", "Test", "gemini", parameters={"model": "gemini-pro"})
-
-        cmd = config.build_command(
-            prompt_file=Path("/tmp/prompt.md"), work_dir=Path("/tmp/workspace")
-        )
-
-        assert "gemini" in cmd
-        assert "-p" in cmd  # Gemini uses -p for prompt file
-        assert "--worktree" in cmd  # Gemini uses --worktree
-        assert "-m" in cmd
-        assert "gemini-pro" in cmd
 
     def test_build_command_with_add_dirs(self):
         """Test building command with additional directories."""
@@ -342,14 +306,6 @@ class TestAgentConfigCommandBuilding(TestIsolator):
 
         assert "--model" not in cmd
 
-    def test_build_gemini_command_no_model_by_default(self):
-        """Test that -m is omitted for gemini when no model is set."""
-        config = AgentConfig.create("test", "Test", "gemini")
-        cmd = config.build_command()
-
-        assert "-m" not in cmd
-
-
 class TestAgentConfigDefaults(TestIsolator):
     """Test default references management."""
 
@@ -391,8 +347,8 @@ class TestValidAgentTypes(TestIsolator):
     """Test valid agent types constant."""
 
     def test_valid_types(self):
-        """Test that only kimi, claude, gemini are valid."""
-        assert VALID_AGENT_TYPES == {"kimi", "claude", "gemini"}
+        """Test that only kimi and claude are valid."""
+        assert VALID_AGENT_TYPES == {"kimi", "claude"}
         assert "openai" not in VALID_AGENT_TYPES
         assert "custom" not in VALID_AGENT_TYPES
 

--- a/tests/unit/test_models_agent.py
+++ b/tests/unit/test_models_agent.py
@@ -306,6 +306,7 @@ class TestAgentConfigCommandBuilding(TestIsolator):
 
         assert "--model" not in cmd
 
+
 class TestAgentConfigDefaults(TestIsolator):
     """Test default references management."""
 

--- a/tests/unit/test_models_env.py
+++ b/tests/unit/test_models_env.py
@@ -388,7 +388,7 @@ class TestEnvConfig(TestIsolator):
             env = EnvConfig.create(
                 code="dict-test",
                 name="Dict Test",
-                for_type="gemini",
+                for_type="claude",
                 variables={"VAR1": "val1"},
                 secrets=[{"name": "SEC1", "source": "env", "key": "K"}],
             )
@@ -397,7 +397,7 @@ class TestEnvConfig(TestIsolator):
             assert data["apiVersion"] == "zima.io/v1"
             assert data["kind"] == "Env"
             assert data["metadata"]["code"] == "dict-test"
-            assert data["spec"]["forType"] == "gemini"
+            assert data["spec"]["forType"] == "claude"
             assert data["spec"]["variables"] == {"VAR1": "val1"}
             assert len(data["spec"]["secrets"]) == 1
             assert data["spec"]["overrideExisting"] is False

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -113,7 +113,6 @@ class TestAgentTypeValidation:
         [
             ("kimi", True),
             ("claude", True),
-            ("gemini", True),
             ("invalid", False),
             ("KIMI", False),  # case sensitive
             ("", False),
@@ -127,7 +126,7 @@ class TestAgentTypeValidation:
     def test_get_valid_agent_types(self):
         """Test getting valid agent types."""
         types = utils.get_valid_agent_types()
-        assert types == {"kimi", "claude", "gemini"}
+        assert types == {"kimi", "claude"}
         # Ensure it's a copy
         types.add("new")
         assert "new" not in utils.get_valid_agent_types()

--- a/zima/commands/agent.py
+++ b/zima/commands/agent.py
@@ -26,7 +26,7 @@ def create(
     code: Optional[str] = typer.Option(
         None, "--code", "-c", help="Unique code (lowercase letters, numbers, hyphens)"
     ),
-    agent_type: str = typer.Option("kimi", "--type", "-t", help="Agent type: kimi/claude/gemini"),
+    agent_type: str = typer.Option("kimi", "--type", "-t", help="Agent type: kimi/claude"),
     description: str = typer.Option("", "--description", "-d", help="Description"),
     from_code: Optional[str] = typer.Option(None, "--from", help="Copy from existing agent"),
     model: Optional[str] = typer.Option(None, "--model", "-m", help="Model name"),
@@ -431,7 +431,6 @@ def types():
     descriptions = {
         "kimi": "Kimi CLI - 月之暗面大模型",
         "claude": "Claude CLI - Anthropic AI",
-        "gemini": "Gemini CLI - Google AI",
     }
 
     for agent_type in sorted(VALID_AGENT_TYPES):

--- a/zima/commands/env.py
+++ b/zima/commands/env.py
@@ -26,7 +26,7 @@ def create(
     ),
     name: Optional[str] = typer.Option(None, "--name", "-n", help="Display name"),
     for_type: Optional[str] = typer.Option(
-        None, "--for-type", "-t", help="Target agent type: kimi/claude/gemini"
+        None, "--for-type", "-t", help="Target agent type: kimi/claude"
     ),
     description: str = typer.Option("", "--description", "-d", help="Description"),
     from_code: Optional[str] = typer.Option(None, "--from", help="Copy from existing env config"),

--- a/zima/models/agent.py
+++ b/zima/models/agent.py
@@ -31,16 +31,9 @@ AGENT_PARAMETER_TEMPLATES = {
         "workDir": "./workspace",
         "addDirs": [],
     },
-    "gemini": {
-        "approvalMode": "default",
-        "checkpointing": False,
-        "workDir": "./workspace",
-        "addDirs": [],
-        "outputFormat": "text",
-    },
 }
 
-VALID_AGENT_TYPES = {"kimi", "claude", "gemini"}
+VALID_AGENT_TYPES = {"kimi", "claude"}
 
 
 @dataclass
@@ -48,10 +41,10 @@ class AgentConfig(BaseConfig):
     """
     Agent configuration model.
 
-    Supports multiple agent types: kimi, claude, gemini
+    Supports multiple agent types: kimi, claude
 
     Attributes:
-        type: Agent type (kimi/claude/gemini)
+        type: Agent type (kimi/claude)
         parameters: Type-specific parameters
         defaults: Default workflow/variable/env/pmg references
     """
@@ -91,7 +84,7 @@ class AgentConfig(BaseConfig):
         Args:
             code: Unique agent code
             name: Display name
-            agent_type: Agent type (kimi/claude/gemini)
+            agent_type: Agent type (kimi/claude)
             description: Optional description
             parameters: Custom parameters (override defaults)
             defaults: Default workflow/variable/env/pmg references
@@ -180,7 +173,6 @@ class AgentConfig(BaseConfig):
         templates = {
             "kimi": ["kimi", "--print", "--yolo"],
             "claude": ["claude", "-p"],
-            "gemini": ["gemini", "--yolo"],
         }
         return templates.get(self.type, [])
 
@@ -213,25 +205,17 @@ class AgentConfig(BaseConfig):
             cmd = self._build_kimi_command(cmd, params)
         elif self.type == "claude":
             cmd = self._build_claude_command(cmd, params)
-        elif self.type == "gemini":
-            cmd = self._build_gemini_command(cmd, params)
 
         # Add prompt file - agent-type-specific handling
         # Claude Code: prompt passed via stdin pipe, not as CLI argument
         # Kimi: uses --prompt flag
-        # Gemini: uses positional argument
         if prompt_file:
             if self.type == "kimi":
                 cmd.extend(["--prompt", str(prompt_file)])
-            elif self.type == "gemini":
-                cmd.extend(["-p", str(prompt_file)])
             # Claude: prompt_file is passed via stdin pipe by the executor, not added to cmd
 
         if work_dir:
-            if self.type == "gemini":
-                cmd.extend(["--worktree", str(work_dir)])
-            else:
-                cmd.extend(["--work-dir", str(work_dir)])
+            cmd.extend(["--work-dir", str(work_dir)])
 
         return cmd
 
@@ -309,26 +293,6 @@ class AgentConfig(BaseConfig):
 
         if params.get("verbose"):
             cmd.append("--verbose")
-
-        return cmd
-
-    def _build_gemini_command(self, cmd: list[str], params: dict) -> list[str]:
-        """Build Gemini-specific command arguments."""
-        if params.get("model"):
-            cmd.extend(["-m", str(params["model"])])
-
-        if params.get("approvalMode") and params["approvalMode"] != "default":
-            cmd.extend(["--approval-mode", str(params["approvalMode"])])
-
-        if params.get("checkpointing"):
-            cmd.append("--checkpointing")
-
-        # Handle addDirs (for Gemini: --include-directories)
-        for add_dir in params.get("addDirs", []):
-            cmd.extend(["--include-directories", str(add_dir)])
-
-        if params.get("outputFormat"):
-            cmd.extend(["--output-format", str(params["outputFormat"])])
 
         return cmd
 

--- a/zima/models/env.py
+++ b/zima/models/env.py
@@ -15,7 +15,7 @@ from zima.utils import generate_timestamp, validate_code
 VALID_SECRET_SOURCES = {"env", "file", "cmd", "vault"}
 
 # Valid agent types that can have env configs
-VALID_ENV_FOR_TYPES = {"kimi", "claude", "gemini"}
+VALID_ENV_FOR_TYPES = {"kimi", "claude"}
 
 
 @dataclass
@@ -198,7 +198,7 @@ class EnvConfig(BaseConfig):
     Supports both plain variables and secrets from various sources.
 
     Attributes:
-        for_type: Target agent type (kimi/claude/gemini)
+        for_type: Target agent type (kimi/claude)
         variables: Plain environment variables (key-value pairs)
         secrets: Secret definitions (resolved at runtime)
         override_existing: Whether to override existing env vars

--- a/zima/models/pmg.py
+++ b/zima/models/pmg.py
@@ -16,7 +16,7 @@ from zima.utils import generate_timestamp, validate_code
 VALID_PARAM_TYPES = {"long", "short", "flag", "positional", "repeatable", "json", "key-value"}
 
 # Valid agent types for PMG
-VALID_PMG_FOR_TYPES = {"kimi", "claude", "gemini"}
+VALID_PMG_FOR_TYPES = {"kimi", "claude"}
 
 
 @dataclass

--- a/zima/utils.py
+++ b/zima/utils.py
@@ -256,7 +256,7 @@ def safe_delete(path: Path) -> bool:
 # =============================================================================
 
 
-VALID_AGENT_TYPES = {"kimi", "claude", "gemini"}
+VALID_AGENT_TYPES = {"kimi", "claude"}
 
 
 def validate_agent_type(agent_type: str) -> bool:


### PR DESCRIPTION
## Summary

Closes #60

- Remove all "gemini" agent type references from source code (6 files) and tests (5 files)
- Gemini was never actually supported — only kimi and claude are active
- All `VALID_*` type sets now contain only `{"kimi", "claude"}`

## Changes

**Source code (6 files):**
- `zima/models/agent.py` — Removed gemini parameter template, `_build_gemini_command()`, gemini branches in `build_command()` and `get_cli_command_template()`, updated `VALID_AGENT_TYPES`
- `zima/models/env.py` — Updated `VALID_ENV_FOR_TYPES`
- `zima/models/pmg.py` — Updated `VALID_PMG_FOR_TYPES`
- `zima/commands/agent.py` — Updated help text, removed gemini from descriptions
- `zima/commands/env.py` — Updated help text
- `zima/utils.py` — Updated `VALID_AGENT_TYPES`

**Tests (5 files):**
- Deleted all gemini-specific test methods (5 unit tests + 1 integration test)
- Updated assertions to expect `{"kimi", "claude"}`
- Updated YAML fixture from gemini to claude

## Test plan

- [x] `grep -ri "gemini" zima/ tests/ --include="*.py"` returns zero matches
- [x] `uv run pytest` — 757 passed (1 pre-existing unrelated failure in test_kimi_agent_real.py)
- [x] `uv run ruff check zima/ tests/` — clean
- [x] `uv run black --check zima/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)