### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.4.0] - 2026-05-03
+
+### Features
+- **pjob**: CLI support for postExec actions configuration (#73)
+- **scenes**: add default_actions to Scene for postExec label transitions
+- **pjob**: add actions parameter to PJobConfig.create()
+- PR code review automation with preExec actions and label management (#35)
+- PJob 运行时状态追踪与生命周期管理 (#70) (#72)
+
+### Fixes
+- **pjob**: improve actions_remove empty list message and refactor tests (#81)
+- **scenes**: deserialize default_actions dict from user scenes.yaml
+- **quickstart**: pass scene default_actions to generated PJob (#74)
+- **actions_runner**: inject pr_diff via fetch_diff in preExec scan_pr (#75 follow-up)
+- **agent**: do not pass --work-dir or --cwd to Claude CLI (#64) (#71)
+- **agent**: use --cwd for Claude agent instead of --work-dir (#69)
+
+### Changes
+- Merge pull request #78 from zhuxixi/fix/74-quickstart-actions
+- add implementation plan for PJob actions CLI (#73)
+- add design spec for PJob actions CLI (#73)
+
+[0.4.0]: https://github.com/zhuxixi/zima-blue-cli/compare/v0.3.1...v0.4.0
+
 ## [0.3.1] - 2026-04-27
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zima-blue-cli"
-version = "0.3.1"
+version = "0.4.0"
 description = "Zima Blue CLI - Personal Agent Orchestration Platform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -801,7 +801,7 @@ wheels = [
 
 [[package]]
 name = "zima-blue-cli"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary
Bump version from 0.3.1 to 0.4.0

## [0.4.0] - 2026-05-03

### Features
- **pjob**: CLI support for postExec actions configuration (#73)
- **scenes**: add default_actions to Scene for postExec label transitions
- **pjob**: add actions parameter to PJobConfig.create()
- PR code review automation with preExec actions and label management (#35)
- PJob 运行时状态追踪与生命周期管理 (#70) (#72)

### Fixes
- **pjob**: improve actions_remove empty list message and refactor tests (#81)
- **scenes**: deserialize default_actions dict from user scenes.yaml
- **quickstart**: pass scene default_actions to generated PJob (#74)
- **actions_runner**: inject pr_diff via fetch_diff in preExec scan_pr (#75 follow-up)
- **agent**: do not pass --work-dir or --cwd to Claude CLI (#64) (#71)
- **agent**: use --cwd for Claude agent instead of --work-dir (#69)

### Changes
- Merge pull request #78 from zhuxixi/fix/74-quickstart-actions
- add implementation plan for PJob actions CLI (#73)
- add design spec for PJob actions CLI (#73)

🤖 Generated with [Claude Code](https://claude.com/claude-code)