### PR TITLE
feat: multi-PR queue for scan_pr with skip logic

### DIFF
--- a/tests/unit/test_actions_runner.py
+++ b/tests/unit/test_actions_runner.py
@@ -306,3 +306,92 @@ class TestActionsRunnerPreExec:
             assert result["repo"] == "my-org/my-repo"
             assert result["pr_number"] == "7"
             assert result["pr_diff"] == "diff data"
+
+
+class TestActionsRunnerPreExecSkipLogic:
+    def _make_actions(self, repo="owner/repo", label="zima:needs-review"):
+        from zima.models.actions import PreExecAction
+
+        return ActionsConfig(pre_exec=[PreExecAction(type="scan_pr", repo=repo, label=label)])
+
+    def test_no_history_falls_back_to_first_pr(self):
+        """Without history, picks the first PR (prs[0] behavior)."""
+        runner = ActionsRunner()
+        actions = self._make_actions()
+        mock_provider = MagicMock()
+        mock_provider.scan_prs.return_value = [
+            {"number": "10", "title": "PR 10", "url": "url10"},
+            {"number": "20", "title": "PR 20", "url": "url20"},
+        ]
+        mock_provider.fetch_diff.return_value = "diff"
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            result = runner.run_pre(actions, {})
+        assert result["pr_number"] == "10"
+
+    def test_skips_recently_failed_pr(self):
+        """Skips a PR that failed within the time window."""
+        mock_history = MagicMock()
+        mock_history.get_recent_scan_pr_failures.return_value = [
+            {"scan_pr_result": {"repo": "owner/repo", "pr_number": "10"}}
+        ]
+        runner = ActionsRunner(history=mock_history, pjob_code="reviewer")
+        actions = self._make_actions()
+        mock_provider = MagicMock()
+        mock_provider.scan_prs.return_value = [
+            {"number": "10", "title": "PR 10", "url": "url10"},
+            {"number": "20", "title": "PR 20", "url": "url20"},
+        ]
+        mock_provider.fetch_diff.return_value = "diff"
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            result = runner.run_pre(actions, {})
+        assert result["pr_number"] == "20"
+        mock_history.get_recent_scan_pr_failures.assert_called_once_with("reviewer", 90)
+
+    def test_skips_all_raises_skip_action(self):
+        """Raises SkipAction when all PRs were recently attempted."""
+        mock_history = MagicMock()
+        mock_history.get_recent_scan_pr_failures.return_value = [
+            {"scan_pr_result": {"repo": "owner/repo", "pr_number": "10"}},
+            {"scan_pr_result": {"repo": "owner/repo", "pr_number": "20"}},
+        ]
+        runner = ActionsRunner(history=mock_history, pjob_code="reviewer")
+        actions = self._make_actions()
+        mock_provider = MagicMock()
+        mock_provider.scan_prs.return_value = [
+            {"number": "10", "title": "PR 10", "url": "url10"},
+            {"number": "20", "title": "PR 20", "url": "url20"},
+        ]
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            with pytest.raises(SkipAction) as exc_info:
+                runner.run_pre(actions, {})
+            assert "recently attempted" in str(exc_info.value).lower()
+
+    def test_no_history_param_skips_query(self):
+        """When history is None, no query is made and first PR is picked."""
+        runner = ActionsRunner(history=None, pjob_code="reviewer")
+        actions = self._make_actions()
+        mock_provider = MagicMock()
+        mock_provider.scan_prs.return_value = [
+            {"number": "10", "title": "PR 10", "url": "url10"},
+        ]
+        mock_provider.fetch_diff.return_value = "diff"
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            result = runner.run_pre(actions, {})
+        assert result["pr_number"] == "10"
+
+    def test_different_repo_not_skipped(self):
+        """A failed PR on a different repo does not cause skipping."""
+        mock_history = MagicMock()
+        mock_history.get_recent_scan_pr_failures.return_value = [
+            {"scan_pr_result": {"repo": "other/repo", "pr_number": "10"}},
+        ]
+        runner = ActionsRunner(history=mock_history, pjob_code="reviewer")
+        actions = self._make_actions(repo="owner/repo")
+        mock_provider = MagicMock()
+        mock_provider.scan_prs.return_value = [
+            {"number": "10", "title": "PR 10", "url": "url10"},
+        ]
+        mock_provider.fetch_diff.return_value = "diff"
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            result = runner.run_pre(actions, {})
+        assert result["pr_number"] == "10"

