### PR TITLE
fix(scenes): change code-review template to use stable trigger keyword

### DIFF
--- a/zima/scenes.py
+++ b/zima/scenes.py
@@ -36,7 +36,7 @@ BUILTIN_SCENES: dict[str, Scene] = {
     "code-review": Scene(
         name="Code Review",
         description="Review PRs/MRs with AI agent",
-        workflow_template="CR {{ pr_url }}",
+        workflow_template="review pr {{ pr_url }}",
         variables={"pr_url": ""},
         provider="github",
         scan_command=[


### PR DESCRIPTION
## Summary

Change the `code-review` quickstart scene's workflow template from `CR {{ pr_url }}` to `review pr {{ pr_url }}` to ensure stable activation of the github-code-review skill.

## Problem

The old template generated prompts like `CR https://github.com/owner/repo/pull/123`, but `CR` is not in the github-code-review skill's trigger keyword list (`review pr`, `审查 pr`, `pr review`, `github review`, `review pull request`). This caused unstable skill activation — sometimes the skill would trigger, sometimes it wouldn't, depending on fuzzy matching behavior.

## Fix

The new template generates `review pr https://github.com/owner/repo/pull/123`, which directly matches the first trigger keyword `review pr` for reliable activation.

## Test Plan

- [x] All existing tests pass
- [x] ruff lint passes
- [x] black formatting passes

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)