### PR TITLE
feat: PR code review automation with preExec actions and label management (#35)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,13 +70,13 @@ The core design is composability through seven YAML-based configuration types:
 - **`zima/core/kimi_runner.py`** / **`zima/core/claude_runner.py`** — Agent-specific subprocess runners for Kimi and Claude.
 - **`zima/execution/background_runner.py`** — Background PJob execution in detached process.
 - **`zima/execution/history.py`** — Execution history tracking with PID recording.
-- **`zima/execution/actions_runner.py`** — `ActionsRunner`: executes postExec actions through configured provider after agent exit.
-- **`zima/actions/base.py`** — `ActionProvider` ABC — interface all providers implement.
+- **`zima/execution/actions_runner.py`** — `ActionsRunner`: executes preExec actions before agent starts and postExec actions after agent exit. Supports `SkipAction` to short-circuit execution when preExec finds no work.
+- **`zima/actions/base.py`** — `ActionProvider` ABC — interface all providers implement (add_label, remove_label, post_comment, fetch_diff, scan_prs).
 - **`zima/actions/registry.py`** — `ProviderRegistry`: loads built-in + discovers external providers via `importlib.metadata.entry_points`.
 - **`zima/actions/exceptions.py`** — `ProviderNotFoundError`, `ProviderError`.
 - **`zima/providers/__init__.py`** — `BUILTIN_PROVIDERS` dict.
-- **`zima/providers/github.py`** — `GitHubProvider`: wraps `gh` CLI for label/comment/diff operations.
-- **`zima/models/actions.py`** — `PostExecAction` / `ActionsConfig`: dataclasses for PJob post-execution automation.
+- **`zima/providers/github.py`** — `GitHubProvider`: wraps `gh` CLI for label/comment/diff/scan_prs operations.
+- **`zima/models/actions.py`** — `PreExecAction` / `PostExecAction` / `ActionsConfig`: dataclasses for PJob pre-execution and post-execution automation.
 - **`zima/scenes.py`** — `Scene` dataclass, `load_scenes()` merges built-in scenes with user-defined `~/.zima/scenes.yaml`.
 - **`zima/daemon_runner.py`** — Entry point for detached daemon process (`python -m zima.daemon_runner`).
 - **`zima/core/daemon_scheduler.py`** — `DaemonScheduler`: 32-cycle PJob scheduling with stage timers, PJob spawn/kill, JSONL history.
@@ -90,6 +90,8 @@ zima pjob run <code>
   → Resolves referenced Agent/Workflow/Variable/Env/PMG
   → Renders Workflow template with Variables
   → Builds CLI command from Agent parameters
+  → Runs preExec actions (e.g., scan_pr) before agent starts
+     → If SkipAction raised, returns ExecutionResult(status=SKIPPED)
   → Executes subprocess (kimi/claude)
   → Runs postExec actions through configured provider (label/comment) in finally block
   → Captures output, stores execution history centrally

--- a/scripts/init_labels.py
+++ b/scripts/init_labels.py
@@ -33,16 +33,25 @@ def run_gh(args: list[str]) -> subprocess.CompletedProcess:
         capture_output=True,
         text=True,
         check=False,
+        stdin=subprocess.DEVNULL,
     )
     return result
 
 
-def label_exists(repo: str, name: str) -> bool:
-    """Check if a label already exists in the repo."""
+def list_labels(repo: str) -> list[dict]:
+    """List all labels in the repo. Returns empty list on error."""
     result = run_gh(["label", "list", "--repo", repo, "--json", "name"])
     if result.returncode != 0:
-        return False
-    existing = json.loads(result.stdout)
+        return []
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+
+
+def label_exists(repo: str, name: str) -> bool:
+    """Check if a label already exists in the repo."""
+    existing = list_labels(repo)
     return any(item["name"] == name for item in existing)
 
 
@@ -103,9 +112,14 @@ def main():
     skipped = 0
     failed = 0
 
+    # In dry-run, list labels once to avoid repeated API calls
+    existing_labels = set()
+    if args.dry_run:
+        existing_labels = {item["name"] for item in list_labels(args.repo)}
+
     for label in LABELS:
         if args.dry_run:
-            exists = label_exists(args.repo, label["name"])
+            exists = label["name"] in existing_labels
             if exists and not args.force:
                 print(f"  [DRY-RUN] Would skip: {label['name']} (exists)")
                 skipped += 1

