### PR TITLE
fix(executor): preExec {{var}} substitution includes VariableConfig values

### DIFF
--- a/tests/unit/test_executor_preexec.py
+++ b/tests/unit/test_executor_preexec.py
@@ -523,3 +523,62 @@ class TestPreExecIntegration:
 
         # Runtime override should win over preExec in env_vars
         assert result.env.get("pr_number") == "OVERRIDE"
+
+    def test_preexec_substitutes_variable_config_values(self, isolated_zima_home):
+        """Test that preExec {{var}} substitution includes VariableConfig values, not just env_vars.
+
+        Regression test for #88: preExec used _substitute_env_str which only looked up
+        env_vars (from EnvConfig), missing VariableConfig values like {{repo}}.
+        """
+        from zima.config.manager import ConfigManager
+        from zima.models.variable import VariableConfig
+
+        manager = ConfigManager()
+
+        agent = AgentConfig.create(
+            code="test-agent",
+            name="Test Agent",
+            agent_type="kimi",
+            parameters={"mockCommand": "echo hello"},
+        )
+        manager.save_config("agent", "test-agent", agent.to_dict())
+
+        workflow = WorkflowConfig.create(
+            code="test-workflow",
+            name="Test Workflow",
+            template="Hello",
+        )
+        manager.save_config("workflow", "test-workflow", workflow.to_dict())
+
+        # VariableConfig defines repo, NOT EnvConfig
+        var = VariableConfig.create(
+            code="test-var",
+            name="Test Vars",
+            values={"repo": "zhuxixi/zima-blue-cli", "label": "zima:needs-review"},
+        )
+        manager.save_config("variable", "test-var", var.to_dict())
+
+        pjob = PJobConfig.create(
+            code="test-pjob",
+            name="Test PJob",
+            agent="test-agent",
+            workflow="test-workflow",
+            variable="test-var",
+        )
+        pjob.spec.actions = ActionsConfig(
+            provider="github",
+            pre_exec=[PreExecAction(type="scan_pr", repo="{{repo}}", label="{{label}}")],
+        )
+        manager.save_config("pjob", "test-pjob", pjob.to_dict())
+
+        executor = PJobExecutor()
+
+        with patch.object(executor._actions_runner, "run_pre", return_value={}) as mock_run_pre:
+            with patch.object(executor, "_run_command") as mock_run:
+                mock_run.return_value = (0, "done", "", 12345)
+                executor.execute("test-pjob")
+
+        # The env dict passed to run_pre should contain VariableConfig values
+        call_env = mock_run_pre.call_args[0][1]  # second positional arg = env dict
+        assert call_env.get("repo") == "zhuxixi/zima-blue-cli"
+        assert call_env.get("label") == "zima:needs-review"

--- a/zima/execution/executor.py
+++ b/zima/execution/executor.py
@@ -203,7 +203,8 @@ class PJobExecutor:
                     # Merge variable config values into env for {{var}} substitution
                     pre_env = env_vars.copy()
                     for k, v in bundle.get_variable_values().items():
-                        pre_env.setdefault(k, str(v))
+                        if v is not None:
+                            pre_env.setdefault(k, str(v))
                     dynamic_vars = self._actions_runner.run_pre(pjob.spec.actions, pre_env)
                     # Merge discovered vars into env (for postExec substitution)
                     # Skip keys that already exist in runtime overrides (higher priority)

--- a/zima/execution/executor.py
+++ b/zima/execution/executor.py
@@ -200,7 +200,11 @@ class PJobExecutor:
             # Skip preExec in dry_run to avoid side effects (e.g. GitHub API calls)
             if pjob.spec.actions and pjob.spec.actions.pre_exec and not dry_run:
                 try:
-                    dynamic_vars = self._actions_runner.run_pre(pjob.spec.actions, env_vars)
+                    # Merge variable config values into env for {{var}} substitution
+                    pre_env = env_vars.copy()
+                    for k, v in bundle.get_variable_values().items():
+                        pre_env.setdefault(k, str(v))
+                    dynamic_vars = self._actions_runner.run_pre(pjob.spec.actions, pre_env)
                     # Merge discovered vars into env (for postExec substitution)
                     # Skip keys that already exist in runtime overrides (higher priority)
                     for key, value in dynamic_vars.items():


### PR DESCRIPTION
## Summary
- Fix preExec `{{var}}` substitution to include VariableConfig values, not just EnvConfig env_vars
- Before this fix, `{{repo}}` in preExec actions was passed literally when the value was defined in VariableConfig

Closes #88

## Root Cause
`executor.py` called `run_pre(pjob.spec.actions, env_vars)` where `env_vars` only contained EnvConfig values. `_substitute_env_str()` couldn't find VariableConfig keys like `repo`, leaving `{{repo}}` unsubstituted.

## Fix
Merge `bundle.get_variable_values()` into a copy of `env_vars` using `setdefault` (env_vars keep higher priority) before passing to `run_pre()`.

## Test plan
- [x] New regression test: `test_preexec_substitutes_variable_config_values` verifies VariableConfig values are passed to `run_pre()`
- [x] All 926 existing tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)