--- a/tests/unit/test_execution_history.py
+++ b/tests/unit/test_execution_history.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from zima.execution.history import ExecutionHistory, _is_pid_alive
+from zima.execution.history import ExecutionHistory, ExecutionRecord, _is_pid_alive
 
 
 class TestExecutionHistoryWriteAndRead:
@@ -199,6 +199,45 @@ class TestExecutionHistoryWriteAndRead:
         data = self.history.get_runtime_state(self.pjob_code, self.exec_id)
         assert data is not None
         assert data["status"] == "dead"
+
+    def test_scan_pr_result_round_trip(self):
+        """scan_pr_result is persisted and loaded correctly."""
+        record = ExecutionRecord(
+            execution_id="a1",
+            pjob_code="test-pjob",
+            status="failed",
+            returncode=1,
+            scan_pr_result={"repo": "owner/repo", "pr_number": "42"},
+            started_at="2026-05-03T10:00:00+08:00",
+        )
+        data = record.to_dict()
+        assert data["scan_pr_result"] == {"repo": "owner/repo", "pr_number": "42"}
+
+        restored = ExecutionRecord.from_dict(data)
+        assert restored.scan_pr_result == {"repo": "owner/repo", "pr_number": "42"}
+
+    def test_scan_pr_result_defaults_to_none(self):
+        """Existing records without scan_pr_result deserialize as None."""
+        record = ExecutionRecord.from_dict(
+            {
+                "execution_id": "a1",
+                "pjob_code": "test-pjob",
+                "status": "success",
+                "returncode": 0,
+            }
+        )
+        assert record.scan_pr_result is None
+
+    def test_scan_pr_result_excluded_when_none(self):
+        """to_dict omits scan_pr_result when it is None."""
+        record = ExecutionRecord(
+            execution_id="a1",
+            pjob_code="test-pjob",
+            status="success",
+            returncode=0,
+        )
+        data = record.to_dict()
+        assert "scan_pr_result" not in data
 
 
 class TestLegacyMigration:

--- a/tests/unit/test_execution_history.py
+++ b/tests/unit/test_execution_history.py
@@ -240,6 +240,69 @@ class TestExecutionHistoryWriteAndRead:
         assert "scan_pr_result" not in data
 
 
