### PR TITLE
fix(providers): configurable default provider via ZIMA_GIT_REPO_PROVIDER (#102)

### DIFF
--- a/tests/unit/test_models_actions.py
+++ b/tests/unit/test_models_actions.py
@@ -172,6 +172,44 @@ class TestActionsConfig:
         assert len(errors) == 2
         assert "Action[1]" in errors[0]
 
+    def test_default_provider_uses_env_var(self, monkeypatch):
+        """ActionsConfig() resolves provider from ZIMA_GIT_REPO_PROVIDER."""
+        monkeypatch.setenv("ZIMA_GIT_REPO_PROVIDER", "gitlab")
+        config = ActionsConfig()
+        assert config.provider == "gitlab"
+
+    def test_default_provider_github_without_env(self, monkeypatch):
+        """ActionsConfig() defaults to 'github' without env var."""
+        monkeypatch.delenv("ZIMA_GIT_REPO_PROVIDER", raising=False)
+        config = ActionsConfig()
+        assert config.provider == "github"
+
+    def test_to_dict_omits_provider_when_env_default(self, monkeypatch):
+        """to_dict omits provider when it matches the env-configured default."""
+        monkeypatch.setenv("ZIMA_GIT_REPO_PROVIDER", "gitlab")
+        config = ActionsConfig()
+        d = config.to_dict()
+        assert "provider" not in d
+
+    def test_to_dict_includes_provider_when_not_default(self, monkeypatch):
+        """to_dict includes provider when it differs from the env default."""
+        monkeypatch.setenv("ZIMA_GIT_REPO_PROVIDER", "gitlab")
+        config = ActionsConfig(provider="github")
+        d = config.to_dict()
+        assert d["provider"] == "github"
+
+    def test_from_dict_resolves_default_provider(self, monkeypatch):
+        """from_dict with no provider key resolves to env default."""
+        monkeypatch.setenv("ZIMA_GIT_REPO_PROVIDER", "gitlab")
+        d = {"postExec": [{"condition": "success", "type": "add_label"}]}
+        config = ActionsConfig.from_dict(d)
+        assert config.provider == "gitlab"
+
+    def test_explicit_provider_not_overridden(self):
+        """Explicitly passed provider is never overridden by __post_init__."""
+        config = ActionsConfig(provider="bitbucket")
+        assert config.provider == "bitbucket"
+
 
 class TestPreExecAction:
     def test_default_action(self):

--- a/tests/unit/test_provider_defaults.py
+++ b/tests/unit/test_provider_defaults.py
@@ -1,0 +1,46 @@
+"""Tests for zima/providers/defaults.py — default provider resolver."""
+
+import os
+
+import pytest
+
+
+class TestGetDefaultProviderName:
+    def test_returns_github_by_default(self, monkeypatch):
+        """Without env var, default is github."""
+        monkeypatch.delenv("ZIMA_GIT_REPO_PROVIDER", raising=False)
+        from zima.providers.defaults import get_default_provider_name
+
+        assert get_default_provider_name() == "github"
+
+    def test_returns_env_var_when_set(self, monkeypatch):
+        """With env var set, returns its value."""
+        monkeypatch.setenv("ZIMA_GIT_REPO_PROVIDER", "gitlab")
+        from zima.providers.defaults import get_default_provider_name
+
+        assert get_default_provider_name() == "gitlab"
+
+    def test_returns_empty_string_if_env_var_empty(self, monkeypatch):
+        """Empty env var is treated as a valid provider name."""
+        monkeypatch.setenv("ZIMA_GIT_REPO_PROVIDER", "")
+        from zima.providers.defaults import get_default_provider_name
+
+        assert get_default_provider_name() == ""
+
+
+class TestIsDefaultProvider:
+    def test_github_is_default_when_no_env(self, monkeypatch):
+        """Without env var, 'github' is the default."""
+        monkeypatch.delenv("ZIMA_GIT_REPO_PROVIDER", raising=False)
+        from zima.providers.defaults import is_default_provider
+
+        assert is_default_provider("github") is True
+        assert is_default_provider("gitlab") is False
+
+    def test_custom_default_matches_env(self, monkeypatch):
+        """With env var, the env value is the default."""
+        monkeypatch.setenv("ZIMA_GIT_REPO_PROVIDER", "gitlab")
+        from zima.providers.defaults import is_default_provider
+
+        assert is_default_provider("gitlab") is True
+        assert is_default_provider("github") is False

--- a/tests/unit/test_provider_defaults.py
+++ b/tests/unit/test_provider_defaults.py
@@ -1,9 +1,5 @@
 """Tests for zima/providers/defaults.py — default provider resolver."""
 
-import os
-
-import pytest
-
 
 class TestGetDefaultProviderName:
     def test_returns_github_by_default(self, monkeypatch):

--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -101,6 +101,45 @@ class TestDetectRepoSlug(TestIsolator):
             assert mock_run.call_args.kwargs.get("cwd") == "/tmp/my-repo"
             assert result == "zhuxixi/zima-blue-cli"
 
+    def test_detect_repo_slug_gitlab_nested_group(self):
+        """Test GitLab nested group path is preserved in full."""
+        from zima.commands.quickstart import _detect_repo_slug
+
+        with patch("zima.commands.quickstart.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="git@gitlab.com:group/sub/proj.git\n",
+                stderr="",
+            )
+            result = _detect_repo_slug()
+            assert result == "group/sub/proj"
+
+    def test_detect_repo_slug_gitlab_nested_group_https(self):
+        """Test GitLab nested group via HTTPS preserves full path."""
+        from zima.commands.quickstart import _detect_repo_slug
+
+        with patch("zima.commands.quickstart.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="https://gitlab.com/group/sub/proj.git\n",
+                stderr="",
+            )
+            result = _detect_repo_slug()
+            assert result == "group/sub/proj"
+
+    def test_detect_repo_slug_deeply_nested(self):
+        """Test deeply nested group with 4+ segments."""
+        from zima.commands.quickstart import _detect_repo_slug
+
+        with patch("zima.commands.quickstart.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="git@gitlab.com:a/b/c/d/proj.git\n",
+                stderr="",
+            )
+            result = _detect_repo_slug()
+            assert result == "a/b/c/d/proj"
+
 
 class TestGenerateUniqueCode(TestIsolator):
     """Test unique code generation."""

--- a/tests/unit/test_scenes.py
+++ b/tests/unit/test_scenes.py
@@ -46,6 +46,28 @@ class TestSceneDataclass:
         )
         assert scene.default_actions is None
 
