### PR TITLE
refactor(labels): remove unused zima:needs-re-review label

### DIFF
--- a/scripts/init_labels.py
+++ b/scripts/init_labels.py
@@ -16,7 +16,6 @@ import sys
 LABELS = [
     {"name": "zima:needs-review", "color": "0969DA", "description": "等待 code review"},
     {"name": "zima:needs-fix", "color": "CF222E", "description": "CR 发现问题，需要修复"},
-    {"name": "zima:needs-re-review", "color": "BC4C00", "description": "fix 后等待重新 review"},
     {
         "name": "zima:wait-human-merge",
         "color": "2DA44E",


### PR DESCRIPTION
## Summary
- Remove unused `zima:needs-re-review` label from `init_labels.py` (5→4 labels)
- `zima:needs-review` is reused for both initial review and re-review — daemon's `scan_pr` doesn't need to distinguish
- pr-monitor gets loop protection (round >= 3 → `zima:jesus-help`) in a separate skill update

## Label state machine (simplified)
```
zima:needs-review → CR runs → success: remove labels (done)
                             → failure: zima:needs-fix → pr-monitor fix → zima:needs-review
                             → round >= 3: zima:jesus-help (manual intervention)
```

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>