### PR TITLE
chore: bump version to 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.5.3] - 2026-05-13
+
+### Features
+- **actions**: add git-pull preExec action type
+
+### Changes
+- **plan**: add implementation plan for issue #110 git-pull preExec action
+- **spec**: add design for issue #110 git-pull preExec action
+
+[0.5.3]: https://github.com/zhuxixi/zima-blue-cli/compare/v0.5.2...v0.5.3
+
 ## [0.5.2] - 2026-05-10
 
 ### Fixes

--- a/docs/superpowers/plans/2026-05-10-issue-110-git-pull-preexec.md
+++ b/docs/superpowers/plans/2026-05-10-issue-110-git-pull-preexec.md
@@ -1,0 +1,270 @@
+# git-pull preExec Action Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `git_pull` preExec action type that runs `git pull` in the agent's workDir before execution.
+
+**Architecture:** Extend the existing preExec action dispatch in `ActionsRunner.run_pre()` with a new `git_pull` case. The model constant `VALID_PRE_ACTION_TYPES` gains the new type. The executor passes `workdir` to `run_pre()`. Failure is non-blocking — logs warning and continues.
+
+**Tech Stack:** Python 3.10+, subprocess, unittest.mock for testing
+
+---
+
+### Task 1: Add `git_pull` to valid preExec types
+
+**Files:**
+- Modify: `zima/models/actions.py:12`
+- Test: `tests/unit/test_models_actions.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TestPreExecAction` class in `tests/unit/test_models_actions.py` (after line 240):
+
+```python
+    def test_git_pull_valid_type(self):
+        """Test git_pull is accepted as a valid preExec action type."""
+        action = PreExecAction(type="git_pull")
+        assert action.validate() == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_models_actions.py::TestPreExecAction::test_git_pull_valid_type -v`
+Expected: FAIL — `validate()` rejects `"git_pull"` because it's not in `VALID_PRE_ACTION_TYPES`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `zima/models/actions.py` line 12, change:
+
+```python
+VALID_PRE_ACTION_TYPES = {"scan_pr", "git_pull"}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/test_models_actions.py::TestPreExecAction::test_git_pull_valid_type -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full model tests to confirm no regressions**
+
+Run: `uv run pytest tests/unit/test_models_actions.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add zima/models/actions.py tests/unit/test_models_actions.py
+git commit -m "feat(actions): add git_pull to valid preExec action types"
+```
+
+---
+
+### Task 2: Implement `git_pull` in ActionsRunner
+
+**Files:**
+- Modify: `zima/execution/actions_runner.py:1-4` (imports), `:171-217` (run_pre method)
+- Test: `tests/unit/test_actions_runner.py`
+
+- [ ] **Step 1: Write the failing test for git_pull success**
+
+Add import at top of `tests/unit/test_actions_runner.py`:
+
+```python
+from zima.models.actions import PreExecAction
+```
+
+Note: `PreExecAction` is already imported inside individual test methods. Move it to the top-level imports alongside existing `PostExecAction`.
+
+Add to `TestActionsRunnerPreExec` class (after line 425):
+
+```python
+    def test_git_pull_success(self, capsys):
+        """Test git_pull runs git pull in workdir and returns empty dict."""
+        runner = ActionsRunner()
+        actions = ActionsConfig(
+            pre_exec=[PreExecAction(type="git_pull")]
+        )
+        mock_provider = MagicMock()
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            with patch("zima.execution.actions_runner.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                result = runner.run_pre(actions, {}, workdir="/path/to/repo")
+        mock_run.assert_called_once_with(
+            ["git", "pull"],
+            cwd="/path/to/repo",
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result == {}
+
+    def test_git_pull_failure_continues(self, capsys):
+        """Test git_pull with non-zero returncode logs warning and continues."""
+        runner = ActionsRunner()
+        actions = ActionsConfig(
+            pre_exec=[PreExecAction(type="git_pull")]
+        )
+        mock_provider = MagicMock()
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            with patch("zima.execution.actions_runner.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1, stderr="merge conflict")
+                result = runner.run_pre(actions, {}, workdir="/path/to/repo")
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out
+        assert "merge conflict" in captured.out
+        assert result == {}
+
+    def test_git_pull_timeout(self, capsys):
+        """Test git_pull timeout logs warning and continues."""
+        import subprocess
+
+        runner = ActionsRunner()
+        actions = ActionsConfig(
+            pre_exec=[PreExecAction(type="git_pull")]
+        )
+        mock_provider = MagicMock()
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            with patch("zima.execution.actions_runner.subprocess.run") as mock_run:
+                mock_run.side_effect = subprocess.TimeoutExpired(cmd="git pull", timeout=60)
+                result = runner.run_pre(actions, {}, workdir="/path/to/repo")
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out
+        assert "timed out" in captured.out
+        assert result == {}
+
+    def test_git_pull_no_workdir(self, capsys):
+        """Test git_pull skipped with warning when no workdir configured."""
+        runner = ActionsRunner()
+        actions = ActionsConfig(
+            pre_exec=[PreExecAction(type="git_pull")]
+        )
+        mock_provider = MagicMock()
+        with patch.object(runner._registry, "get", return_value=mock_provider):
+            with patch("zima.execution.actions_runner.subprocess.run") as mock_run:
+                result = runner.run_pre(actions, {})
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out
+        assert "no workdir" in captured.out
+        mock_run.assert_not_called()
+        assert result == {}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_actions_runner.py::TestActionsRunnerPreExec::test_git_pull_success tests/unit/test_actions_runner.py::TestActionsRunnerPreExec::test_git_pull_failure_continues tests/unit/test_actions_runner.py::TestActionsRunnerPreExec::test_git_pull_timeout tests/unit/test_actions_runner.py::TestActionsRunnerPreExec::test_git_pull_no_workdir -v`
+Expected: FAIL — `run_pre()` doesn't accept `workdir` parameter, and no `git_pull` handling exists
+
+- [ ] **Step 3: Update run_pre signature and add git_pull case**
+
+In `zima/execution/actions_runner.py`, add `subprocess` import at the top (after line 3):
+
+```python
+import subprocess
+```
+
+Change `run_pre` signature at line 171:
+
+```python
+    def run_pre(self, actions: ActionsConfig, env: dict[str, str], workdir: Optional[str] = None) -> dict[str, str]:
+```
+
+Update the docstring at line 172-183, add `workdir` param:
+
+```python
+        """Execute all preExec actions, return discovered variables.
+
+        Args:
+            actions: Actions configuration from PJob.
+            env: Environment dict for {{VAR}} substitution in action fields.
+            workdir: Working directory for git_pull action (agent's workDir).
+
+        Returns:
+            Dictionary of discovered variables (e.g., pr_number, pr_url, pr_diff).
+
+        Raises:
+            SkipAction: If a preExec action indicates no work to do.
+        """
+```
+
+Replace the `else` block at line 214-215 with:
+
+```python
+            elif action.type == "git_pull":
+                if not workdir:
+                    print("Warning: git_pull skipped, no workdir configured")
+                else:
+                    try:
+                        pull_result = subprocess.run(
+                            ["git", "pull"],
+                            cwd=workdir,
+                            capture_output=True,
+                            text=True,
+                            timeout=60,
+                        )
+                        if pull_result.returncode != 0:
+                            print(
+                                f"Warning: git pull failed in {workdir}: "
+                                f"{pull_result.stderr.strip()}"
+                            )
+                    except subprocess.TimeoutExpired:
+                        print(f"Warning: git pull timed out in {workdir}")
+            else:
+                print(f"Warning: Unknown preExec action type '{action.type}', skipping")
+```
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_actions_runner.py::TestActionsRunnerPreExec -v`
+Expected: All tests PASS (8 existing + 4 new)
+
+- [ ] **Step 5: Run full test suite to confirm no regressions**
+
+Run: `uv run pytest tests/unit/test_actions_runner.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add zima/execution/actions_runner.py tests/unit/test_actions_runner.py
+git commit -m "feat(actions): implement git_pull preExec action in ActionsRunner"
+```
+
+---
+
+### Task 3: Wire executor to pass workdir to run_pre
+
+**Files:**
+- Modify: `zima/execution/executor.py:217`
+
+- [ ] **Step 1: Update the run_pre call site**
+
+In `zima/execution/executor.py` at line 217, change:
+
+```python
+                    dynamic_vars = self._actions_runner.run_pre(pjob.spec.actions, pre_env)
+```
+
+to:
+
+```python
+                    dynamic_vars = self._actions_runner.run_pre(
+                        pjob.spec.actions, pre_env, workdir=bundle.work_dir
+                    )
+```
+
+- [ ] **Step 2: Run integration tests to verify no regressions**
+
+Run: `uv run pytest tests/integration/test_executor_actions.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `uv run pytest -v`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add zima/execution/executor.py
+git commit -m "feat(executor): pass workdir to run_pre for git_pull action"
+```

--- a/docs/superpowers/specs/2026-05-10-issue-110-git-pull-preexec-design.md
+++ b/docs/superpowers/specs/2026-05-10-issue-110-git-pull-preexec-design.md
@@ -1,0 +1,130 @@
+# Design: git-pull preExec Action Type
+
+**Issue:** #110
+**Date:** 2026-05-10
+**Status:** Approved
+
+## Problem
+
+When PJobs run on remote machines (e.g., 7700k daemon), the local repo can become stale if not manually pulled. While `scan_pr` fetches PR diffs from GitHub directly (not affected by stale local code), the agent's understanding of codebase context relies on local files being up-to-date. Manual `git pull` before reviews is error-prone for unattended daemon execution.
+
+## Solution
+
+Add `git_pull` as a new preExec action type that runs `git pull` in the agent's workDir before execution.
+
+### Approach
+
+Inline in `ActionsRunner.run_pre()`, matching the existing `scan_pr` pattern. Minimal changes — one constant addition and one new case in the type dispatch.
+
+## Design
+
+### 1. Model Changes (`zima/models/actions.py`)
+
+Add `"git_pull"` to `VALID_PRE_ACTION_TYPES`:
+
+```python
+VALID_PRE_ACTION_TYPES = {"scan_pr", "git_pull"}
+```
+
+No field changes to `PreExecAction`. The `git_pull` type has no parameters — workDir comes from the agent config at runtime. The existing `validate()` already checks type against this set.
+
+### 2. Runner Changes (`zima/execution/actions_runner.py`)
+
+#### 2a. `run_pre()` signature change
+
+Add optional `workdir` parameter:
+
+```python
+def run_pre(self, actions: ActionsConfig, env: dict, workdir: Optional[str] = None) -> dict:
+```
+
+#### 2b. New `git_pull` case in type dispatch
+
+Inside the `run_pre()` loop, after the `scan_pr` case:
+
+```python
+if action.type == "git_pull":
+    if not workdir:
+        print("Warning: git_pull skipped, no workdir configured")
+    else:
+        try:
+            result = subprocess.run(
+                ["git", "pull"],
+                cwd=workdir,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if result.returncode != 0:
+                print(f"Warning: git pull failed in {workdir}: {result.stderr.strip()}")
+        except subprocess.TimeoutExpired:
+            print(f"Warning: git pull timed out in {workdir}")
+    # git_pull produces no dynamic vars — continue to next action
+```
+
+**Behavior:**
+- Runs `git pull` in the agent's workDir
+- 60-second timeout — network hangs don't block execution
+- Failure logs a warning only — PJob proceeds (diff comes from GitHub anyway)
+- Produces no dynamic variables — falls through to next preExec action
+- Skipped silently if no workdir is configured
+- If workDir is not a git repo, subprocess fails and is caught as warning
+
+### 3. Executor Changes (`zima/execution/executor.py`)
+
+Pass `workdir` to `run_pre()` at the existing call site (step 5, preExec). The executor already has `agent_workdir` available from the resolved config bundle.
+
+```python
+dynamic_vars = self._actions_runner.run_pre(
+    pjob.spec.actions, pre_env, workdir=agent_workdir
+)
+```
+
+### 4. YAML Usage
+
+```yaml
+actions:
+  preExec:
+    - type: git_pull           # runs git pull in agent's workDir
+    - type: scan_pr
+      repo: '{{repo}}'
+      label: zima:needs-review
+```
+
+`git_pull` runs first (list order), then `scan_pr` operates with the repo freshly updated.
+
+## Tests
+
+### Unit Tests (`tests/unit/test_actions_runner.py`)
+
+Add to `TestActionsRunnerPreExec`:
+- `test_git_pull_success` — mock subprocess, verify empty dict returned
+- `test_git_pull_failure_continues` — mock non-zero returncode, verify warning printed, empty dict returned
+- `test_git_pull_timeout` — mock `subprocess.TimeoutExpired`, verify warning printed
+- `test_git_pull_no_workdir` — verify skipped with warning when workdir is None
+
+### Unit Tests (`tests/unit/test_models_actions.py`)
+
+Add to `TestPreExecAction`:
+- `test_git_pull_valid_type` — verify `git_pull` passes validation
+
+### Integration Tests
+
+Optional: add to existing `TestPreExecToPostExecFlow` to verify git_pull + scan_pr ordering.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `zima/models/actions.py` | Add `"git_pull"` to `VALID_PRE_ACTION_TYPES` |
+| `zima/execution/actions_runner.py` | Add `workdir` param to `run_pre()`, add `git_pull` case |
+| `zima/execution/executor.py` | Pass `workdir=agent_workdir` to `run_pre()` |
+| `tests/unit/test_actions_runner.py` | 4 new tests for git_pull |
+| `tests/unit/test_models_actions.py` | 1 new test for git_pull validation |
+
+## Out of Scope
+
+- Configurable path field (use agent workDir only)
+- Arbitrary command execution (`run_command` preExec type)
+- Retry logic on git pull failure
+- Authentication handling (assumes git credentials are configured)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zima-blue-cli"
-version = "0.5.2"
+version = "0.5.3"
 description = "Zima Blue CLI - Personal Agent Orchestration Platform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -801,7 +801,7 @@ wheels = [
 
 [[package]]
 name = "zima-blue-cli"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary
Bump version from 0.5.2 to 0.5.3

## [0.5.3] - 2026-05-13

### Features
- **actions**: add git-pull preExec action type

### Changes
- **plan**: add implementation plan for issue #110 git-pull preExec action
- **spec**: add design for issue #110 git-pull preExec action

[0.5.3]: https://github.com/zhuxixi/zima-blue-cli/compare/v0.5.2...v0.5.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)