+class TestGetRecentScanPrFailures:
+    @pytest.fixture(autouse=True)
+    def setup(self, isolated_zima_home):
+        self.history = ExecutionHistory()
+        self.pjob_code = "reviewer-kimi"
+
+    def _write_record(self, exec_id, status, scan_pr_result, started_at, minutes_ago=0):
+        """Helper to write an execution record."""
+        from datetime import datetime, timedelta, timezone
+
+        if started_at is None:
+            ts = datetime.now(timezone.utc).astimezone() - timedelta(minutes=minutes_ago)
+            started_at = ts.isoformat()
+        self.history.write_runtime_state(
+            self.pjob_code,
+            exec_id,
+            {
+                "execution_id": exec_id,
+                "pjob_code": self.pjob_code,
+                "status": status,
+                "returncode": 1,
+                "started_at": started_at,
+                "scan_pr_result": scan_pr_result,
+            },
+        )
+
+    def test_returns_recently_failed_prs(self):
+        self._write_record("a1", "failed", {"repo": "o/r", "pr_number": "10"}, None, minutes_ago=5)
+        self._write_record("a2", "failed", {"repo": "o/r", "pr_number": "20"}, None, minutes_ago=30)
+
+        results = self.history.get_recent_scan_pr_failures(self.pjob_code, within_minutes=90)
+        assert len(results) == 2
+        pr_numbers = {r["scan_pr_result"]["pr_number"] for r in results}
+        assert pr_numbers == {"10", "20"}
+
+    def test_excludes_prs_outside_time_window(self):
+        self._write_record("a1", "failed", {"repo": "o/r", "pr_number": "10"}, None, minutes_ago=5)
+        self._write_record(
+            "a2", "failed", {"repo": "o/r", "pr_number": "20"}, None, minutes_ago=120
+        )
+
+        results = self.history.get_recent_scan_pr_failures(self.pjob_code, within_minutes=90)
+        assert len(results) == 1
+        assert results[0]["scan_pr_result"]["pr_number"] == "10"
+
+    def test_excludes_success_and_running_status(self):
+        self._write_record("a1", "success", {"repo": "o/r", "pr_number": "10"}, None, minutes_ago=5)
+        self._write_record("a2", "running", {"repo": "o/r", "pr_number": "20"}, None, minutes_ago=5)
+
+        results = self.history.get_recent_scan_pr_failures(self.pjob_code, within_minutes=90)
+        assert len(results) == 0
+
+    def test_excludes_records_without_scan_pr_result(self):
+        self._write_record("a1", "failed", None, None, minutes_ago=5)
+
+        results = self.history.get_recent_scan_pr_failures(self.pjob_code, within_minutes=90)
+        assert len(results) == 0
+
+    def test_returns_empty_for_nonexistent_pjob(self):
+        results = self.history.get_recent_scan_pr_failures("nonexistent", within_minutes=90)
+        assert results == []
+
+
 class TestLegacyMigration:
     @pytest.fixture(autouse=True)
     def setup(self, isolated_zima_home):

--- a/zima/execution/actions_runner.py
+++ b/zima/execution/actions_runner.py
@@ -42,8 +42,15 @@ class ActionsRunner:
     and action dispatch to the configured provider.
     """
 
-    def __init__(self, registry: Optional[ProviderRegistry] = None):
+    def __init__(
+        self,
+        registry: Optional[ProviderRegistry] = None,
+        history=None,
+        pjob_code: Optional[str] = None,
+    ):
         self._registry = registry or get_default_registry()
+        self._history = history
+        self._pjob_code = pjob_code
 
     def run(
         self,
@@ -119,6 +126,28 @@ class ActionsRunner:
             value = value.replace(f"{{{{{key}}}}}", str(val))
         return value
 
+    def _select_pr(self, prs: list[dict], repo: str) -> dict:
+        """Select the next eligible PR, skipping recently-failed ones.
+
+        Falls back to prs[0] when no history is configured.
+        """
+        if not self._history or not self._pjob_code:
+            return prs[0]
+
+        failures = self._history.get_recent_scan_pr_failures(self._pjob_code, 90)
+        skip_set = set()
+        for rec in failures:
+            spr = rec.get("scan_pr_result")
+            if spr:
+                skip_set.add((spr.get("repo", ""), spr.get("pr_number", "")))
+
+        for pr in prs:
+            pr_num = str(pr.get("number") or "")
+            if (repo, pr_num) not in skip_set:
+                return pr
+
+        raise SkipAction(f"All {len(prs)} PR(s) recently attempted, skipping")
+
     def run_pre(self, actions: ActionsConfig, env: dict[str, str]) -> dict[str, str]:
         """Execute all preExec actions, return discovered variables.
 
@@ -146,7 +175,7 @@ class ActionsRunner:
                 prs = provider.scan_prs(repo, label)
                 if not prs:
                     raise SkipAction(f"No PRs found with label '{label}' in {repo}")
-                pr = prs[0]
+                pr = self._select_pr(prs, repo)
                 discovered["repo"] = repo
                 discovered["pr_number"] = str(pr.get("number") or "")
                 discovered["pr_title"] = pr.get("title") or ""