+    def test_scene_default_provider_from_env(self, monkeypatch):
+        """Scene() resolves provider from ZIMA_GIT_REPO_PROVIDER."""
+        monkeypatch.setenv("ZIMA_GIT_REPO_PROVIDER", "gitlab")
+        scene = Scene(
+            name="Test",
+            description="Test",
+            workflow_template="hi",
+            variables={},
+        )
+        assert scene.provider == "gitlab"
+
+    def test_scene_default_provider_github_without_env(self, monkeypatch):
+        """Scene() defaults to 'github' without env var."""
+        monkeypatch.delenv("ZIMA_GIT_REPO_PROVIDER", raising=False)
+        scene = Scene(
+            name="Test",
+            description="Test",
+            workflow_template="hi",
+            variables={},
+        )
+        assert scene.provider == "github"
+
 
 class TestBuiltinScenes:
     """Test BUILTIN_SCENES structure."""

--- a/zima/commands/quickstart.py
+++ b/zima/commands/quickstart.py
@@ -68,9 +68,8 @@ def _detect_repo_slug(work_dir: str = "") -> str:
         path = url
 
     path = path.strip("/").removesuffix(".git")
-    parts = path.split("/")
-    if len(parts) >= 2:
-        return f"{parts[-2]}/{parts[-1]}"
+    if "/" in path:
+        return path
     return ""
 
 

--- a/zima/models/actions.py
+++ b/zima/models/actions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from zima.models.serialization import YamlSerializable, omit_empty
+from zima.providers.defaults import get_default_provider_name, is_default_provider
 
 VALID_ACTION_CONDITIONS = {"success", "failure", "always"}
 VALID_POST_ACTION_TYPES = {"add_label", "add_comment"}
@@ -116,20 +117,25 @@ class ActionsConfig(YamlSerializable):
     """Collection of actions for a PJob.
 
     Attributes:
-        provider: The action provider to use (default: "github").
+        provider: The action provider to use. Defaults to ZIMA_GIT_REPO_PROVIDER
+            env var, or "github" if unset.
         pre_exec: List of PreExecAction instances to run before the agent starts.
         post_exec: List of PostExecAction instances to run after agent exits.
     """
 
     FIELD_ALIASES = {"pre_exec": "preExec", "post_exec": "postExec"}
 
