### PR TITLE
fix(actions_runner): inject pr_diff via fetch_diff in preExec scan_pr (#75 follow-up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ Thumbs.db
 
 # Claude worktrees
 .claude/worktrees/
+.claude/settings.local.json
 
 # Misc
 pr_diff.txt

--- a/tests/unit/test_actions_runner.py
+++ b/tests/unit/test_actions_runner.py
@@ -289,9 +289,13 @@ class TestActionsRunnerPreExec:
         mock_provider.scan_prs.return_value = [
             {"number": "7", "title": "Test", "url": "https://github.com/o/r/pull/7"}
         ]
+        mock_provider.fetch_diff.return_value = "diff data"
         with patch.object(runner._registry, "get", return_value=mock_provider):
             env = {"repo": "my-org/my-repo", "label": "needs-review"}
             runner.run_pre(actions, env)
             mock_provider.scan_prs.assert_called_once_with("my-org/my-repo", "needs-review")
+            mock_provider.fetch_diff.assert_called_once_with("my-org/my-repo", "7")
             assert env["repo"] == "my-org/my-repo"
             assert env["pr_number"] == "7"
+            assert env["pr_diff"] == "diff data"
+

--- a/tests/unit/test_actions_runner.py
+++ b/tests/unit/test_actions_runner.py
@@ -301,5 +301,3 @@ class TestActionsRunnerPreExec:
             assert env["repo"] == "my-org/my-repo"
             assert env["pr_number"] == "7"
             assert env["pr_diff"] == "diff data"
-
-

--- a/tests/unit/test_actions_runner.py
+++ b/tests/unit/test_actions_runner.py
@@ -299,3 +299,4 @@ class TestActionsRunnerPreExec:
             assert env["pr_number"] == "7"
             assert env["pr_diff"] == "diff data"
 
+

--- a/tests/unit/test_actions_runner.py
+++ b/tests/unit/test_actions_runner.py
@@ -227,13 +227,16 @@ class TestActionsRunnerPreExec:
         mock_provider.scan_prs.return_value = [
             {"number": "42", "title": "Fix", "url": "https://github.com/o/r/pull/42"}
         ]
+        mock_provider.fetch_diff.return_value = "diff content"
         with patch.object(runner._registry, "get", return_value=mock_provider):
             env = {}
             runner.run_pre(actions, env)
             mock_provider.scan_prs.assert_called_once_with("owner/repo", "zima:needs-review")
+            mock_provider.fetch_diff.assert_called_once_with("owner/repo", "42")
             assert env["pr_number"] == "42"
             assert env["pr_title"] == "Fix"
             assert env["pr_url"] == "https://github.com/o/r/pull/42"
+            assert env["pr_diff"] == "diff content"
 
     def test_run_pre_exec_empty_result(self):
         """Test preExec scan_pr with no results raises SkipAction."""

--- a/zima/execution/actions_runner.py
+++ b/zima/execution/actions_runner.py
@@ -148,5 +148,6 @@ class ActionsRunner:
                 env["pr_number"] = str(pr.get("number") or "")
                 env["pr_title"] = pr.get("title") or ""
                 env["pr_url"] = pr.get("url") or ""
+                env["pr_diff"] = provider.fetch_diff(repo, env["pr_number"])
             else:
                 print(f"Warning: Unknown preExec action type '{action.type}', skipping")


### PR DESCRIPTION
## 问题

PR #75 的 `preExec scan_pr` action 扫描到 PR 后注入了 `repo`, `pr_number`, `pr_title`, `pr_url`，但**遗漏了 `pr_diff`**。`reviewer-cr` workflow template 需要 `{{pr_diff}}` 来渲染 diff block，导致 reviewer prompt 中的 diff 区域始终为空。

## 修复

在 `ActionsRunner.run_pre()` 的 `scan_pr` 分支中，扫描到 PR 后调用 `provider.fetch_diff(repo, pr_number)` 获取 diff 内容并注入环境变量。

## 变更

- `zima/execution/actions_runner.py`: 补充 `fetch_diff` 调用
- `tests/unit/test_actions_runner.py`: 更新 preExec 测试验证 `pr_diff` 注入

## 验证

```bash
uv run pytest tests/unit/test_actions_runner.py -v  # 18 passed
uv run pytest tests/unit/ -q                          # 654 passed
```