--- a/zima/execution/actions_runner.py
+++ b/zima/execution/actions_runner.py
@@ -139,7 +139,7 @@ class ActionsRunner:
         for rec in failures:
             spr = rec.get("scan_pr_result")
             if spr:
-                skip_set.add((spr.get("repo", ""), spr.get("pr_number", "")))
+                skip_set.add((spr.get("repo") or "", spr.get("pr_number") or ""))
 
         for pr in prs:
             pr_num = str(pr.get("number") or "")

--- a/zima/execution/background_runner.py
+++ b/zima/execution/background_runner.py
@@ -86,6 +86,7 @@ def run_pjob_in_background(
         stdout_preview=stdout_preview,
         stderr_preview=stderr_preview,
         error_detail=result.error_detail[:2000] if result.error_detail else "",
+        scan_pr_result=result.scan_pr_result,
     )
 
     return 0 if result.status.value == "success" else 1

--- a/zima/execution/executor.py
+++ b/zima/execution/executor.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 from zima.config.manager import ConfigManager
 from zima.execution.actions_runner import ActionsRunner, SkipAction
+from zima.execution.history import ExecutionHistory
 from zima.models.config_bundle import ConfigBundle
 from zima.models.pjob import Overrides, PJobConfig
 from zima.review.parser import ReviewParser
@@ -71,6 +72,7 @@ class ExecutionResult:
     prompt_content: str = ""  # Rendered workflow content (kept for dry-run)
     pid: Optional[int] = None  # 执行的进程 PID
     action_errors: list[str] = field(default_factory=list)
+    scan_pr_result: Optional[dict] = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary."""
@@ -151,7 +153,11 @@ class PJobExecutor:
         """Initialize executor."""
         self.config_manager = ConfigManager()
         self._current_process: Optional[subprocess.Popen] = None
-        self._actions_runner = ActionsRunner()
+        self._history = ExecutionHistory()
+        self._actions_runner = ActionsRunner(
+            history=self._history,
+            pjob_code=None,
+        )
 
     def execute(
         self,
@@ -178,6 +184,7 @@ class PJobExecutor:
             execution_id=execution_id,
             started_at=generate_timestamp(),
         )
+        self._actions_runner._pjob_code = pjob_code
         temp_dir: Optional[Path] = None
 
         try:
@@ -216,6 +223,12 @@ class PJobExecutor:
                             env_vars[key] = value
                     # Merge discovered vars into bundle (for Jinja2 rendering)
                     bundle.inject_dynamic_vars(dynamic_vars)
+                    # Persist scan_pr_result for skip logic
+                    if "pr_number" in dynamic_vars:
+                        result.scan_pr_result = {
+                            "repo": dynamic_vars.get("repo", ""),
+                            "pr_number": dynamic_vars["pr_number"],
+                        }
                 except SkipAction as e:
                     result.status = ExecutionStatus.SKIPPED
                     result.returncode = 0

--- a/zima/execution/executor.py
+++ b/zima/execution/executor.py
@@ -53,6 +53,7 @@ class ExecutionResult:
         execution_id: Unique execution ID
         temp_dir: Temporary directory (if kept)
         action_errors: Post-exec action failure messages
+        scan_pr_result: Scan PR result data (repo, pr_number, etc.)
     """
 
     pjob_code: str = ""
@@ -92,6 +93,7 @@ class ExecutionResult:
             "temp_dir": str(self.temp_dir) if self.temp_dir else None,
             "pid": self.pid,
             "action_errors": self.action_errors,
+            **({"scan_pr_result": self.scan_pr_result} if self.scan_pr_result is not None else {}),
         }
 
     @property

--- a/zima/execution/history.py
+++ b/zima/execution/history.py
@@ -433,6 +433,46 @@ class ExecutionHistory:
             "avg_duration": round(avg_duration, 2),
         }
 
