### PR TITLE
fix(execution): guard empty repo in preExec scan_pr

### DIFF
--- a/tests/unit/test_actions_runner.py
+++ b/tests/unit/test_actions_runner.py
@@ -496,6 +496,37 @@ class TestActionsRunnerPreExecSkipLogic:
             result = runner.run_pre(actions, {})
         assert result["pr_number"] == "10"
 
+    def test_empty_repo_raises_skip_action(self):
+        """Empty repo after substitution raises SkipAction instead of crashing."""
+        from zima.models.actions import PreExecAction
+
+        runner = ActionsRunner(pjob_code="my-reviewer")
+        actions = ActionsConfig(
+            pre_exec=[PreExecAction(type="scan_pr", repo="{{repo}}", label="zima:needs-review")]
+        )
+        mock_provider = MagicMock()
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            with pytest.raises(SkipAction) as exc_info:
+                runner.run_pre(actions, {"repo": ""})
+            mock_provider.scan_prs.assert_not_called()
+            assert "repo resolved to empty" in str(exc_info.value)
+            assert "my-reviewer" in str(exc_info.value)
+
+    def test_whitespace_repo_raises_skip_action(self):
+        """Whitespace-only repo raises SkipAction."""
+        from zima.models.actions import PreExecAction
+
+        runner = ActionsRunner()
+        actions = ActionsConfig(
+            pre_exec=[PreExecAction(type="scan_pr", repo="{{repo}}", label="zima:needs-review")]
+        )
+        mock_provider = MagicMock()
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            with pytest.raises(SkipAction) as exc_info:
+                runner.run_pre(actions, {"repo": "   "})
+            mock_provider.scan_prs.assert_not_called()
+            assert "repo resolved to empty" in str(exc_info.value)
+
     def test_different_repo_not_skipped(self):
         """A failed PR on a different repo does not cause skipping."""
         mock_history = MagicMock()

--- a/tests/unit/test_actions_runner.py
+++ b/tests/unit/test_actions_runner.py
@@ -527,6 +527,21 @@ class TestActionsRunnerPreExecSkipLogic:
             mock_provider.scan_prs.assert_not_called()
             assert "repo resolved to empty" in str(exc_info.value)
 
+    def test_empty_label_raises_skip_action(self):
+        """Empty label after substitution raises SkipAction."""
+        from zima.models.actions import PreExecAction
+
+        runner = ActionsRunner()
+        actions = ActionsConfig(
+            pre_exec=[PreExecAction(type="scan_pr", repo="owner/repo", label="{{label}}")]
+        )
+        mock_provider = MagicMock()
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            with pytest.raises(SkipAction) as exc_info:
+                runner.run_pre(actions, {"label": ""})
+            mock_provider.scan_prs.assert_not_called()
+            assert "label resolved to empty" in str(exc_info.value)
+
     def test_different_repo_not_skipped(self):
         """A failed PR on a different repo does not cause skipping."""
         mock_history = MagicMock()

--- a/zima/execution/actions_runner.py
+++ b/zima/execution/actions_runner.py
@@ -192,6 +192,11 @@ class ActionsRunner:
             if action.type == "scan_pr":
                 repo = self._substitute_env_str(action.repo, env)
                 label = self._substitute_env_str(action.label, env)
+                if not repo or not repo.strip():
+                    raise SkipAction(
+                        f"preExec scan_pr skipped — repo resolved to empty "
+                        f"(pjob={self._pjob_code or '?'}, original='{action.repo}')"
+                    )
                 prs = provider.scan_prs(repo, label)
                 if not prs:
                     raise SkipAction(f"No PRs found with label '{label}' in {repo}")

--- a/zima/execution/actions_runner.py
+++ b/zima/execution/actions_runner.py
@@ -197,6 +197,11 @@ class ActionsRunner:
                         f"preExec scan_pr skipped — repo resolved to empty "
                         f"(pjob={self._pjob_code or '?'}, original='{action.repo}')"
                     )
+                if not label or not label.strip():
+                    raise SkipAction(
+                        f"preExec scan_pr skipped — label resolved to empty "
+                        f"(pjob={self._pjob_code or '?'}, original='{action.label}')"
+                    )
                 prs = provider.scan_prs(repo, label)
                 if not prs:
                     raise SkipAction(f"No PRs found with label '{label}' in {repo}")


### PR DESCRIPTION
## Summary

- Add empty/whitespace repo guard in `ActionsRunner.run_pre()` before calling `provider.scan_prs()`
- Raises `SkipAction` (consistent with existing "no work to do" pattern) instead of letting `gh pr list --repo ""` crash with `RuntimeError`
- Includes `pjob_code` and original template in the skip message for debugging
- Adds 2 tests: empty string and whitespace-only repo

Closes #96

## Test plan

- [x] `uv run pytest tests/unit/test_actions_runner.py` — 30 passed
- [x] `uv run pytest` — 955 passed, 0 failed
- [ ] Verify manually: create PJob with `preExec scan_pr` where `repo: "{{repo}}"` and repo variable is empty — should skip gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)