### PR TITLE
feat(actions): add git-pull preExec action type

### DIFF
--- a/tests/unit/test_actions_runner.py
+++ b/tests/unit/test_actions_runner.py
@@ -418,6 +418,8 @@ class TestActionsRunnerPreExec:
 
     def test_git_pull_success(self):
         """Test git_pull runs git pull in workdir and returns empty dict."""
+        import subprocess as _subprocess
+
         runner = ActionsRunner()
         actions = ActionsConfig(pre_exec=[PreExecAction(type="git_pull")])
         mock_provider = MagicMock()
@@ -428,6 +430,7 @@ class TestActionsRunnerPreExec:
         mock_run.assert_called_once_with(
             ["git", "pull"],
             cwd="/path/to/repo",
+            stdin=_subprocess.DEVNULL,
             capture_output=True,
             text=True,
             timeout=60,
@@ -476,6 +479,20 @@ class TestActionsRunnerPreExec:
         assert "Warning" in captured.out
         assert "no workdir" in captured.out
         mock_run.assert_not_called()
+        assert result == {}
+
+    def test_git_pull_file_not_found(self, capsys):
+        """Test git_pull with FileNotFoundError (git not on PATH) logs warning."""
+        runner = ActionsRunner()
+        actions = ActionsConfig(pre_exec=[PreExecAction(type="git_pull")])
+        mock_provider = MagicMock()
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            with patch("zima.execution.actions_runner.subprocess.run") as mock_run:
+                mock_run.side_effect = FileNotFoundError("git not found")
+                result = runner.run_pre(actions, {}, workdir="/path/to/repo")
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out
+        assert "git not found" in captured.out
         assert result == {}
 
 

--- a/tests/unit/test_actions_runner.py
+++ b/tests/unit/test_actions_runner.py
@@ -4,7 +4,7 @@ import pytest
 
 from zima.actions.exceptions import ProviderNotFoundError
 from zima.execution.actions_runner import ActionsRunner, SkipAction, _matches_condition
-from zima.models.actions import ActionsConfig, PostExecAction
+from zima.models.actions import ActionsConfig, PostExecAction, PreExecAction
 
 
 class TestMatchesCondition:
@@ -328,8 +328,6 @@ class TestActionsRunnerErrorPropagation:
 class TestActionsRunnerPreExec:
     def test_run_pre_exec_scan_pr(self):
         """Test running preExec scan_pr action returns discovered variables."""
-        from zima.models.actions import PreExecAction
-
         runner = ActionsRunner()
         actions = ActionsConfig(
             pre_exec=[
@@ -361,8 +359,6 @@ class TestActionsRunnerPreExec:
 
     def test_run_pre_exec_empty_result(self):
         """Test preExec scan_pr with no results raises SkipAction."""
-        from zima.models.actions import PreExecAction
-
         runner = ActionsRunner()
         actions = ActionsConfig(
             pre_exec=[PreExecAction(type="scan_pr", repo="owner/repo", label="x")]
@@ -376,8 +372,6 @@ class TestActionsRunnerPreExec:
 
     def test_run_pre_provider_not_found(self, capsys):
         """Test run_pre warns and returns empty dict when provider is not found."""
-        from zima.models.actions import PreExecAction
-
         runner = ActionsRunner()
         actions = ActionsConfig(
             provider="nonexistent",
@@ -398,8 +392,6 @@ class TestActionsRunnerPreExec:
 
     def test_run_pre_exec_env_substitution(self):
         """Test env variable substitution in run_pre before calling scan_prs."""
-        from zima.models.actions import PreExecAction
-
         runner = ActionsRunner()
         actions = ActionsConfig(
             pre_exec=[
@@ -424,11 +416,71 @@ class TestActionsRunnerPreExec:
             assert result["pr_number"] == "7"
             assert result["pr_diff"] == "diff data"
 
+    def test_git_pull_success(self):
+        """Test git_pull runs git pull in workdir and returns empty dict."""
+        runner = ActionsRunner()
+        actions = ActionsConfig(pre_exec=[PreExecAction(type="git_pull")])
+        mock_provider = MagicMock()
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            with patch("zima.execution.actions_runner.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                result = runner.run_pre(actions, {}, workdir="/path/to/repo")
+        mock_run.assert_called_once_with(
+            ["git", "pull"],
+            cwd="/path/to/repo",
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result == {}
+
+    def test_git_pull_failure_continues(self, capsys):
+        """Test git_pull with non-zero returncode logs warning and continues."""
+        runner = ActionsRunner()
+        actions = ActionsConfig(pre_exec=[PreExecAction(type="git_pull")])
+        mock_provider = MagicMock()
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            with patch("zima.execution.actions_runner.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1, stderr="merge conflict")
+                result = runner.run_pre(actions, {}, workdir="/path/to/repo")
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out
+        assert "merge conflict" in captured.out
+        assert result == {}
+
+    def test_git_pull_timeout(self, capsys):
+        """Test git_pull timeout logs warning and continues."""
+        import subprocess as _subprocess
+
+        runner = ActionsRunner()
+        actions = ActionsConfig(pre_exec=[PreExecAction(type="git_pull")])
+        mock_provider = MagicMock()
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            with patch("zima.execution.actions_runner.subprocess.run") as mock_run:
+                mock_run.side_effect = _subprocess.TimeoutExpired(cmd="git pull", timeout=60)
+                result = runner.run_pre(actions, {}, workdir="/path/to/repo")
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out
+        assert "timed out" in captured.out
+        assert result == {}
+
+    def test_git_pull_no_workdir(self, capsys):
+        """Test git_pull skipped with warning when no workdir configured."""
+        runner = ActionsRunner()
+        actions = ActionsConfig(pre_exec=[PreExecAction(type="git_pull")])
+        mock_provider = MagicMock()
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            with patch("zima.execution.actions_runner.subprocess.run") as mock_run:
+                result = runner.run_pre(actions, {})
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out
+        assert "no workdir" in captured.out
+        mock_run.assert_not_called()
+        assert result == {}
+
 
 class TestActionsRunnerPreExecSkipLogic:
     def _make_actions(self, repo="owner/repo", label="zima:needs-review"):
-        from zima.models.actions import PreExecAction
-
         return ActionsConfig(pre_exec=[PreExecAction(type="scan_pr", repo=repo, label=label)])
 
     def test_no_history_falls_back_to_first_pr(self):
@@ -498,8 +550,6 @@ class TestActionsRunnerPreExecSkipLogic:
 
     def test_empty_repo_raises_skip_action(self):
         """Empty repo after substitution raises SkipAction instead of crashing."""
-        from zima.models.actions import PreExecAction
-
         runner = ActionsRunner(pjob_code="my-reviewer")
         actions = ActionsConfig(
             pre_exec=[PreExecAction(type="scan_pr", repo="{{repo}}", label="zima:needs-review")]
@@ -514,8 +564,6 @@ class TestActionsRunnerPreExecSkipLogic:
 
     def test_whitespace_repo_raises_skip_action(self):
         """Whitespace-only repo raises SkipAction."""
-        from zima.models.actions import PreExecAction
-
         runner = ActionsRunner()
         actions = ActionsConfig(
             pre_exec=[PreExecAction(type="scan_pr", repo="{{repo}}", label="zima:needs-review")]
@@ -529,8 +577,6 @@ class TestActionsRunnerPreExecSkipLogic:
 
     def test_empty_label_raises_skip_action(self):
         """Empty label after substitution raises SkipAction."""
-        from zima.models.actions import PreExecAction
-
         runner = ActionsRunner()
         actions = ActionsConfig(
             pre_exec=[PreExecAction(type="scan_pr", repo="owner/repo", label="{{label}}")]

--- a/tests/unit/test_actions_runner.py
+++ b/tests/unit/test_actions_runner.py
@@ -438,7 +438,7 @@ class TestActionsRunnerPreExec:
         assert result == {}
 
     def test_git_pull_failure_continues(self, capsys):
-        """Test git_pull with non-zero returncode logs warning and continues."""
+        """Test git_pull with non-zero returncode logs warning without stderr."""
         runner = ActionsRunner()
         actions = ActionsConfig(pre_exec=[PreExecAction(type="git_pull")])
         mock_provider = MagicMock()
@@ -448,7 +448,8 @@ class TestActionsRunnerPreExec:
                 result = runner.run_pre(actions, {}, workdir="/path/to/repo")
         captured = capsys.readouterr()
         assert "Warning" in captured.out
-        assert "merge conflict" in captured.out
+        assert "rc=1" in captured.out
+        assert "merge conflict" not in captured.out
         assert result == {}
 
     def test_git_pull_timeout(self, capsys):

--- a/tests/unit/test_actions_runner.py
+++ b/tests/unit/test_actions_runner.py
@@ -428,11 +428,12 @@ class TestActionsRunnerPreExec:
                 mock_run.return_value = MagicMock(returncode=0)
                 result = runner.run_pre(actions, {}, workdir="/path/to/repo")
         mock_run.assert_called_once_with(
-            ["git", "pull"],
+            ["git", "pull", "--no-verify"],
             cwd="/path/to/repo",
             stdin=_subprocess.DEVNULL,
             capture_output=True,
             text=True,
+            errors="replace",
             timeout=60,
         )
         assert result == {}

--- a/tests/unit/test_models_actions.py
+++ b/tests/unit/test_models_actions.py
@@ -239,6 +239,11 @@ class TestPreExecAction:
         assert d["repo"] == "o/r"
         assert d["label"] == "x"
 
+    def test_git_pull_valid_type(self):
+        """Test git_pull is accepted as a valid preExec action type."""
+        action = PreExecAction(type="git_pull")
+        assert action.validate() == []
+
 
 class TestActionsConfigPreExec:
     def test_pre_exec_field(self):

--- a/zima/execution/actions_runner.py
+++ b/zima/execution/actions_runner.py
@@ -221,11 +221,12 @@ class ActionsRunner:
                 else:
                     try:
                         pull_result = subprocess.run(
-                            ["git", "pull"],
+                            ["git", "pull", "--no-verify"],
                             cwd=workdir,
                             stdin=subprocess.DEVNULL,
                             capture_output=True,
                             text=True,
+                            errors="replace",
                             timeout=60,
                         )
                         if pull_result.returncode != 0:

--- a/zima/execution/actions_runner.py
+++ b/zima/execution/actions_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from typing import Optional
 
 from zima.actions.base import ActionProvider
@@ -168,12 +169,15 @@ class ActionsRunner:
 
         raise SkipAction(f"All {len(prs)} PR(s) recently attempted, skipping")
 
-    def run_pre(self, actions: ActionsConfig, env: dict[str, str]) -> dict[str, str]:
+    def run_pre(
+        self, actions: ActionsConfig, env: dict[str, str], workdir: Optional[str] = None
+    ) -> dict[str, str]:
         """Execute all preExec actions, return discovered variables.
 
         Args:
             actions: Actions configuration from PJob.
             env: Environment dict for {{VAR}} substitution in action fields.
+            workdir: Working directory for git_pull action (agent's workDir).
 
         Returns:
             Dictionary of discovered variables (e.g., pr_number, pr_url, pr_diff).
@@ -211,6 +215,25 @@ class ActionsRunner:
                 discovered["pr_title"] = pr.get("title") or ""
                 discovered["pr_url"] = pr.get("url") or ""
                 discovered["pr_diff"] = provider.fetch_diff(repo, discovered["pr_number"])
+            elif action.type == "git_pull":
+                if not workdir:
+                    print("Warning: git_pull skipped, no workdir configured")
+                else:
+                    try:
+                        pull_result = subprocess.run(
+                            ["git", "pull"],
+                            cwd=workdir,
+                            capture_output=True,
+                            text=True,
+                            timeout=60,
+                        )
+                        if pull_result.returncode != 0:
+                            print(
+                                f"Warning: git pull failed in {workdir}: "
+                                f"{pull_result.stderr.strip()}"
+                            )
+                    except subprocess.TimeoutExpired:
+                        print(f"Warning: git pull timed out in {workdir}")
             else:
                 print(f"Warning: Unknown preExec action type '{action.type}', skipping")
 

--- a/zima/execution/actions_runner.py
+++ b/zima/execution/actions_runner.py
@@ -223,6 +223,7 @@ class ActionsRunner:
                         pull_result = subprocess.run(
                             ["git", "pull"],
                             cwd=workdir,
+                            stdin=subprocess.DEVNULL,
                             capture_output=True,
                             text=True,
                             timeout=60,
@@ -234,6 +235,8 @@ class ActionsRunner:
                             )
                     except subprocess.TimeoutExpired:
                         print(f"Warning: git pull timed out in {workdir}")
+                    except (FileNotFoundError, OSError) as e:
+                        print(f"Warning: git pull failed in {workdir}: {e}")
             else:
                 print(f"Warning: Unknown preExec action type '{action.type}', skipping")
 

--- a/zima/execution/actions_runner.py
+++ b/zima/execution/actions_runner.py
@@ -230,8 +230,7 @@ class ActionsRunner:
                         )
                         if pull_result.returncode != 0:
                             print(
-                                f"Warning: git pull failed in {workdir}: "
-                                f"{pull_result.stderr.strip()}"
+                                f"Warning: git pull failed in {workdir} (rc={pull_result.returncode})"
                             )
                     except subprocess.TimeoutExpired:
                         print(f"Warning: git pull timed out in {workdir}")

--- a/zima/execution/executor.py
+++ b/zima/execution/executor.py
@@ -214,7 +214,9 @@ class PJobExecutor:
                     for k, v in bundle.get_variable_values().items():
                         if v is not None:
                             pre_env.setdefault(k, str(v))
-                    dynamic_vars = self._actions_runner.run_pre(pjob.spec.actions, pre_env)
+                    dynamic_vars = self._actions_runner.run_pre(
+                        pjob.spec.actions, pre_env, workdir=bundle.work_dir
+                    )
                     # Merge discovered vars into env (for postExec substitution)
                     # Skip keys that already exist in runtime overrides (higher priority)
                     for key, value in dynamic_vars.items():

--- a/zima/models/actions.py
+++ b/zima/models/actions.py
@@ -78,7 +78,7 @@ class PreExecAction(YamlSerializable):
 
     Attributes:
         condition: When to run — "always", "success", or "failure".
-        type: Action type — "scan_pr".
+        type: Action type — "scan_pr" or "git_pull".
         repo: Repository slug in "owner/repo" format (for scan_pr).
         label: Label to scan for (for scan_pr).
         command: Reserved for future use.

--- a/zima/models/actions.py
+++ b/zima/models/actions.py
@@ -9,7 +9,7 @@ from zima.providers.defaults import get_default_provider_name, is_default_provid
 
 VALID_ACTION_CONDITIONS = {"success", "failure", "always"}
 VALID_POST_ACTION_TYPES = {"add_label", "add_comment"}
-VALID_PRE_ACTION_TYPES = {"scan_pr"}
+VALID_PRE_ACTION_TYPES = {"scan_pr", "git_pull"}
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Add `git_pull` as a new preExec action type that runs `git pull` in the agent's workDir before execution
- Non-blocking: failure logs a warning but doesn't skip the PJob (diff comes from GitHub anyway)
- Useful for remote daemon execution where local repos can become stale

## Test plan
- [x] Unit test: `git_pull` validates as valid preExec type
- [x] Unit test: `git_pull` success case runs subprocess correctly
- [x] Unit test: `git_pull` failure (non-zero returncode) logs warning and continues
- [x] Unit test: `git_pull` timeout logs warning and continues
- [x] Unit test: `git_pull` skipped with warning when no workdir configured
- [x] All existing unit tests pass (no regressions)

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)