--- a/scripts/init_labels.py
+++ b/scripts/init_labels.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Initialize zima PR labels in a GitHub repository.
+
+Usage:
+    python scripts/init_labels.py --repo owner/repo
+    python scripts/init_labels.py --repo owner/repo --force
+    python scripts/init_labels.py --repo owner/repo --dry-run
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+LABELS = [
+    {"name": "zima:needs-review", "color": "0969DA", "description": "等待 code review"},
+    {"name": "zima:needs-fix", "color": "CF222E", "description": "CR 发现问题，需要修复"},
+    {"name": "zima:needs-re-review", "color": "BC4C00", "description": "fix 后等待重新 review"},
+    {
+        "name": "zima:wait-human-merge",
+        "color": "2DA44E",
+        "description": "CR 阶段完成，等待人工 merge",
+    },
+    {"name": "zima:jesus-help", "color": "8250DF", "description": "循环超限，需人工介入"},
+]
+
+
+def run_gh(args: list[str]) -> subprocess.CompletedProcess:
+    """Run gh CLI command."""
+    result = subprocess.run(
+        ["gh"] + args,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result
+
+
+def label_exists(repo: str, name: str) -> bool:
+    """Check if a label already exists in the repo."""
+    result = run_gh(["label", "list", "--repo", repo, "--json", "name"])
+    if result.returncode != 0:
+        return False
+    existing = json.loads(result.stdout)
+    return any(item["name"] == name for item in existing)
+
+
+def create_label(repo: str, label: dict, force: bool = False) -> str:
+    """Create a single label. Returns 'created', 'skipped', or 'failed'."""
+    name = label["name"]
+    exists = label_exists(repo, name)
+
+    if exists and not force:
+        print(f"  [SKIP] {name} already exists")
+        return "skipped"
+
+    if exists and force:
+        # Delete and recreate
+        run_gh(["label", "delete", name, "--repo", repo, "--yes"])
+        print(f"  [DELETE] {name} (force mode)")
+
+    result = run_gh(
+        [
+            "label",
+            "create",
+            name,
+            "--repo",
+            repo,
+            "--color",
+            label["color"],
+            "--description",
+            label["description"],
+        ]
+    )
+
+    if result.returncode == 0:
+        print(f"  [OK] {name} (#{label['color']})")
+        return "created"
+    else:
+        print(f"  [FAIL] {name}: {result.stderr.strip()}")
+        return "failed"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Initialize zima PR labels")
+    parser.add_argument("--repo", required=True, help="Repository in owner/repo format")
+    parser.add_argument("--force", action="store_true", help="Recreate existing labels")
+    parser.add_argument("--dry-run", action="store_true", help="Preview only")
+    args = parser.parse_args()
+
+    # Validate gh is available
+    result = run_gh(["--version"])
+    if result.returncode != 0:
+        print("[ERROR] gh CLI not found. Install from https://cli.github.com/")
+        sys.exit(1)
+
+    print(f"Initializing zima labels for {args.repo}...")
+    if args.dry_run:
+        print("[DRY-RUN] No changes will be made")
+
+    created = 0
+    skipped = 0
+    failed = 0
+
+    for label in LABELS:
+        if args.dry_run:
+            exists = label_exists(args.repo, label["name"])
+            if exists and not args.force:
+                print(f"  [DRY-RUN] Would skip: {label['name']} (exists)")
+                skipped += 1
+            else:
+                action = "recreate" if exists else "create"
+                print(f"  [DRY-RUN] Would {action}: {label['name']} (#{label['color']})")
+                created += 1
+        else:
+            status = create_label(args.repo, label, force=args.force)
+            if status == "created":
+                created += 1
+            elif status == "skipped":
+                skipped += 1
+            else:
+                failed += 1
+
+    print(f"\nDone: {created} created, {skipped} skipped, {failed} failed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_actions_base.py
+++ b/tests/unit/test_actions_base.py
@@ -24,12 +24,16 @@ class TestActionProvider:
             def fetch_diff(self, repo: str, issue: str) -> str:
                 return "diff"
 
+            def scan_prs(self, repo: str, label: str) -> list[dict]:
+                return []
+
         provider = TestProvider()
         assert provider.name == "test"
         provider.add_label("o/r", "1", "bug")
         provider.remove_label("o/r", "1", "bug")
         provider.post_comment("o/r", "1", "ok")
         assert provider.fetch_diff("o/r", "1") == "diff"
+        assert provider.scan_prs("o/r", "bug") == []
 
     def test_abstract_methods_must_be_implemented(self):
         """Test that missing abstract methods prevent instantiation."""

--- a/tests/unit/test_actions_runner.py
+++ b/tests/unit/test_actions_runner.py
@@ -270,3 +270,28 @@ class TestActionsRunnerPreExec:
             assert "Warning" in captured.out
             assert "nonexistent" in captured.out
             assert env == {"existing": "value"}
+
+    def test_run_pre_exec_env_substitution(self):
+        """Test env variable substitution in run_pre before calling scan_prs."""
+        from zima.models.actions import PreExecAction
+
+        runner = ActionsRunner()
+        actions = ActionsConfig(
+            pre_exec=[
+                PreExecAction(
+                    type="scan_pr",
+                    repo="{{repo}}",
+                    label="{{label}}",
+                )
+            ]
+        )
+        mock_provider = MagicMock()
+        mock_provider.scan_prs.return_value = [
+            {"number": "7", "title": "Test", "url": "https://github.com/o/r/pull/7"}
+        ]
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            env = {"repo": "my-org/my-repo", "label": "needs-review"}
+            runner.run_pre(actions, env)
+            mock_provider.scan_prs.assert_called_once_with("my-org/my-repo", "needs-review")
+            assert env["repo"] == "my-org/my-repo"
+            assert env["pr_number"] == "7"

--- a/tests/unit/test_actions_runner.py
+++ b/tests/unit/test_actions_runner.py
@@ -1,7 +1,9 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from zima.actions.exceptions import ProviderNotFoundError
-from zima.execution.actions_runner import ActionsRunner, _matches_condition
+from zima.execution.actions_runner import ActionsRunner, SkipAction, _matches_condition
 from zima.models.actions import ActionsConfig, PostExecAction
 
 
@@ -204,3 +206,67 @@ class TestActionsRunner:
             captured = capsys.readouterr()
             assert "Warning" in captured.out
             assert "nonexistent" in captured.out
+
+
+class TestActionsRunnerPreExec:
+    def test_run_pre_exec_scan_pr(self):
+        """Test running preExec scan_pr action."""
+        from zima.models.actions import PreExecAction
+
+        runner = ActionsRunner()
+        actions = ActionsConfig(
+            pre_exec=[
+                PreExecAction(
+                    type="scan_pr",
+                    repo="owner/repo",
+                    label="zima:needs-review",
+                )
+            ]
+        )
+        mock_provider = MagicMock()
+        mock_provider.scan_prs.return_value = [
+            {"number": "42", "title": "Fix", "url": "https://github.com/o/r/pull/42"}
+        ]
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            env = {}
+            runner.run_pre(actions, env)
+            mock_provider.scan_prs.assert_called_once_with("owner/repo", "zima:needs-review")
+            assert env["pr_number"] == "42"
+            assert env["pr_title"] == "Fix"
+            assert env["pr_url"] == "https://github.com/o/r/pull/42"
+
+    def test_run_pre_exec_empty_result(self):
+        """Test preExec scan_pr with no results raises SkipAction."""
+        from zima.models.actions import PreExecAction
+
+        runner = ActionsRunner()
+        actions = ActionsConfig(
+            pre_exec=[PreExecAction(type="scan_pr", repo="owner/repo", label="x")]
+        )
+        mock_provider = MagicMock()
+        mock_provider.scan_prs.return_value = []
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            with pytest.raises(SkipAction) as exc_info:
+                runner.run_pre(actions, {})
+            assert "no prs found" in str(exc_info.value).lower()
+
+    def test_run_pre_provider_not_found(self, capsys):
+        """Test run_pre warns and returns when provider is not found."""
+        from zima.models.actions import PreExecAction
+
+        runner = ActionsRunner()
+        actions = ActionsConfig(
+            provider="nonexistent",
+            pre_exec=[PreExecAction(type="scan_pr", repo="owner/repo", label="x")],
+        )
+        with patch.object(
+            runner._registry,
+            "get",
+            side_effect=ProviderNotFoundError("Provider 'nonexistent' not found"),
+        ):
+            env = {"existing": "value"}
+            runner.run_pre(actions, env)
+            captured = capsys.readouterr()
+            assert "Warning" in captured.out
+            assert "nonexistent" in captured.out
+            assert env == {"existing": "value"}

--- a/tests/unit/test_examples.py
+++ b/tests/unit/test_examples.py
@@ -286,11 +286,16 @@ class TestReviewerPJob:
         assert config.spec.agent == "kimi-standard"
         assert config.spec.workflow == "reviewer-cr"
         assert config.spec.variable == "reviewer-vars"
+        assert len(config.spec.actions.pre_exec) == 1
+        # Pre action: scan_pr
+        assert config.spec.actions.pre_exec[0].type == "scan_pr"
+        assert config.spec.actions.pre_exec[0].repo == "{{repo}}"
+        assert config.spec.actions.pre_exec[0].label == "zima:needs-review"
         assert len(config.spec.actions.post_exec) == 2
         # First action: success -> add_label
         assert config.spec.actions.post_exec[0].condition == "success"
         assert config.spec.actions.post_exec[0].type == "add_label"
-        assert "zima:review-approved" in config.spec.actions.post_exec[0].add_labels
+        assert config.spec.actions.post_exec[0].add_labels == []
         assert "zima:needs-review" in config.spec.actions.post_exec[0].remove_labels
         assert config.spec.actions.post_exec[0].repo == "{{repo}}"
         assert config.spec.actions.post_exec[0].issue == "{{pr_number}}"

--- a/tests/unit/test_executor_preexec.py
+++ b/tests/unit/test_executor_preexec.py
@@ -1,0 +1,170 @@
+"""Unit tests for PJobExecutor preExec integration."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from zima.execution.actions_runner import SkipAction
+from zima.execution.executor import ExecutionStatus, PJobExecutor
+from zima.models.actions import ActionsConfig, PreExecAction
+from zima.models.agent import AgentConfig
+from zima.models.pjob import PJobConfig
+from zima.models.workflow import WorkflowConfig
+
+
+class TestPreExecIntegration:
+    """Test preExec action integration in PJobExecutor.execute()."""
+
+    @pytest.fixture
+    def mock_pjob_with_pre_exec(self, isolated_zima_home):
+        """Create a PJobConfig with pre_exec actions and save required configs."""
+        from zima.config.manager import ConfigManager
+
+        manager = ConfigManager()
+
+        # Save agent config
+        agent = AgentConfig.create(
+            code="test-agent",
+            name="Test Agent",
+            agent_type="kimi",
+            parameters={"mockCommand": "echo hello"},
+        )
+        manager.save_config("agent", "test-agent", agent.to_dict())
+
+        # Save workflow config
+        workflow = WorkflowConfig.create(
+            code="test-workflow",
+            name="Test Workflow",
+            template="Hello {{ name }}",
+        )
+        manager.save_config("workflow", "test-workflow", workflow.to_dict())
+
+        # Create PJob with pre_exec actions
+        pjob = PJobConfig.create(
+            code="test-pjob",
+            name="Test PJob",
+            agent="test-agent",
+            workflow="test-workflow",
+        )
+        pjob.spec.actions = ActionsConfig(
+            provider="github",
+            pre_exec=[
+                PreExecAction(
+                    type="scan_pr",
+                    repo="owner/repo",
+                    label="ready-for-review",
+                )
+            ],
+        )
+        manager.save_config("pjob", "test-pjob", pjob.to_dict())
+
+        return pjob
+
+    def test_run_pre_exec_skipped(self, mock_pjob_with_pre_exec, isolated_zima_home):
+        """Test that SkipAction from preExec returns SKIPPED status."""
+        executor = PJobExecutor()
+
+        with patch.object(
+            executor._actions_runner,
+            "run_pre",
+            side_effect=SkipAction("No PRs found with label 'ready-for-review' in owner/repo"),
+        ):
+            result = executor.execute("test-pjob")
+
+        assert result.status == ExecutionStatus.SKIPPED
+        assert result.returncode == 0
+        assert "No PRs found" in result.stderr
+        assert result.stdout == ""
+        # Command is built before preExec runs; agent subprocess is skipped
+
+    def test_run_pre_exec_success(self, mock_pjob_with_pre_exec, isolated_zima_home):
+        """Test that successful preExec allows agent execution to proceed."""
+        executor = PJobExecutor()
+
+        with patch.object(executor._actions_runner, "run_pre") as mock_run_pre:
+            with patch.object(executor, "_run_command") as mock_run_command:
+                mock_run_command.return_value = (0, "hello output", "", 12345)
+
+                result = executor.execute("test-pjob")
+
+        mock_run_pre.assert_called_once()
+        mock_run_command.assert_called_once()
+        assert result.status == ExecutionStatus.SUCCESS
+        assert result.returncode == 0
+        assert result.stdout == "hello output"
+
+    def test_run_pre_exec_no_actions(self, isolated_zima_home):
+        """Test that PJob without pre_exec actions runs normally."""
+        from zima.config.manager import ConfigManager
+
+        manager = ConfigManager()
+
+        agent = AgentConfig.create(
+            code="test-agent",
+            name="Test Agent",
+            agent_type="kimi",
+            parameters={"mockCommand": "echo hello"},
+        )
+        manager.save_config("agent", "test-agent", agent.to_dict())
+
+        workflow = WorkflowConfig.create(
+            code="test-workflow",
+            name="Test Workflow",
+            template="Hello world",
+        )
+        manager.save_config("workflow", "test-workflow", workflow.to_dict())
+
+        pjob = PJobConfig.create(
+            code="test-pjob",
+            name="Test PJob",
+            agent="test-agent",
+            workflow="test-workflow",
+        )
+        manager.save_config("pjob", "test-pjob", pjob.to_dict())
+
+        executor = PJobExecutor()
+
+        with patch.object(executor._actions_runner, "run_pre") as mock_run_pre:
+            with patch.object(executor, "_run_command") as mock_run_command:
+                mock_run_command.return_value = (0, "hello output", "", 12345)
+
+                result = executor.execute("test-pjob")
+
+        mock_run_pre.assert_not_called()
+        mock_run_command.assert_called_once()
+        assert result.status == ExecutionStatus.SUCCESS
+
+    def test_run_pre_exec_mutates_env(self, mock_pjob_with_pre_exec, isolated_zima_home):
+        """Test that preExec can mutate env vars (e.g., inject PR info)."""
+        executor = PJobExecutor()
+
+        with patch.object(
+            executor._actions_runner,
+            "run_pre",
+            side_effect=lambda actions, env: env.update({"pr_number": "42", "pr_title": "Test PR"}),
+        ):
+            with patch.object(executor, "_run_command") as mock_run_command:
+                mock_run_command.return_value = (0, "hello output", "", 12345)
+
+                result = executor.execute("test-pjob")
+
+        assert result.status == ExecutionStatus.SUCCESS
+        assert result.env.get("pr_number") == "42"
+        assert result.env.get("pr_title") == "Test PR"
+
+    def test_run_pre_exec_failure(self, mock_pjob_with_pre_exec, isolated_zima_home):
+        """Test that non-SkipAction exception from preExec returns FAILED status."""
+        executor = PJobExecutor()
+
+        with patch.object(
+            executor._actions_runner,
+            "run_pre",
+            side_effect=RuntimeError("GitHub API rate limit exceeded"),
+        ):
+            result = executor.execute("test-pjob")
+
+        assert result.status == ExecutionStatus.FAILED
+        assert result.returncode == 1
+        assert "GitHub API rate limit exceeded" in result.stderr

--- a/tests/unit/test_models_actions.py
+++ b/tests/unit/test_models_actions.py
@@ -1,4 +1,4 @@
-from zima.models.actions import ActionsConfig, PostExecAction
+from zima.models.actions import ActionsConfig, PostExecAction, PreExecAction
 
 
 class TestPostExecAction:
@@ -171,3 +171,55 @@ class TestActionsConfig:
         errors = config.validate()
         assert len(errors) == 2
         assert "Action[1]" in errors[0]
+
+
+class TestPreExecAction:
+    def test_default_action(self):
+        """Test creating a PreExecAction with default values."""
+        action = PreExecAction()
+        assert action.type == "scan_pr"
+        assert action.condition == "always"
+        assert action.repo == ""
+        assert action.label == ""
+
+    def test_full_action(self):
+        """Test creating a fully configured PreExecAction."""
+        action = PreExecAction(
+            type="scan_pr",
+            repo="owner/repo",
+            label="zima:needs-review",
+        )
+        assert action.type == "scan_pr"
+        assert action.repo == "owner/repo"
+        assert action.label == "zima:needs-review"
+
+    def test_to_dict(self):
+        """Test converting PreExecAction to dictionary."""
+        action = PreExecAction(type="scan_pr", repo="o/r", label="x")
+        d = action.to_dict()
+        assert d["type"] == "scan_pr"
+        assert d["repo"] == "o/r"
+        assert d["label"] == "x"
+
+
+class TestActionsConfigPreExec:
+    def test_pre_exec_field(self):
+        """Test ActionsConfig with pre_exec field."""
+        pre = PreExecAction(type="scan_pr", repo="o/r", label="x")
+        config = ActionsConfig(pre_exec=[pre])
+        assert len(config.pre_exec) == 1
+        assert config.pre_exec[0].type == "scan_pr"
+
+    def test_to_dict_includes_pre_exec(self):
+        """Test that to_dict includes preExec when non-empty."""
+        config = ActionsConfig(pre_exec=[PreExecAction(type="scan_pr", repo="o/r")])
+        d = config.to_dict()
+        assert "preExec" in d
+        assert len(d["preExec"]) == 1
+
+    def test_from_dict_reads_pre_exec(self):
+        """Test that from_dict reads preExec field."""
+        d = {"preExec": [{"type": "scan_pr", "repo": "o/r", "label": "x"}]}
+        config = ActionsConfig.from_dict(d)
+        assert len(config.pre_exec) == 1
+        assert config.pre_exec[0].type == "scan_pr"

--- a/tests/unit/test_providers_github.py
+++ b/tests/unit/test_providers_github.py
@@ -22,14 +22,16 @@ class TestGitHubProvider:
             provider.add_label("owner/repo", "123", "zima:needs-fix")
             mock_run.assert_called_once()
             args = mock_run.call_args[0][0]
-            assert "gh" in args
-            assert "issue" in args
-            assert "edit" in args
-            assert "123" in args
-            assert "--add-label" in args
-            assert "zima:needs-fix" in args
-            assert "--repo" in args
-            assert "owner/repo" in args
+            assert args == [
+                "gh",
+                "issue",
+                "edit",
+                "123",
+                "--add-label",
+                "zima:needs-fix",
+                "--repo",
+                "owner/repo",
+            ]
             assert mock_run.call_args[1].get("stdin") == subprocess.DEVNULL
 
     def test_remove_label(self):
@@ -40,8 +42,16 @@ class TestGitHubProvider:
             provider.remove_label("owner/repo", "123", "zima:needs-review")
             mock_run.assert_called_once()
             args = mock_run.call_args[0][0]
-            assert "--remove-label" in args
-            assert "zima:needs-review" in args
+            assert args == [
+                "gh",
+                "issue",
+                "edit",
+                "123",
+                "--remove-label",
+                "zima:needs-review",
+                "--repo",
+                "owner/repo",
+            ]
 
     def test_post_comment(self):
         """Verify correct gh issue comment args."""
@@ -50,9 +60,16 @@ class TestGitHubProvider:
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
             provider.post_comment("owner/repo", "123", "Review done")
             args = mock_run.call_args[0][0]
-            assert "comment" in args
-            assert "--body" in args
-            assert "Review done" in args
+            assert args == [
+                "gh",
+                "issue",
+                "comment",
+                "123",
+                "--body",
+                "Review done",
+                "--repo",
+                "owner/repo",
+            ]
 
     def test_post_comment_multiline(self):
         """Verify --body flag used for multiline comments."""
@@ -61,7 +78,16 @@ class TestGitHubProvider:
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
             provider.post_comment("owner/repo", "123", "Line 1\nLine 2")
             args = mock_run.call_args[0][0]
-            assert "--body" in args
+            assert args == [
+                "gh",
+                "issue",
+                "comment",
+                "123",
+                "--body",
+                "Line 1\nLine 2",
+                "--repo",
+                "owner/repo",
+            ]
 
     def test_add_label_failure_raises(self):
         """Verify RuntimeError on gh failure."""
@@ -81,10 +107,15 @@ class TestGitHubProvider:
             diff = provider.fetch_diff("owner/repo", "123")
             assert diff == "diff --git a/foo.py b/foo.py"
             args = mock_run.call_args[0][0]
-            assert "pr" in args
-            assert "view" in args
-            assert "--patch" in args
-            assert "123" in args
+            assert args == [
+                "gh",
+                "pr",
+                "view",
+                "123",
+                "--repo",
+                "owner/repo",
+                "--patch",
+            ]
 
     def test_fetch_diff_failure_returns_empty(self):
         """Verify fetch_diff returns empty string on gh failure."""
@@ -93,3 +124,55 @@ class TestGitHubProvider:
             mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="not found")
             diff = provider.fetch_diff("owner/repo", "123")
             assert diff == ""
+
+    def test_scan_prs(self):
+        """Verify scan_prs calls gh pr list with correct args."""
+        provider = GitHubProvider()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout='[{"number":42,"title":"Fix bug","url":"https://github.com/o/r/pull/42"}]',
+                stderr="",
+            )
+            prs = provider.scan_prs("owner/repo", "zima:needs-review")
+            assert len(prs) == 1
+            assert prs[0]["number"] == 42
+            assert prs[0]["url"] == "https://github.com/o/r/pull/42"
+            args = mock_run.call_args[0][0]
+            assert args == [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                "owner/repo",
+                "--label",
+                "zima:needs-review",
+                "--state",
+                "open",
+                "--json",
+                "number,title,url,headRefName",
+            ]
+
+    def test_scan_prs_empty(self):
+        """Verify scan_prs returns empty list when no PRs match."""
+        provider = GitHubProvider()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="[]", stderr="")
+            prs = provider.scan_prs("owner/repo", "zima:needs-review")
+            assert prs == []
+
+    def test_scan_prs_failure_raises(self):
+        """Verify RuntimeError on gh failure."""
+        provider = GitHubProvider()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="API error")
+            with pytest.raises(RuntimeError, match="gh CLI failed"):
+                provider.scan_prs("owner/repo", "zima:needs-review")
+
+    def test_scan_prs_invalid_json_raises(self):
+        """Verify RuntimeError on invalid JSON output."""
+        provider = GitHubProvider()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="not-json", stderr="")
+            with pytest.raises(RuntimeError, match="Failed to parse gh pr list output"):
+                provider.scan_prs("owner/repo", "zima:needs-review")

--- a/tests/unit/test_review_parser.py
+++ b/tests/unit/test_review_parser.py
@@ -84,7 +84,7 @@ class TestReviewParser:
         """Test parsing invalid XML returns fallback result."""
         result = ReviewParser.parse("<zima-review><unclosed>")
         assert result.verdict == "needs_discussion"
-        assert "Invalid" in result.summary
+        assert "No review block" in result.summary
 
     def test_parse_empty_issues(self):
         """Test parsing a review with explicit empty issues list."""
@@ -111,3 +111,23 @@ class TestReviewParser:
         stdout = '<zima-review><verdict>needs_fix</verdict><summary>x</summary><issues><issue severity="error" file="a.py" line="abc">msg</issue></issues></zima-review>'
         result = ReviewParser.parse(stdout)
         assert result.issues[0].line == 0
+
+    def test_parse_skill_no_issues_found(self):
+        """Test fallback when agent outputs 'No issues found' (skill pattern)."""
+        stdout = "Some review output...\n### Code Review\n\nNo issues found. Checked for bugs, CLAUDE.md and AGENTS.md compliance.\n🤖 Generated with Kimi Code CLI"
+        result = ReviewParser.parse(stdout)
+        assert result.verdict == "approved"
+        assert "No issues found" in result.summary
+
+    def test_parse_skill_found_n_issues(self):
+        """Test fallback when agent outputs 'Found N issues' (skill pattern)."""
+        stdout = "Some review output...\n### Code Review\n\nFound 3 issues:\n\n1. Missing error handling (bug)\n\nhttps://github.com/o/r/blob/abc/src/auth.ts#L67-L72\n\n🤖 Generated with Kimi Code CLI"
+        result = ReviewParser.parse(stdout)
+        assert result.verdict == "needs_fix"
+        assert "Found 3 issues" in result.summary
+
+    def test_parse_skill_found_zero_issues(self):
+        """Edge case: 'Found 0 issues' should map to approved."""
+        stdout = "Found 0 issues"
+        result = ReviewParser.parse(stdout)
+        assert result.verdict == "approved"

--- a/zima/actions/base.py
+++ b/zima/actions/base.py
@@ -29,6 +29,7 @@ class ActionProvider(ABC):
     def fetch_diff(self, repo: str, issue: str) -> str:
         """Fetch PR/MR diff content. Returns empty string on failure."""
 
+    @abstractmethod
     def scan_prs(self, repo: str, label: str) -> list[dict]:
         """Scan PRs by label.
 

--- a/zima/actions/base.py
+++ b/zima/actions/base.py
@@ -28,3 +28,15 @@ class ActionProvider(ABC):
     @abstractmethod
     def fetch_diff(self, repo: str, issue: str) -> str:
         """Fetch PR/MR diff content. Returns empty string on failure."""
+
+    def scan_prs(self, repo: str, label: str) -> list[dict]:
+        """Scan PRs by label.
+
+        Args:
+            repo: Repository in "owner/repo" format.
+            label: Label to filter by.
+
+        Returns:
+            List of PR dictionaries with at least 'number', 'title', 'url'.
+        """
+        raise NotImplementedError

--- a/zima/execution/actions_runner.py
+++ b/zima/execution/actions_runner.py
@@ -139,10 +139,7 @@ class ActionsRunner:
             if action.type == "scan_pr":
                 repo = self._substitute_env_str(action.repo, env)
                 label = self._substitute_env_str(action.label, env)
-                try:
-                    prs = provider.scan_prs(repo, label)
-                except Exception as e:
-                    raise SkipAction(f"Failed to scan PRs with label '{label}' in {repo}: {e}")
+                prs = provider.scan_prs(repo, label)
                 if not prs:
                     raise SkipAction(f"No PRs found with label '{label}' in {repo}")
                 # Take the first PR and inject into env

--- a/zima/execution/actions_runner.py
+++ b/zima/execution/actions_runner.py
@@ -1,4 +1,4 @@
-"""Actions runner for executing postExec actions after agent process exits."""
+"""Actions runner for executing preExec and postExec actions around agent execution."""
 
 from __future__ import annotations
 
@@ -8,6 +8,12 @@ from zima.actions.base import ActionProvider
 from zima.actions.exceptions import ProviderNotFoundError
 from zima.actions.registry import ProviderRegistry, get_default_registry
 from zima.models.actions import ActionsConfig, PostExecAction
+
+
+class SkipAction(Exception):
+    """Raised when a preExec action indicates the PJob should be skipped."""
+
+    pass
 
 
 def _matches_condition(condition: str, returncode: int) -> bool:
@@ -30,7 +36,7 @@ def _matches_condition(condition: str, returncode: int) -> bool:
 
 
 class ActionsRunner:
-    """Executes postExec actions after agent process exits.
+    """Executes preExec and postExec actions around agent execution.
 
     Handles condition matching, environment variable substitution,
     and action dispatch to the configured provider.
@@ -106,3 +112,36 @@ class ActionsRunner:
                     provider.post_comment(action.repo, action.issue, action.body)
                 except Exception as e:
                     print(f"Warning: Failed to post comment: {e}")
+
+    def run_pre(self, actions: ActionsConfig, env: dict[str, str]) -> None:
+        """Execute all preExec actions, mutating env with scan results.
+
+        Args:
+            actions: Actions configuration from PJob.
+            env: Mutable environment dict for variable substitution.
+
+        Raises:
+            SkipAction: If a preExec action indicates no work to do.
+        """
+        try:
+            provider = self._registry.get(actions.provider)
+        except ProviderNotFoundError as e:
+            print(f"Warning: {e}")
+            return
+
+        for action in actions.pre_exec:
+            if action.type == "scan_pr":
+                try:
+                    prs = provider.scan_prs(action.repo, action.label)
+                except Exception as e:
+                    raise SkipAction(
+                        f"Failed to scan PRs with label '{action.label}' in {action.repo}: {e}"
+                    )
+                if not prs:
+                    raise SkipAction(f"No PRs found with label '{action.label}' in {action.repo}")
+                # Take the first PR and inject into env
+                pr = prs[0]
+                env["repo"] = action.repo
+                env["pr_number"] = str(pr.get("number", ""))
+                env["pr_title"] = pr.get("title", "")
+                env["pr_url"] = pr.get("url", "")

--- a/zima/execution/actions_runner.py
+++ b/zima/execution/actions_runner.py
@@ -113,6 +113,12 @@ class ActionsRunner:
                 except Exception as e:
                     print(f"Warning: Failed to post comment: {e}")
 
+    def _substitute_env_str(self, value: str, env: dict[str, str]) -> str:
+        """Replace {{VAR}} placeholders with env values."""
+        for key, val in env.items():
+            value = value.replace(f"{{{{{key}}}}}", str(val))
+        return value
+
     def run_pre(self, actions: ActionsConfig, env: dict[str, str]) -> None:
         """Execute all preExec actions, mutating env with scan results.
 
@@ -131,17 +137,17 @@ class ActionsRunner:
 
         for action in actions.pre_exec:
             if action.type == "scan_pr":
+                repo = self._substitute_env_str(action.repo, env)
+                label = self._substitute_env_str(action.label, env)
                 try:
-                    prs = provider.scan_prs(action.repo, action.label)
+                    prs = provider.scan_prs(repo, label)
                 except Exception as e:
-                    raise SkipAction(
-                        f"Failed to scan PRs with label '{action.label}' in {action.repo}: {e}"
-                    )
+                    raise SkipAction(f"Failed to scan PRs with label '{label}' in {repo}: {e}")
                 if not prs:
-                    raise SkipAction(f"No PRs found with label '{action.label}' in {action.repo}")
+                    raise SkipAction(f"No PRs found with label '{label}' in {repo}")
                 # Take the first PR and inject into env
                 pr = prs[0]
-                env["repo"] = action.repo
+                env["repo"] = repo
                 env["pr_number"] = str(pr.get("number", ""))
                 env["pr_title"] = pr.get("title", "")
                 env["pr_url"] = pr.get("url", "")

--- a/zima/execution/actions_runner.py
+++ b/zima/execution/actions_runner.py
@@ -148,6 +148,8 @@ class ActionsRunner:
                 # Take the first PR and inject into env
                 pr = prs[0]
                 env["repo"] = repo
-                env["pr_number"] = str(pr.get("number", ""))
-                env["pr_title"] = pr.get("title", "")
-                env["pr_url"] = pr.get("url", "")
+                env["pr_number"] = str(pr.get("number") or "")
+                env["pr_title"] = pr.get("title") or ""
+                env["pr_url"] = pr.get("url") or ""
+            else:
+                print(f"Warning: Unknown preExec action type '{action.type}', skipping")

--- a/zima/execution/executor.py
+++ b/zima/execution/executor.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Optional
 
 from zima.config.manager import ConfigManager
-from zima.execution.actions_runner import ActionsRunner
+from zima.execution.actions_runner import ActionsRunner, SkipAction
 from zima.models.config_bundle import ConfigBundle
 from zima.models.pjob import Overrides, PJobConfig
 from zima.review.parser import ReviewParser
@@ -29,6 +29,7 @@ class ExecutionStatus(Enum):
     FAILED = "failed"
     TIMEOUT = "timeout"
     CANCELLED = "cancelled"
+    SKIPPED = "skipped"
 
 
 @dataclass
@@ -132,14 +133,18 @@ class PJobExecutor:
 
     Handles the complete execution flow:
     1. Load PJob configuration
-    2. Resolve and combine all referenced configs
-    3. Render workflow template with variables
-    4. Resolve environment variables and secrets
-    5. Build agent command with parameters
-    6. Execute pre-hooks
-    7. Run agent command
-    8. Execute post-hooks
-    9. Handle output and cleanup
+    2. Resolve config bundle
+    3. Create temp directory
+    4. Render workflow template
+    5. Resolve environment variables
+    6. Build agent command
+    7. Dry run check
+    8. Execute pre-hooks
+    9. Execute preExec actions
+    10. Run main command
+    11. Execute post-hooks
+    12. Handle output and cleanup
+    13. Execute postExec actions
     """
 
     def __init__(self):
@@ -211,7 +216,18 @@ class PJobExecutor:
             # 8. Execute pre-hooks
             self._run_hooks(pjob.spec.hooks.get("preExec", []), env_vars, bundle.work_dir)
 
-            # 9. Run main command
+            # 9. Execute preExec actions
+            if pjob.spec.actions and pjob.spec.actions.pre_exec:
+                try:
+                    self._actions_runner.run_pre(pjob.spec.actions, env_vars)
+                except SkipAction as e:
+                    result.status = ExecutionStatus.SKIPPED
+                    result.returncode = 0
+                    result.stderr = str(e)
+                    result.finished_at = generate_timestamp()
+                    return result
+
+            # 10. Run main command
             result.status = ExecutionStatus.RUNNING
             self._current_process = None
 
@@ -232,7 +248,7 @@ class PJobExecutor:
             result.pid = process_pid
             result.status = ExecutionStatus.SUCCESS if returncode == 0 else ExecutionStatus.FAILED
 
-            # 10. Execute post-hooks
+            # 11. Execute post-hooks
             self._run_hooks(pjob.spec.hooks.get("postExec", []), env_vars, bundle.work_dir)
 
             # 12. Handle output
@@ -263,7 +279,7 @@ class PJobExecutor:
             result.stderr = _friendly_error(e)
             result.error_detail = traceback.format_exc()
         finally:
-            # 11. Execute postExec actions even on timeout/cancel/error,
+            # 13. Execute postExec actions even on timeout/cancel/error,
             # but skip on dry-run (finally runs after return in try block).
             if not dry_run:
                 try:

--- a/zima/execution/executor.py
+++ b/zima/execution/executor.py
@@ -280,8 +280,8 @@ class PJobExecutor:
             result.error_detail = traceback.format_exc()
         finally:
             # 13. Execute postExec actions even on timeout/cancel/error,
-            # but skip on dry-run (finally runs after return in try block).
-            if not dry_run:
+            # but skip on dry-run and skipped preExec.
+            if not dry_run and result.status != ExecutionStatus.SKIPPED:
                 try:
                     _pjob = locals().get("pjob")
                     _bundle = locals().get("bundle")

--- a/zima/models/actions.py
+++ b/zima/models/actions.py
@@ -77,10 +77,10 @@ class PreExecAction(YamlSerializable):
 
     Attributes:
         condition: When to run — "always", "success", or "failure".
-        type: Action type — "scan_pr" or "run_command".
+        type: Action type — "scan_pr".
         repo: Repository slug in "owner/repo" format (for scan_pr).
         label: Label to scan for (for scan_pr).
-        command: Shell command to run (for run_command).
+        command: Reserved for future use.
     """
 
     condition: str = "always"

--- a/zima/models/actions.py
+++ b/zima/models/actions.py
@@ -8,7 +8,7 @@ from zima.models.serialization import YamlSerializable, omit_empty
 
 VALID_ACTION_CONDITIONS = {"success", "failure", "always"}
 VALID_POST_ACTION_TYPES = {"add_label", "add_comment"}
-VALID_PRE_ACTION_TYPES = {"scan_pr", "run_command"}
+VALID_PRE_ACTION_TYPES = {"scan_pr"}
 
 
 @dataclass

--- a/zima/models/actions.py
+++ b/zima/models/actions.py
@@ -1,4 +1,4 @@
-"""Post-execution action models for PJob automation."""
+"""Action models for PJob automation."""
 
 from __future__ import annotations
 
@@ -7,7 +7,8 @@ from dataclasses import dataclass, field
 from zima.models.serialization import YamlSerializable, omit_empty
 
 VALID_ACTION_CONDITIONS = {"success", "failure", "always"}
-VALID_ACTION_TYPES = {"add_label", "add_comment"}
+VALID_POST_ACTION_TYPES = {"add_label", "add_comment"}
+VALID_PRE_ACTION_TYPES = {"scan_pr", "run_command"}
 
 
 @dataclass
@@ -65,8 +66,48 @@ class PostExecAction(YamlSerializable):
         errors = []
         if self.condition not in VALID_ACTION_CONDITIONS:
             errors.append(f"Invalid condition '{self.condition}'. Valid: {VALID_ACTION_CONDITIONS}")
-        if self.type not in VALID_ACTION_TYPES:
-            errors.append(f"Invalid type '{self.type}'. Valid: {VALID_ACTION_TYPES}")
+        if self.type not in VALID_POST_ACTION_TYPES:
+            errors.append(f"Invalid type '{self.type}'. Valid: {VALID_POST_ACTION_TYPES}")
+        return errors
+
+
+@dataclass
+class PreExecAction(YamlSerializable):
+    """Single pre-execution action run before agent starts.
+
+    Attributes:
+        condition: When to run — "always", "success", or "failure".
+        type: Action type — "scan_pr" or "run_command".
+        repo: Repository slug in "owner/repo" format (for scan_pr).
+        label: Label to scan for (for scan_pr).
+        command: Shell command to run (for run_command).
+    """
+
+    condition: str = "always"
+    type: str = "scan_pr"
+    repo: str = ""
+    label: str = ""
+    command: str = ""
+
+    def to_dict(self) -> dict:
+        return omit_empty(super().to_dict())
+
+    @classmethod
+    def from_dict(cls, data: dict) -> PreExecAction:
+        """Create from dictionary and validate."""
+        action = super().from_dict(data)
+        errors = action.validate()
+        if errors:
+            raise ValueError("; ".join(errors))
+        return action
+
+    def validate(self) -> list[str]:
+        """Validate pre-execution action configuration."""
+        errors = []
+        if self.condition not in VALID_ACTION_CONDITIONS:
+            errors.append(f"Invalid condition '{self.condition}'. Valid: {VALID_ACTION_CONDITIONS}")
+        if self.type not in VALID_PRE_ACTION_TYPES:
+            errors.append(f"Invalid type '{self.type}'. Valid: {VALID_PRE_ACTION_TYPES}")
         return errors
 
 
@@ -75,15 +116,15 @@ class ActionsConfig(YamlSerializable):
     """Collection of actions for a PJob.
 
     Attributes:
-        provider: The action provider to use (default: "github"). Controls which
-            backend executes the postExec actions. Currently only "github" is
-            supported. Omitted from serialized output when set to the default.
-        post_exec: List of PostExecAction instances to run after the agent exits.
+        provider: The action provider to use (default: "github").
+        pre_exec: List of PreExecAction instances to run before the agent starts.
+        post_exec: List of PostExecAction instances to run after agent exits.
     """
 
-    FIELD_ALIASES = {"post_exec": "postExec"}
+    FIELD_ALIASES = {"pre_exec": "preExec", "post_exec": "postExec"}
 
     provider: str = "github"
+    pre_exec: list[PreExecAction] = field(default_factory=list)
     post_exec: list[PostExecAction] = field(default_factory=list)
 
     def to_dict(self) -> dict:
@@ -104,6 +145,9 @@ class ActionsConfig(YamlSerializable):
     def validate(self) -> list[str]:
         """Validate all actions."""
         errors = []
+        for i, action in enumerate(self.pre_exec):
+            action_errors = action.validate()
+            errors.extend([f"PreAction[{i}]: {e}" for e in action_errors])
         for i, action in enumerate(self.post_exec):
             action_errors = action.validate()
             errors.extend([f"Action[{i}]: {e}" for e in action_errors])

--- a/zima/providers/github.py
+++ b/zima/providers/github.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 
 from zima.actions.base import ActionProvider
@@ -88,3 +89,38 @@ class GitHubProvider(ActionProvider):
             check=False,
         )
         return result.stdout if result.returncode == 0 else ""
+
+    def scan_prs(self, repo: str, label: str) -> list[dict]:
+        """Scan PRs by label using gh CLI.
+
+        Args:
+            repo: Repository in "owner/repo" format.
+            label: Label to filter by.
+
+        Returns:
+            List of PR dictionaries with number, title, url fields.
+
+        Raises:
+            RuntimeError: If the gh CLI command fails.
+        """
+        result = self._run(
+            [
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--label",
+                label,
+                "--state",
+                "open",
+                "--json",
+                "number,title,url,headRefName",
+            ]
+        )
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as e:
+            stdout_preview = result.stdout[:200] if result.stdout else "<empty>"
+            raise RuntimeError(
+                f"Failed to parse gh pr list output: {e}\nstdout preview: {stdout_preview}"
+            ) from e

--- a/zima/review/parser.py
+++ b/zima/review/parser.py
@@ -54,9 +54,11 @@ class ReviewParser:
             stdout: Raw agent output string to parse.
 
         Returns:
-            ReviewResult with parsed verdict, summary, and issues. Returns
-            ReviewResult(verdict="needs_discussion") if no block is found
-            or the XML is invalid.
+            ReviewResult with parsed verdict, summary, and issues. If no
+            <zima-review> block is found or the XML is invalid, falls back
+            to parsing skill output patterns (e.g. "Found N issues" or
+            "No issues found"). If fallback parsing also fails, returns
+            ReviewResult(verdict="needs_discussion").
         """
         # Security: limit input size to prevent billion laughs / XML bomb
         if len(stdout) > _MAX_REVIEW_XML_SIZE:
@@ -74,24 +76,15 @@ class ReviewParser:
                 try:
                     root = ET.fromstring(xml_content)
                 except ET.ParseError:
-                    return ReviewResult(
-                        verdict="needs_discussion",
-                        summary="Invalid review XML format",
-                    )
+                    return ReviewParser._fallback_parse(stdout)
             else:
-                return ReviewResult(
-                    verdict="needs_discussion",
-                    summary="No review block found in agent output",
-                )
+                return ReviewParser._fallback_parse(stdout)
         else:
             xml_content = f"<zima-review>{match.group(1)}</zima-review>"
             try:
                 root = ET.fromstring(xml_content)
             except ET.ParseError:
-                return ReviewResult(
-                    verdict="needs_discussion",
-                    summary="Invalid review XML format",
-                )
+                return ReviewParser._fallback_parse(stdout)
         verdict = root.findtext("verdict", default="needs_discussion").strip()
         summary = root.findtext("summary", default="").strip()
 
@@ -114,3 +107,19 @@ class ReviewParser:
                 )
 
         return ReviewResult(verdict=verdict, summary=summary, issues=issues)
+
+    @staticmethod
+    def _fallback_parse(stdout: str) -> ReviewResult:
+        """Parse review result from skill output patterns when XML is absent."""
+        if "No issues found" in stdout:
+            return ReviewResult(verdict="approved", summary="No issues found")
+        match = re.search(r"\bFound\s+(\d+)\s+issues?\b", stdout, re.IGNORECASE)
+        if match:
+            count = int(match.group(1))
+            if count == 0:
+                return ReviewResult(verdict="approved", summary="Found 0 issues")
+            return ReviewResult(verdict="needs_fix", summary=f"Found {count} issues")
+        return ReviewResult(
+            verdict="needs_discussion",
+            summary="No review block found in agent output",
+        )

--- a/zima/review/parser.py
+++ b/zima/review/parser.py
@@ -111,7 +111,7 @@ class ReviewParser:
     @staticmethod
     def _fallback_parse(stdout: str) -> ReviewResult:
         """Parse review result from skill output patterns when XML is absent."""
-        if "No issues found" in stdout:
+        if re.search(r"\bNo issues found\b", stdout, re.IGNORECASE):
             return ReviewResult(verdict="approved", summary="No issues found")
         match = re.search(r"\bFound\s+(\d+)\s+issues?\b", stdout, re.IGNORECASE)
         if match:

--- a/zima/templates/examples.py
+++ b/zima/templates/examples.py
@@ -191,11 +191,13 @@ spec:
   workflow: reviewer-cr
   variable: reviewer-vars
   actions:
+    preExec:
+      - type: scan_pr
+        repo: "{{repo}}"
+        label: "zima:needs-review"
     postExec:
       - condition: success
         type: add_label
-        addLabels:
-          - zima:review-approved
         removeLabels:
           - zima:needs-review
         repo: "{{repo}}"


### PR DESCRIPTION
## Summary

This PR implements automated PR code review automation for Issue #35:

- **ReviewParser fallback**: Parses skill output patterns ("No issues found", "Found N issues") when `<zima-review>` XML is absent
- **GitHub PR scanning**: Added `scan_prs()` to ActionProvider and GitHubProvider via `gh pr list`
- **preExec actions**: New `PreExecAction` and `pre_exec` field in `ActionsConfig`, with `ActionsRunner.run_pre()` executing scan_pr actions before the agent
- **PJobExecutor integration**: Catches `SkipAction` from preExec and returns `SKIPPED` status when no matching PRs are found
- **Label initialization script**: `scripts/init_labels.py` creates the 5 zima:* PR labels with correct colors
- **Reviewer template updates**: Workflow now requires `<zima-review>` XML output; PJob includes preExec `scan_pr` and postExec label transitions

## Test Plan

- [ ] All 653 unit tests pass
- [ ] `uv run black --check` passes
- [ ] `uv run ruff check` passes
- [ ] `python scripts/init_labels.py --repo owner/repo --dry-run` previews labels correctly
- [ ] Reviewer PJob template round-trips through YAML parse/load