-    provider: str = "github"
+    provider: str | None = None
     pre_exec: list[PreExecAction] = field(default_factory=list)
     post_exec: list[PostExecAction] = field(default_factory=list)
 
+    def __post_init__(self):
+        if self.provider is None:
+            self.provider = get_default_provider_name()
+
     def to_dict(self) -> dict:
         d = omit_empty(super().to_dict())
-        if self.provider == "github":
+        if is_default_provider(self.provider):
             d.pop("provider", None)
         return d
 

--- a/zima/providers/defaults.py
+++ b/zima/providers/defaults.py
@@ -1,0 +1,21 @@
+"""Default provider resolution via environment variable."""
+
+from __future__ import annotations
+
+import os
+
+DEFAULT_PROVIDER_ENV = "ZIMA_GIT_REPO_PROVIDER"
+_FALLBACK_PROVIDER = "github"
+
+
+def get_default_provider_name() -> str:
+    """Return the default action provider name.
+
+    Reads ``ZIMA_GIT_REPO_PROVIDER`` env var, falling back to ``"github"``.
+    """
+    return os.environ.get(DEFAULT_PROVIDER_ENV, _FALLBACK_PROVIDER)
+
+
+def is_default_provider(name: str) -> bool:
+    """Return True if *name* matches the resolved default provider."""
+    return name == get_default_provider_name()

--- a/zima/scenes.py
+++ b/zima/scenes.py
@@ -9,30 +9,25 @@ from typing import Optional
 import yaml
 
 from zima.models.actions import ActionsConfig, PostExecAction, PreExecAction
+from zima.providers.defaults import get_default_provider_name
 from zima.utils import get_zima_home
 
 
 @dataclass
 class Scene:
-    """A quickstart scene template with rendering variables and provider config.
-
-    Attributes:
-        name: Display name for the scene.
-        description: Short description shown in the quickstart wizard.
-        workflow_template: Jinja2 template string rendered into the agent prompt.
-        variables: Default variable values for the template.
-        provider: Action provider name (default ``"github"``).
-        scan_command: Optional CLI command to scan for items (e.g. PRs/MRs).
-        default_actions: Optional default actions (postExec label transitions, etc.).
-    """
+    """A quickstart scene template with rendering variables and provider config."""
 
     name: str
     description: str
     workflow_template: str
     variables: dict[str, str]
-    provider: str = "github"
+    provider: str | None = None
     scan_command: Optional[list[str]] = None
     default_actions: Optional[ActionsConfig] = None
+
+    def __post_init__(self):
+        if self.provider is None:
+            self.provider = get_default_provider_name()
 
 
 BUILTIN_SCENES: dict[str, Scene] = {


### PR DESCRIPTION
## Summary

- Add `zima/providers/defaults.py` with `get_default_provider_name()` and `is_default_provider()` to resolve default provider from `ZIMA_GIT_REPO_PROVIDER` env var (fallback: `"github"`)
- Update `ActionsConfig` and `Scene` to use dynamic defaults via `__post_init__` instead of hardcoded `"github"`
- Fix `_detect_repo_slug` to preserve full path for nested GitLab groups (e.g., `group/sub/proj`) instead of truncating to last 2 segments

## Acceptance Criteria (from #102)

- [x] `ZIMA_GIT_REPO_PROVIDER` env var overrides all hardcoded `"github"` defaults
- [x] Without env var, behavior is identical to current code (all defaults = `"github"`)
- [x] `ActionsConfig.to_dict()` omits provider only when it matches the resolved default
- [x] `Scene.provider` supports env var override
- [x] `_detect_repo_slug` preserves full path (no segment truncation)
- [x] Internal providers register via `pyproject.toml` `[project.entry-points."zima.action_providers"]` (already supported by existing `ProviderRegistry`)

## Test plan

- [x] 5 new tests for `defaults.py` resolver
- [x] 6 new tests for `ActionsConfig` env var behavior
- [x] 2 new tests for `Scene` env var behavior
- [x] 3 new tests for nested GitLab group slug detection
- [x] All existing tests pass (467 passed, 1 skipped)
- [x] Coverage: 72.5% (above 60% threshold)

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)