### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.5.1] - 2026-05-06
+
+### Fixes
+- **execution**: guard empty repo in preExec scan_pr (#96)
+- **quickstart**: code-review scene preExec, variables, repo detection (#95)
+
+### Changes
+- add implementation plan for issue #83 quickstart scene fix
+- add spec for issue #83 quickstart scene fix design
+- add implementation plan for issue #80 multi-PR queue
+- add spec for issue #80 multi-PR queue scan_pr design
+
+[0.5.1]: https://github.com/zhuxixi/zima-blue-cli/compare/v0.5.0...v0.5.1
+
 ## [0.5.0] - 2026-05-05
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zima-blue-cli"
-version = "0.5.0"
+version = "0.5.1"
 description = "Zima Blue CLI - Personal Agent Orchestration Platform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -801,7 +801,7 @@ wheels = [
 
 [[package]]
 name = "zima-blue-cli"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary
Bump version from 0.5.0 to 0.5.1

## [0.5.1] - 2026-05-06

### Fixes
- **execution**: guard empty repo in preExec scan_pr (#96)
- **quickstart**: code-review scene preExec, variables, repo detection (#95)

### Changes
- add implementation plan for issue #83 quickstart scene fix
- add spec for issue #83 quickstart scene fix design
- add implementation plan for issue #80 multi-PR queue
- add spec for issue #80 multi-PR queue scan_pr design

🤖 Generated with [Claude Code](https://claude.com/claude-code)