### PR TITLE
feat: CLI support for postExec actions configuration (#73)

### DIFF
--- a/tests/integration/test_pjob_actions_commands.py
+++ b/tests/integration/test_pjob_actions_commands.py
@@ -255,7 +255,7 @@ class TestPJobActionsAdd:
 
     def test_add_multiple_actions(self):
         _create_deps(self.tmp_path)
-        runner.invoke(
+        result1 = runner.invoke(
             app,
             [
                 "pjob",
@@ -270,7 +270,8 @@ class TestPJobActionsAdd:
                 "a",
             ],
         )
-        runner.invoke(
+        assert result1.exit_code == 0
+        result2 = runner.invoke(
             app,
             [
                 "pjob",
@@ -285,9 +286,29 @@ class TestPJobActionsAdd:
                 "fail",
             ],
         )
+        assert result2.exit_code == 0
         list_result = runner.invoke(app, ["pjob", "actions", "test-pjob", "list"])
         assert "add_label" in list_result.output
         assert "add_comment" in list_result.output
+
+    def test_add_comment_warns_no_body(self):
+        _create_deps(self.tmp_path)
+        result = runner.invoke(
+            app,
+            [
+                "pjob",
+                "actions",
+                "test-pjob",
+                "add",
+                "--condition",
+                "failure",
+                "--type",
+                "add_comment",
+            ],
+        )
+        assert result.exit_code == 0
+        output_lower = result.output.lower()
+        assert "warn" in output_lower
 
 
 class TestPJobActionsRemove:

--- a/tests/integration/test_pjob_actions_commands.py
+++ b/tests/integration/test_pjob_actions_commands.py
@@ -1,0 +1,356 @@
+"""Integration tests for PJob actions subcommands."""
+
+import pytest
+from typer.testing import CliRunner
+
+from zima.cli import app
+from zima.config.manager import ConfigManager
+from zima.models.agent import AgentConfig
+from zima.models.workflow import WorkflowConfig
+
+runner = CliRunner()
+
+
+def _create_deps(tmp_path, pjob_code="test-pjob"):
+    """Helper: set up ZIMA_HOME, create agent+workflow+pjob."""
+    manager = ConfigManager()
+    agent = AgentConfig.create(code="test-agent", name="Test Agent", agent_type="kimi")
+    manager.save_config("agent", "test-agent", agent.to_dict())
+    wf = WorkflowConfig.create(code="test-workflow", name="Test WF", template="# Test")
+    manager.save_config("workflow", "test-workflow", wf.to_dict())
+    result = runner.invoke(
+        app,
+        [
+            "pjob",
+            "create",
+            "--name",
+            "Test PJob",
+            "--code",
+            pjob_code,
+            "--agent",
+            "test-agent",
+            "--workflow",
+            "test-workflow",
+        ],
+    )
+    assert result.exit_code == 0
+    return manager
+
+
+class TestPJobActionsProvider:
+    @pytest.fixture(autouse=True)
+    def setup_isolation(self, monkeypatch, tmp_path):
+        self.tmp_path = tmp_path
+        monkeypatch.setenv("ZIMA_HOME", str(tmp_path))
+        for kind in ["agents", "workflows", "variables", "envs", "pmgs", "pjobs"]:
+            (tmp_path / "configs" / kind).mkdir(parents=True, exist_ok=True)
+
+    def test_provider_default(self):
+        _create_deps(self.tmp_path)
+        result = runner.invoke(app, ["pjob", "actions", "test-pjob", "provider"])
+        assert result.exit_code == 0
+        assert "github" in result.output
+
+    def test_provider_set(self):
+        _create_deps(self.tmp_path)
+        result = runner.invoke(app, ["pjob", "actions", "test-pjob", "provider", "gitlab"])
+        assert result.exit_code == 0
+        assert "gitlab" in result.output
+        result2 = runner.invoke(app, ["pjob", "actions", "test-pjob", "provider"])
+        assert "gitlab" in result2.output
+
+    def test_provider_pjob_not_found(self):
+        result = runner.invoke(app, ["pjob", "actions", "missing-pjob", "provider"])
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+
+class TestPJobActionsList:
+    @pytest.fixture(autouse=True)
+    def setup_isolation(self, monkeypatch, tmp_path):
+        self.tmp_path = tmp_path
+        monkeypatch.setenv("ZIMA_HOME", str(tmp_path))
+        for kind in ["agents", "workflows", "variables", "envs", "pmgs", "pjobs"]:
+            (tmp_path / "configs" / kind).mkdir(parents=True, exist_ok=True)
+
+    def test_list_empty(self):
+        _create_deps(self.tmp_path, "t1")
+        result = runner.invoke(app, ["pjob", "actions", "t1", "list"])
+        assert result.exit_code == 0
+        assert "No postExec actions" in result.output
+
+    def test_list_with_actions(self):
+        from zima.models.actions import PostExecAction
+
+        _create_deps(self.tmp_path)
+        manager = ConfigManager()
+        data = manager.load_config("pjob", "test-pjob")
+        from zima.models.pjob import PJobConfig
+
+        pjob = PJobConfig.from_dict(data)
+        pjob.spec.actions.post_exec.append(
+            PostExecAction(
+                condition="success",
+                type="add_label",
+                add_labels=["reviewed"],
+                repo="owner/repo",
+                issue="{{pr_number}}",
+            )
+        )
+        manager.save_config("pjob", "test-pjob", pjob.to_dict())
+        result = runner.invoke(app, ["pjob", "actions", "test-pjob", "list"])
+        assert result.exit_code == 0
+        assert "add_label" in result.output
+        assert "reviewed" in result.output
+
+    def test_list_pjob_not_found(self):
+        result = runner.invoke(app, ["pjob", "actions", "missing", "list"])
+        assert result.exit_code != 0
+
+
+class TestPJobActionsAdd:
+    @pytest.fixture(autouse=True)
+    def setup_isolation(self, monkeypatch, tmp_path):
+        self.tmp_path = tmp_path
+        monkeypatch.setenv("ZIMA_HOME", str(tmp_path))
+        for kind in ["agents", "workflows", "variables", "envs", "pmgs", "pjobs"]:
+            (tmp_path / "configs" / kind).mkdir(parents=True, exist_ok=True)
+
+    def test_add_label_action(self):
+        _create_deps(self.tmp_path)
+        result = runner.invoke(
+            app,
+            [
+                "pjob",
+                "actions",
+                "test-pjob",
+                "add",
+                "--condition",
+                "success",
+                "--type",
+                "add_label",
+                "--add-label",
+                "reviewed",
+                "--remove-label",
+                "needs-review",
+                "--repo",
+                "owner/repo",
+                "--issue",
+                "{{pr_number}}",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "added" in result.output.lower()
+        list_result = runner.invoke(app, ["pjob", "actions", "test-pjob", "list"])
+        assert "add_label" in list_result.output
+        assert "reviewed" in list_result.output
+
+    def test_add_comment_action(self):
+        _create_deps(self.tmp_path)
+        result = runner.invoke(
+            app,
+            [
+                "pjob",
+                "actions",
+                "test-pjob",
+                "add",
+                "--condition",
+                "failure",
+                "--type",
+                "add_comment",
+                "--body",
+                "Review failed",
+                "--repo",
+                "owner/repo",
+                "--issue",
+                "{{pr_number}}",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_add_invalid_condition(self):
+        _create_deps(self.tmp_path)
+        result = runner.invoke(
+            app,
+            [
+                "pjob",
+                "actions",
+                "test-pjob",
+                "add",
+                "--condition",
+                "invalid",
+                "--type",
+                "add_label",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "Invalid condition" in result.output
+
+    def test_add_invalid_type(self):
+        _create_deps(self.tmp_path)
+        result = runner.invoke(
+            app,
+            [
+                "pjob",
+                "actions",
+                "test-pjob",
+                "add",
+                "--condition",
+                "success",
+                "--type",
+                "invalid",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "Invalid type" in result.output
+
+    def test_add_missing_condition(self):
+        _create_deps(self.tmp_path)
+        result = runner.invoke(app, ["pjob", "actions", "test-pjob", "add", "--type", "add_label"])
+        assert result.exit_code != 0
+
+    def test_add_missing_type(self):
+        _create_deps(self.tmp_path)
+        result = runner.invoke(
+            app, ["pjob", "actions", "test-pjob", "add", "--condition", "success"]
+        )
+        assert result.exit_code != 0
+
+    def test_add_label_warns_no_labels(self):
+        _create_deps(self.tmp_path)
+        result = runner.invoke(
+            app,
+            [
+                "pjob",
+                "actions",
+                "test-pjob",
+                "add",
+                "--condition",
+                "success",
+                "--type",
+                "add_label",
+            ],
+        )
+        assert result.exit_code == 0
+        output_lower = result.output.lower()
+        assert "warn" in output_lower
+
+    def test_add_pjob_not_found(self):
+        result = runner.invoke(
+            app,
+            [
+                "pjob",
+                "actions",
+                "missing",
+                "add",
+                "--condition",
+                "success",
+                "--type",
+                "add_label",
+                "--add-label",
+                "x",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_add_multiple_actions(self):
+        _create_deps(self.tmp_path)
+        runner.invoke(
+            app,
+            [
+                "pjob",
+                "actions",
+                "test-pjob",
+                "add",
+                "--condition",
+                "success",
+                "--type",
+                "add_label",
+                "--add-label",
+                "a",
+            ],
+        )
+        runner.invoke(
+            app,
+            [
+                "pjob",
+                "actions",
+                "test-pjob",
+                "add",
+                "--condition",
+                "failure",
+                "--type",
+                "add_comment",
+                "--body",
+                "fail",
+            ],
+        )
+        list_result = runner.invoke(app, ["pjob", "actions", "test-pjob", "list"])
+        assert "add_label" in list_result.output
+        assert "add_comment" in list_result.output
+
+
+class TestPJobActionsRemove:
+    @pytest.fixture(autouse=True)
+    def setup_isolation(self, monkeypatch, tmp_path):
+        self.tmp_path = tmp_path
+        monkeypatch.setenv("ZIMA_HOME", str(tmp_path))
+        for kind in ["agents", "workflows", "variables", "envs", "pmgs", "pjobs"]:
+            (tmp_path / "configs" / kind).mkdir(parents=True, exist_ok=True)
+
+    def _create_with_actions(self, pjob_code="test-pjob"):
+        _create_deps(self.tmp_path, pjob_code)
+        runner.invoke(
+            app,
+            [
+                "pjob",
+                "actions",
+                pjob_code,
+                "add",
+                "--condition",
+                "success",
+                "--type",
+                "add_label",
+                "--add-label",
+                "a",
+            ],
+        )
+        runner.invoke(
+            app,
+            [
+                "pjob",
+                "actions",
+                pjob_code,
+                "add",
+                "--condition",
+                "failure",
+                "--type",
+                "add_comment",
+                "--body",
+                "fail",
+            ],
+        )
+
+    def test_remove_by_index(self):
+        self._create_with_actions()
+        result = runner.invoke(app, ["pjob", "actions", "test-pjob", "remove", "--index", "0"])
+        assert result.exit_code == 0
+        list_result = runner.invoke(app, ["pjob", "actions", "test-pjob", "list"])
+        assert "add_comment" in list_result.output
+        assert "add_label" not in list_result.output
+
+    def test_remove_out_of_range(self):
+        self._create_with_actions()
+        result = runner.invoke(app, ["pjob", "actions", "test-pjob", "remove", "--index", "99"])
+        assert result.exit_code != 0
+
+    def test_remove_pjob_not_found(self):
+        result = runner.invoke(app, ["pjob", "actions", "missing", "remove", "--index", "0"])
+        assert result.exit_code != 0
+
+    def test_remove_last_action(self):
+        self._create_with_actions()
+        runner.invoke(app, ["pjob", "actions", "test-pjob", "remove", "--index", "0"])
+        runner.invoke(app, ["pjob", "actions", "test-pjob", "remove", "--index", "0"])
+        list_result = runner.invoke(app, ["pjob", "actions", "test-pjob", "list"])
+        assert "No postExec actions" in list_result.output

--- a/tests/integration/test_pjob_lifecycle.py
+++ b/tests/integration/test_pjob_lifecycle.py
@@ -600,6 +600,72 @@ class TestPJobLifecycle:
         assert result.exit_code == 0
         assert "created from" in result.output
 
+    def test_show_with_actions(self):
+        """Test show displays actions branch when configured."""
+        self.create_test_agent()
+        self.create_test_workflow()
+        runner.invoke(
+            app,
+            [
+                "pjob",
+                "create",
+                "--name",
+                "T",
+                "--code",
+                "test-pjob",
+                "--agent",
+                "test-agent",
+                "--workflow",
+                "test-workflow",
+            ],
+        )
+        runner.invoke(
+            app,
+            [
+                "pjob",
+                "actions",
+                "test-pjob",
+                "add",
+                "--condition",
+                "success",
+                "--type",
+                "add_label",
+                "--add-label",
+                "reviewed",
+                "--repo",
+                "owner/repo",
+                "--issue",
+                "{{pr_number}}",
+            ],
+        )
+        result = runner.invoke(app, ["pjob", "show", "test-pjob"])
+        assert result.exit_code == 0
+        assert "Actions" in result.output
+        assert "add_label" in result.output
+
+    def test_show_without_actions(self):
+        """Test show omits actions branch when none configured."""
+        self.create_test_agent()
+        self.create_test_workflow()
+        runner.invoke(
+            app,
+            [
+                "pjob",
+                "create",
+                "--name",
+                "T",
+                "--code",
+                "test-pjob",
+                "--agent",
+                "test-agent",
+                "--workflow",
+                "test-workflow",
+            ],
+        )
+        result = runner.invoke(app, ["pjob", "show", "test-pjob"])
+        assert result.exit_code == 0
+        assert "Actions" not in result.output
+
 
 class TestBackgroundRunnerState:
     """Test background runner writes state files correctly."""

--- a/zima/commands/pjob.py
+++ b/zima/commands/pjob.py
@@ -377,6 +377,24 @@ def show(
             exec_branch.add(f"Timeout: {config.spec.execution.timeout}s")
             exec_branch.add(f"Retries: {config.spec.execution.retries}")
 
+            # Actions
+            if config.spec.actions.post_exec:
+                actions_branch = tree.add("[bold]Actions[/bold]")
+                post_branch = actions_branch.add("[bold]PostExec[/bold]")
+                for i, action in enumerate(config.spec.actions.post_exec):
+                    if action.type == "add_label":
+                        parts = []
+                        if action.add_labels:
+                            parts.append("+" + ", +".join(action.add_labels))
+                        if action.remove_labels:
+                            parts.append("-" + ", -".join(action.remove_labels))
+                        detail = " ".join(parts) if parts else "(no labels)"
+                    elif action.type == "add_comment":
+                        detail = f'"{action.body[:50]}"' if action.body else "(no body)"
+                    else:
+                        detail = action.type
+                    post_branch.add(f"[{i}] {action.condition} / {action.type}: {detail}")
+
             console.print(tree)
             console.print(f"\n[dim]File: {manager.get_config_path('pjob', code)}[/dim]")
 

--- a/zima/commands/pjob.py
+++ b/zima/commands/pjob.py
@@ -15,14 +15,29 @@ from rich.tree import Tree
 from zima.config.manager import ConfigManager
 from zima.execution.executor import PJobExecutor
 from zima.execution.history import ExecutionHistory
+from zima.models.actions import VALID_ACTION_CONDITIONS, VALID_POST_ACTION_TYPES, PostExecAction
 from zima.models.pjob import Overrides, PJobConfig
 from zima.utils import get_zima_home, validate_code_with_error
 
 app = typer.Typer(name="pjob", help="PJob management - execute Agent tasks")
 console = Console(legacy_windows=False, force_terminal=True)
 
-actions_app = typer.Typer(name="actions", help="Manage PJob postExec actions and provider")
+actions_app = typer.Typer(
+    name="actions",
+    help="Manage PJob postExec actions and provider",
+    invoke_without_command=True,
+)
 app.add_typer(actions_app, name="actions")
+
+
+@actions_app.callback()
+def actions_callback(
+    ctx: typer.Context,
+    code: str = typer.Argument(..., help="PJob code"),
+):
+    """Manage PJob postExec actions and provider."""
+    ctx.ensure_object(dict)
+    ctx.obj["pjob_code"] = code
 
 
 @app.command()
@@ -1246,3 +1261,152 @@ def show_history(
         f"avg {stats['avg_duration']:.1f}s"
     )
     console.print(f"\nUse [dim]zima pjob history {code} --detail <ID>[/dim] to see error details")
+
+
+# =============================================================================
+# Actions subcommands
+# =============================================================================
+
+
+@actions_app.command("provider")
+def actions_provider(
+    ctx: typer.Context,
+    name: Optional[str] = typer.Argument(None, help="Provider name (omit to view current)"),
+):
+    """Get or set the action provider for a PJob."""
+    code = ctx.obj["pjob_code"]
+    manager = ConfigManager()
+    if not manager.config_exists("pjob", code):
+        console.print(f"[red]✗[/red] PJob '{code}' not found")
+        raise typer.Exit(1)
+    data = manager.load_config("pjob", code)
+    config = PJobConfig.from_dict(data)
+    if name is None:
+        console.print(f"Provider: {config.spec.actions.provider}")
+    else:
+        config.spec.actions.provider = name
+        manager.save_config("pjob", code, config.to_dict())
+        console.print(f"[green]✓[/green] Provider set to '{name}'")
+
+
+@actions_app.command("list")
+def actions_list(
+    ctx: typer.Context,
+):
+    """List all postExec actions for a PJob."""
+    code = ctx.obj["pjob_code"]
+    manager = ConfigManager()
+    if not manager.config_exists("pjob", code):
+        console.print(f"[red]✗[/red] PJob '{code}' not found")
+        raise typer.Exit(1)
+    data = manager.load_config("pjob", code)
+    config = PJobConfig.from_dict(data)
+    actions = config.spec.actions.post_exec
+    if not actions:
+        console.print(f"[yellow]No postExec actions configured for '{code}'[/yellow]")
+        return
+    table = Table(title=f"PostExec Actions: {code}")
+    table.add_column("Index", style="cyan", width=5)
+    table.add_column("Condition", style="green")
+    table.add_column("Type", style="yellow")
+    table.add_column("Details")
+    for i, action in enumerate(actions):
+        if action.type == "add_label":
+            parts = []
+            if action.add_labels:
+                parts.append("+" + ", +".join(action.add_labels))
+            if action.remove_labels:
+                parts.append("-" + ", -".join(action.remove_labels))
+            detail = " ".join(parts) if parts else "(no labels)"
+        elif action.type == "add_comment":
+            detail = action.body[:60] if action.body else "(no body)"
+        else:
+            detail = ""
+        if action.repo:
+            detail += f" ({action.repo}"
+            if action.issue:
+                detail += f" #{action.issue}"
+            detail += ")"
+        table.add_row(str(i), action.condition, action.type, detail)
+    console.print(table)
+
+
+@actions_app.command("add")
+def actions_add(
+    ctx: typer.Context,
+    condition: str = typer.Option(..., "--condition", help="When to run: success, failure, always"),
+    action_type: str = typer.Option(..., "--type", help="Action type: add_label, add_comment"),
+    add_label: Optional[List[str]] = typer.Option(
+        None, "--add-label", help="Labels to add (repeatable)"
+    ),
+    remove_label: Optional[List[str]] = typer.Option(
+        None, "--remove-label", help="Labels to remove (repeatable)"
+    ),
+    repo: str = typer.Option("", "--repo", help="Repository (owner/repo)"),
+    issue: str = typer.Option("", "--issue", help="Issue/PR number (supports {{VAR}})"),
+    body: str = typer.Option("", "--body", help="Comment body (for add_comment)"),
+):
+    """Add a postExec action to a PJob."""
+    code = ctx.obj["pjob_code"]
+    manager = ConfigManager()
+    if not manager.config_exists("pjob", code):
+        console.print(f"[red]✗[/red] PJob '{code}' not found")
+        raise typer.Exit(1)
+    if condition not in VALID_ACTION_CONDITIONS:
+        console.print(
+            f"[red]✗[/red] Invalid condition '{condition}'. "
+            f"Valid: {', '.join(sorted(VALID_ACTION_CONDITIONS))}"
+        )
+        raise typer.Exit(1)
+    if action_type not in VALID_POST_ACTION_TYPES:
+        console.print(
+            f"[red]✗[/red] Invalid type '{action_type}'. "
+            f"Valid: {', '.join(sorted(VALID_POST_ACTION_TYPES))}"
+        )
+        raise typer.Exit(1)
+    if action_type == "add_label" and not add_label and not remove_label:
+        console.print("[yellow]⚠[/yellow] Warning: No labels specified for add_label action")
+    if action_type == "add_comment" and not body:
+        console.print("[yellow]⚠[/yellow] No body specified for add_comment action")
+    data = manager.load_config("pjob", code)
+    config = PJobConfig.from_dict(data)
+    action = PostExecAction(
+        condition=condition,
+        type=action_type,
+        add_labels=list(add_label) if add_label else [],
+        remove_labels=list(remove_label) if remove_label else [],
+        repo=repo,
+        issue=issue,
+        body=body,
+    )
+    config.spec.actions.post_exec.append(action)
+    manager.save_config("pjob", code, config.to_dict())
+    console.print(
+        f"[green]✓[/green] Action added to '{code}' (index {len(config.spec.actions.post_exec) - 1})"
+    )
+
+
+@actions_app.command("remove")
+def actions_remove(
+    ctx: typer.Context,
+    index: int = typer.Option(..., "--index", help="0-based index of action to remove"),
+):
+    """Remove a postExec action by index."""
+    code = ctx.obj["pjob_code"]
+    manager = ConfigManager()
+    if not manager.config_exists("pjob", code):
+        console.print(f"[red]✗[/red] PJob '{code}' not found")
+        raise typer.Exit(1)
+    data = manager.load_config("pjob", code)
+    config = PJobConfig.from_dict(data)
+    actions = config.spec.actions.post_exec
+    if index < 0 or index >= len(actions):
+        upper = len(actions) - 1 if actions else 0
+        console.print(
+            f"[red]✗[/red] Invalid index {index}. "
+            f"PJob '{code}' has {len(actions)} action(s) (indices 0-{upper})"
+        )
+        raise typer.Exit(1)
+    removed = actions.pop(index)
+    manager.save_config("pjob", code, config.to_dict())
+    console.print(f"[green]✓[/green] Removed action at index {index} ({removed.type})")

--- a/zima/commands/pjob.py
+++ b/zima/commands/pjob.py
@@ -382,17 +382,7 @@ def show(
                 actions_branch = tree.add("[bold]Actions[/bold]")
                 post_branch = actions_branch.add("[bold]PostExec[/bold]")
                 for i, action in enumerate(config.spec.actions.post_exec):
-                    if action.type == "add_label":
-                        parts = []
-                        if action.add_labels:
-                            parts.append("+" + ", +".join(action.add_labels))
-                        if action.remove_labels:
-                            parts.append("-" + ", -".join(action.remove_labels))
-                        detail = " ".join(parts) if parts else "(no labels)"
-                    elif action.type == "add_comment":
-                        detail = f'"{action.body[:50]}"' if action.body else "(no body)"
-                    else:
-                        detail = action.type
+                    detail = _format_action_detail(action)
                     post_branch.add(f"[{i}] {action.condition} / {action.type}: {detail}")
 
             console.print(tree)
@@ -1286,6 +1276,20 @@ def show_history(
 # =============================================================================
 
 
+def _format_action_detail(action) -> str:
+    """Format a postExec action into a human-readable detail string."""
+    if action.type == "add_label":
+        parts = []
+        if action.add_labels:
+            parts.append("+" + ", +".join(action.add_labels))
+        if action.remove_labels:
+            parts.append("-" + ", -".join(action.remove_labels))
+        return " ".join(parts) if parts else "(no labels)"
+    if action.type == "add_comment":
+        return f'"{action.body[:50]}"' if action.body else "(no body)"
+    return action.type
+
+
 @actions_app.command("provider")
 def actions_provider(
     ctx: typer.Context,
@@ -1329,17 +1333,7 @@ def actions_list(
     table.add_column("Type", style="yellow")
     table.add_column("Details")
     for i, action in enumerate(actions):
-        if action.type == "add_label":
-            parts = []
-            if action.add_labels:
-                parts.append("+" + ", +".join(action.add_labels))
-            if action.remove_labels:
-                parts.append("-" + ", -".join(action.remove_labels))
-            detail = " ".join(parts) if parts else "(no labels)"
-        elif action.type == "add_comment":
-            detail = action.body[:60] if action.body else "(no body)"
-        else:
-            detail = ""
+        detail = _format_action_detail(action)
         if action.repo:
             detail += f" ({action.repo}"
             if action.issue:
@@ -1385,7 +1379,7 @@ def actions_add(
     if action_type == "add_label" and not add_label and not remove_label:
         console.print("[yellow]⚠[/yellow] Warning: No labels specified for add_label action")
     if action_type == "add_comment" and not body:
-        console.print("[yellow]⚠[/yellow] No body specified for add_comment action")
+        console.print("[yellow]⚠[/yellow] Warning: No body specified for add_comment action")
     data = manager.load_config("pjob", code)
     config = PJobConfig.from_dict(data)
     action = PostExecAction(

--- a/zima/commands/pjob.py
+++ b/zima/commands/pjob.py
@@ -21,6 +21,9 @@ from zima.utils import get_zima_home, validate_code_with_error
 app = typer.Typer(name="pjob", help="PJob management - execute Agent tasks")
 console = Console(legacy_windows=False, force_terminal=True)
 
+actions_app = typer.Typer(name="actions", help="Manage PJob postExec actions and provider")
+app.add_typer(actions_app, name="actions")
+
 
 @app.command()
 def create(


### PR DESCRIPTION
## Summary
- Add `zima pjob actions <code>` subcommand group with 4 commands: `provider`, `list`, `add`, `remove`
- Enhance `pjob show` to display actions branch when configured
- 22 integration tests covering all commands, validation, and edge cases

## Commands Added

```
zima pjob actions <code> provider [name]   — Get/set action provider
zima pjob actions <code> list              — List postExec actions
zima pjob actions <code> add --condition success --type add_label --add-label reviewed
zima pjob actions <code> remove --index 0
```

## Test Plan
- [x] 22 new integration tests all passing
- [x] 900 total tests pass, 0 regressions
- [x] Black formatted, ruff clean
- [x] Pre-commit code review completed

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)