+    def get_recent_scan_pr_failures(self, pjob_code: str, within_minutes: int = 90) -> list[dict]:
+        """Return recent failed executions that have scan_pr_result.
+
+        Used by scan_pr skip logic to avoid re-picking recently-failed PRs.
+
+        Args:
+            pjob_code: PJob code to query.
+            within_minutes: Time window in minutes.
+
+        Returns:
+            List of execution state dicts with status in
+            ("failed", "timeout", "cancelled", "dead") and a non-None
+            scan_pr_result, started within the given time window.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        failed_statuses = {"failed", "timeout", "cancelled", "dead"}
+        cutoff = datetime.now(timezone.utc) - timedelta(minutes=within_minutes)
+
+        results: list[dict] = []
+        for record in self.list_executions(pjob_code):
+            if record.get("status") not in failed_statuses:
+                continue
+            spr = record.get("scan_pr_result")
+            if spr is None:
+                continue
+            started = record.get("started_at", "")
+            if not started:
+                continue
+            try:
+                started_dt = datetime.fromisoformat(started.replace("Z", "+00:00"))
+                if started_dt.tzinfo is None:
+                    started_dt = started_dt.replace(tzinfo=timezone.utc)
+                if started_dt >= cutoff:
+                    results.append(record)
+            except (ValueError, TypeError):
+                continue
+
+        return results
+
     # ------------------------------------------------------------------
     # Backward-compatible API (delegates to directory-based storage)
     # ------------------------------------------------------------------

--- a/zima/execution/history.py
+++ b/zima/execution/history.py
@@ -85,6 +85,7 @@ class ExecutionRecord:
         stderr_preview: First N chars of stderr.
         error_detail: Detailed error information.
         pid: Process PID.
+        scan_pr_result: Scan PR result data (repo, pr_number, etc.).
     """
 
     execution_id: str
@@ -99,6 +100,7 @@ class ExecutionRecord:
     stderr_preview: str = ""
     error_detail: str = ""
     pid: Optional[int] = None
+    scan_pr_result: Optional[dict] = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary."""
@@ -115,6 +117,7 @@ class ExecutionRecord:
             "stderr_preview": self.stderr_preview,
             "error_detail": self.error_detail,
             "pid": self.pid,
+            **({"scan_pr_result": self.scan_pr_result} if self.scan_pr_result is not None else {}),
         }
 
     @classmethod
@@ -133,6 +136,7 @@ class ExecutionRecord:
             stderr_preview=data.get("stderr_preview", ""),
             error_detail=data.get("error_detail", ""),
             pid=data.get("pid"),
+            scan_pr_result=data.get("scan_pr_result"),
         )
 
     @classmethod
@@ -158,6 +162,7 @@ class ExecutionRecord:
             stderr_preview=stderr_preview,
             error_detail=error_detail,
             pid=result.pid,
+            scan_pr_result=getattr(result, "scan_pr_result", None),
         )
 
 
@@ -181,6 +186,7 @@ _STATE_FILE_FIELDS = [
     "log_path",
     "agent",
     "workflow",
+    "scan_pr_result",
 ]
 
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `prs[0]` in scan_pr with skip-aware PR selection that avoids recently-failed PRs for 90 minutes
- Extend `ExecutionRecord` with `scan_pr_result` field to persist which PR was processed per execution
- Add `get_recent_scan_pr_failures()` query method to `ExecutionHistory` for time-window filtering
- Wire executor to pass `ExecutionHistory` and `pjob_code` to `ActionsRunner`, persisting scan results

Closes #80

## Test plan

- [x] Unit tests for `ExecutionRecord.scan_pr_result` serialization (round-trip, default None, excluded when None)
- [x] Unit tests for `get_recent_scan_pr_failures()` (time window, status filter, nonexistent PJob)
- [x] Unit tests for skip-aware PR selection (no-history fallback, skip failed PR, all-skipped raises SkipAction, cross-repo isolation)
- [x] Full test suite passes (690 unit tests)
- [x] Black formatting and ruff linting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)