### PR TITLE
feat(marketplace): convert repo to Claude Code marketplace, add pr-automation plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "zima-blue",
+  "owner": {
+    "name": "zhuxixi"
+  },
+  "description": "Zima Blue 系列 Claude Code 插件 — PR 自动化、CR 调度等",
+  "plugins": [
+    {
+      "name": "pr-automation",
+      "source": "./plugins/pr-automation",
+      "description": "GitHub PR 自动化（批量 CR、调度式审查、双 Agent 交叉验证）",
+      "version": "0.1.0",
+      "category": "automation",
+      "keywords": ["github", "pull-request", "code-review", "automation", "zima"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Define Prompt Template → Configure Parameters → Execute → Get Results
 - [Quick Start](#quick-start)
 - [CLI Commands](#cli-commands)
 - [Documentation](#documentation)
+- [Claude Code Marketplace](#claude-code-marketplace)
 - [Development](#development)
 - [Naming Origin](#naming-origin)
 - [License](#license)
@@ -260,6 +261,27 @@ issue → brainstorm/spec → plan → impl → create-PR → CR → post-fix �
 |-----------|-------------|-------|
 | `jfox-kc-code-review-job` | Code review via Kimi CLI | CR |
 | `jfox-zc-code-review-job` | Code review via Zhipu-driven Claude Code | CR |
+
+---
+
+## Claude Code Marketplace
+
+This repository doubles as a **Claude Code plugin marketplace** named `zima-blue`. The plugins here are the Claude Code-side counterparts of zima daemon's automation — install them in your Claude Code session and zima can drive them via scheduled prompts.
+
+### Install
+
+```
+/plugin marketplace add zhuxixi/zima-blue-cli
+/plugin install pr-automation@zima-blue
+```
+
+### Plugins
+
+| Plugin | Purpose | Skills |
+|---|---|---|
+| [`pr-automation`](plugins/pr-automation/) | GitHub PR automation driven by zima daemon | `github-code-review-batch` |
+
+More plugins (e.g. `pr-monitor`) will be added under the same marketplace as zima's automation surface grows.
 
 ---
 

--- a/plugins/pr-automation/.claude-plugin/plugin.json
+++ b/plugins/pr-automation/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "pr-automation",
+  "displayName": "PR Automation",
+  "version": "0.1.0",
+  "description": "GitHub PR 自动化技能集 — 批量代码审查、调度式 CR、双 Agent 交叉验证。配合 zima daemon 实现端到端 PR 处理。",
+  "author": {
+    "name": "zhuxixi"
+  },
+  "homepage": "https://github.com/zhuxixi/zima-blue-cli",
+  "repository": "https://github.com/zhuxixi/zima-blue-cli",
+  "license": "MIT",
+  "keywords": ["github", "pr", "code-review", "automation", "zima"]
+}

--- a/plugins/pr-automation/README.md
+++ b/plugins/pr-automation/README.md
@@ -1,0 +1,39 @@
+# pr-automation
+
+Claude Code plugin for GitHub PR automation. Designed to be driven by the [zima](https://github.com/zhuxixi/zima-blue-cli) daemon scheduler, but works standalone in any Claude Code session that has the `gh` CLI available.
+
+## Skills
+
+| Skill | Purpose | Trigger phrases |
+|---|---|---|
+| `github-code-review-batch` | One-shot batch / scheduled CR for a single PR. Multi-agent parallel review against `CLAUDE.md` + `AGENTS.md`, issue-validation false-positive filtering, metadata-persisted state for cross-session scheduling. | `batch review pr`, `review pr batch`, `scheduled review pr` |
+
+> The trigger phrases are an external contract with the zima daemon — do not rename without coordinated changes on both sides.
+
+## Requirements
+
+- `gh` CLI authenticated against the target repo
+- Python 3.10+ (for the deterministic helper scripts under `skills/*/scripts/`)
+- Claude Code with sub-agent support (the skill spawns parallel review agents)
+
+## Install
+
+```
+/plugin marketplace add zhuxixi/zima-blue-cli
+/plugin install pr-automation@zima-blue
+```
+
+## Relationship to zima daemon
+
+The skill is a **one-shot short session** — it executes one CR round, posts a PR comment, and exits. State persists in PR review metadata (`cc-cr-meta` / `kimi-cr-meta`) so an external scheduler (zima daemon) can alternate between CR and fix agents across rounds.
+
+This is not a watcher process. If you want continuous monitoring, that's a separate concern (and a future skill in this plugin).
+
+## Roadmap
+
+- `github-code-review-batch` ✅
+- `pr-monitor` (planned) — watch a PR for CR + CI results, auto-fix and auto-merge
+
+## License
+
+MIT

--- a/plugins/pr-automation/skills/github-code-review-batch/SKILL.md
+++ b/plugins/pr-automation/skills/github-code-review-batch/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: github-code-review-batch
+description: |
+  对 GitHub Pull Request 进行批量/调度式代码审查（一次性短会话，非监听模式），
+  Claude Code 端。多 Agent 并行检查 CLAUDE.md / AGENTS.md 合规性、bug 和逻辑安全问题，
+  通过 issue 验证机制过滤误报。状态通过 PR 评论的 metadata 持久化，
+  供外部调度器（如 zima daemon）交替调度 CR/fix agent。
+
+  Use when: 用户要求对指定 PR 进行一次性批量审查或调度式审查，
+  且不希望启动后台监听进程。
+  
+  触发词: "batch review pr", "review pr batch", "scheduled review pr"
+---
+
+# GitHub Code Review Batch (Claude Code)
+
+GitHub PR 批量/调度代码审查工具，**非监听模式**。
+
+本 Skill 是**双 CR Agent 交叉验证体系**的一部分：Claude Code 和 Kimi CLI 分别独立审查同一 PR，互相校验审查结论。两个 Agent 的审查结果通过各自的 HTML metadata（`cc-cr-meta` / `kimi-cr-meta`）独立持久化，**互不干扰**——两边读取评论流时严格忽略对方的 metadata 评论，保证交叉验证的独立性。
+
+**与监听模式的区别**：
+- 每次调用都是独立短会话，执行完立即结束，不启动 background watcher
+- 状态完全通过 PR 评论中的 HTML metadata 持久化，下次调用时恢复
+- 适用于外部调度器交替调度 CR agent 和 fix agent 的场景
+- 每次结束输出机器可读的【状态报告】，供调度器决策是否继续调度 fix agent
+
+## 触发与 PR 编号提取
+
+> **⚠️ 触发短语是外部契约**：调度器（zima daemon）通过 skill 名 + 字面短语 `"batch review pr"` / `"review pr batch"` / `"scheduled review pr"` 调用本 skill。改动这些字面短语会破坏外部调度契约——优化 description 时务必保留这三个短语原文。
+
+支持的调用方式：
+
+```
+batch review pr
+batch review pr #123
+review pr batch 456
+scheduled review pr owner/repo#101
+```
+
+PR 编号提取规则（依次尝试）：
+- `#123` 格式
+- 直接数字 `456`
+- `owner/repo#123` 格式
+- 都未提供 → 使用 `Bash` 执行 `gh pr view --json number` 获取当前分支关联的 PR
+- 当前分支也无关联 PR → 提示用户明确提供 PR 编号
+
+## 前置要求
+
+1. **GitHub CLI (`gh`)** 已安装并认证：`gh --version` / `gh auth status`，需要对仓库的读取和评论权限
+2. 当前目录在 Git 仓库中且有 GitHub remote（`git remote -v` 验证）
+3. **Python 3** 可用（用于运行 `scripts/` 下的辅助脚本）
+
+## 主流程总览
+
+执行流程是一个 11 步状态机。SKILL.md 仅给出骨架，遇到任何一步规则不清楚时，read 对应 reference 小节。
+
+| 步骤 | 目的 | 详细规则 |
+|------|------|----------|
+| Step 0 | 检测 previous metadata，判断首次/增量审查 | [flow.md#step-0](references/flow.md#step-0) |
+| Step 0.2a | 解析 committer 对历史 issues 的回应（wontfix / resolved / clarified） | [flow.md#step-0-2a](references/flow.md#step-0-2a) |
+| Step 1 | PR 资格审查（closed/draft/trivial 检查） | [flow.md#step-1](references/flow.md#step-1) |
+| Step 2 | 收集 CLAUDE.md / AGENTS.md（含子目录） | [flow.md#step-2](references/flow.md#step-2) |
+| Step 3 | summarizer 生成变更摘要 | [flow.md#step-3](references/flow.md#step-3), [subagent-prompts.md#summarizer](references/subagent-prompts.md#summarizer) |
+| Step 3.5 | diff 预处理（过滤测试文件 + 长度兜底） | `scripts/compress_diff.py` |
+| Step 4 | 5 个并行审查 Agent | [subagent-prompts.md](references/subagent-prompts.md) |
+| Step 5 | issue-validator 并行验证 | [subagent-prompts.md#issue-validator](references/subagent-prompts.md#issue-validator) |
+| Step 6 | 过滤 + 去重 + 优先级排序 | [flow.md#step-6](references/flow.md#step-6) |
+| Step 7 | 最终资格审查（防止给已关闭 PR 发评论） | [flow.md#step-7](references/flow.md#step-7) |
+| Step 8 | 终端输出 Markdown 报告 | [flow.md#step-8](references/flow.md#step-8) |
+| Step 9 | 构建并发布 PR Review 评论（含 metadata） | `scripts/build_review_body.py` |
+| Step 10 | 输出机器可读状态报告 | `scripts/render_status_report.py` |
+
+**增量审查分支**：[Step 0](references/flow.md#step-0) 检测到有新 commit 且存在上一轮 metadata 时，跳过 Step 3-5，改用单个 delta-reviewer agent。流程详见 [delta-review.md](references/delta-review.md)。
+
+## 关键约束（why 优先）
+
+- **`Bash` 执行所有 `gh` 和 `git` 命令**：保持环境无关性。`gh` CLI 是不依赖 MCP 的最大公约数，跨调度器/容器/裸机都能跑
+- **`Agent` 启动所有审查/验证 sub-agent**：本 skill 需要的并行+独立上下文执行语义，其他工具（如内联 LLM 调用）保证不了
+- **不依赖任何 MCP 工具（如 `pull_request_read`、`add_issue_comment`）**：保持 skill 在不同环境间可移植，避免对接环境时被 MCP 配置卡住
+- **每轮发布新评论，不编辑旧评论**：metadata 是审查历史的事实记录，覆写会丢失中间状态——下游 fix agent 与人类 reviewer 都依赖完整的轮次链
+- **Acknowledged issues 不计入 open**：尊重 committer 决策，避免跨轮反复打扰；调度器只对真正 open 的 issues 调度 fix agent
+
+## 输出契约
+
+每次执行（除 [Step 1](references/flow.md#step-1)/[Step 7](references/flow.md#step-7) 提前终止外）必须产出三个产物：
+
+1. **终端 Markdown review 报告**（[Step 8](references/flow.md#step-8)）
+2. **PR 评论**（[Step 9](references/flow.md#step-9)）：由 `scripts/build_review_body.py` 生成，包含 `<!-- cc-cr-meta ... -->` 机器可读 header + 人类可读 Round-N 部分。完整样例见 [output-examples.md](references/output-examples.md)
+3. **终端状态报告**（[Step 10](references/flow.md#step-10)）：由 `scripts/render_status_report.py` 生成，三态：
+   - `NEEDS_FIX` — 仍有 open issues 需要修复
+   - `PASS` — 无 open issues（可能有 acknowledged）
+   - `NO_NEW_COMMITS` — Step 0 检测到无新 commit，本轮跳过
+
+zima daemon 通过 grep `Status: <state>` 决策下一步动作。
+
+## SubAgent 概览
+
+| Agent | 职责 | 并发数 |
+|-------|------|--------|
+| summarizer | 摘要 PR 变更意图 | 1 |
+| claude-compliance-checker | 检查 CLAUDE.md 合规 | 2（独立运行交叉验证） |
+| agents-compliance-checker | 检查 AGENTS.md 合规 | 1 |
+| bug-scanner | 扫描 bug、缺失导入、未解析引用 | 1 |
+| logic-analyzer | 逻辑/安全分析、资源泄漏、竞态 | 1 |
+| issue-validator | 验证 issue 是否值得保留 | 每个候选 issue 1 个 |
+| delta-reviewer | 增量审查（替代上述 Step 3-5） | 1（仅增量模式） |
+
+每个 agent 的输入契约、输出 schema、prompt 模板：[subagent-prompts.md](references/subagent-prompts.md)。
+
+## 边界情况与故障排除
+
+完整边界情况表（22 条）+ 故障排除（4 类）+ 常见误报类型（6 种）见 [edge-cases.md](references/edge-cases.md)。
+
+几条最容易遇到的：
+- 无新 commit 时：Step 0 直接输出状态报告 `NO_NEW_COMMITS` 退出
+- Metadata 完全无法解析：**报错并停止**，不静默 fallback 到 Round-1（避免破坏调度器状态机）
+- 审查中途 PR 被关闭：Step 7 拦截，不发布评论
+- 所有 issues 都被 committer acknowledged：状态报告输出 `PASS`
+
+## 常用 gh 命令
+
+```bash
+gh pr view --json number                                        # 当前分支关联 PR
+gh pr view <PR>                                                 # PR 详情
+gh pr view <PR> --comments                                      # 所有评论（用于 Step 0.2a）
+gh pr view <PR> --json reviews                                  # review 评论（喂给 parse_metadata.py）
+gh pr view <PR> --json state                                    # PR 状态（Step 7 二次检查）
+gh pr view <PR> --json headRefOid --jq '.headRefOid'            # head SHA（40 字符）
+gh pr view <PR> --json headRepositoryOwner,headRepository       # 仓库信息（构建链接）
+gh pr diff <PR>                                                 # 完整 diff
+gh pr diff <PR> --name-only                                     # 变更文件列表（Step 2）
+gh pr review <PR> --comment --body-file /tmp/cc-cr-{pr}.md      # 发布 review 评论
+```
+
+## 限制说明
+
+1. 仅支持 GitHub 仓库（不支持 GitLab、Bitbucket）
+2. 依赖 `gh` CLI 与 Python 3
+3. 极大 PR（>1000 行）的审查可能不够全面
+4. 不能替代完整的测试套件和人工代码审查
+5. 非代码文件变更（图片、二进制）无法有效审查
+6. 仅静态分析，不执行代码或运行测试
+7. 非监听模式：多轮修复依赖外部调度器交替调度 CR agent 和 fix agent
+
+## 设计原理
+
+1. **多 Agent 并行**：从不同角度独立审查，避免单一视角的盲区
+2. **冗余检查**：两个 CLAUDE.md checker 独立运行交叉验证
+3. **Issue 验证**：每个发现的问题都经过独立验证，大幅降低误报率
+4. **HIGH SIGNAL**：只报告高置信度的问题，避免噪音淹没真正重要的问题
+5. **终端与 PR 同步**：终端输出和 PR 评论完全一致，确保透明性
+6. **进阶披露**：SKILL.md 只载骨架，详细规则在 references/，确定性逻辑在 scripts/

--- a/plugins/pr-automation/skills/github-code-review-batch/references/delta-review.md
+++ b/plugins/pr-automation/skills/github-code-review-batch/references/delta-review.md
@@ -1,0 +1,112 @@
+# Delta Review Flow
+
+当 [Step 0](flow.md#step-0-3) 检测到 PR 有新的 commit（相对于上一轮 review）时，执行**增量审查**而非完整审查。本流程替代完整流程中的 [Step 3](flow.md#step-3) – [Step 5](flow.md#step-5)。
+
+---
+
+## 适用场景
+
+- [Step 0](flow.md#step-0-3) 检测到 previous review metadata 且当前 head SHA != `previous_head_sha`
+
+---
+
+## 输入
+
+- `previous_issues`：从上一轮 metadata 提取的问题列表（含 `id`, `description`, `reason`, `file`, `lines`, `status`, `first_round`），可能含 `resolution` 和 `committer_note` 字段（由 [Step 0.2a](flow.md#step-0-2a) 填充）
+- `previous_head_sha`：上一轮 review 时的 head SHA
+- `current_head_sha`：当前 PR head SHA
+- PR 完整 diff（`gh pr diff` 输出）
+- 相关规范文件（CLAUDE.md / AGENTS.md）
+
+---
+
+## 执行步骤
+
+### Step Δ1: 获取完整 diff
+
+使用 `Bash` 执行 `gh pr diff <PR>` 获取完整 diff。
+
+### Step Δ2: 启动 delta-reviewer Agent
+
+使用 `Agent` 启动 [delta-reviewer](subagent-prompts.md#delta-reviewer)（前台，1 个 Agent），输入：
+- PR 完整 diff
+- `previous_issues` 列表
+- `previous_head_sha`
+- `current_head_sha`
+- 相关规范文件内容
+
+### Step Δ3: 收集 delta-reviewer 结果
+
+delta-reviewer 输出 JSON：
+
+```json
+{
+  "resolved_issues": [
+    {
+      "original_id": "issue-1",
+      "description": "...",
+      "reason": "bug",
+      "file": "src/auth.ts",
+      "lines": "67-72",
+      "resolution_note": "Error handling added in new commit"
+    }
+  ],
+  "acknowledged_issues": [
+    {
+      "original_id": "issue-2",
+      "description": "...",
+      "reason": "logic",
+      "file": "src/server.py",
+      "lines": "45-50",
+      "committer_note": "..."
+    }
+  ],
+  "new_issues": [
+    {
+      "id": "issue-4",
+      "description": "...",
+      "reason": "logic",
+      "file": "src/auth.ts",
+      "lines": "100-105",
+      "suggestion": "..."
+    }
+  ],
+  "unresolved_issues": [
+    {
+      "original_id": "issue-3",
+      "description": "...",
+      "reason": "bug",
+      "file": "src/auth.ts",
+      "lines": "88-95"
+    }
+  ],
+  "pass": false
+}
+```
+
+### Step Δ4: 汇总问题列表
+
+构建当前轮次的完整 issues 列表：
+- `resolved_issues` → 保留原 `id`，标记 `status="resolved"`，`resolution="resolved"`
+- `acknowledged_issues` → 保留原 `id`，标记 `status="open"`，`resolution="acknowledged"`，保留 `committer_note`
+- `unresolved_issues` → 保留原 `id`，标记 `status="open"`，`resolution=null`
+- `new_issues` → 生成新 `id`（如 `"issue-{max_id+1}"`），标记 `status="open"`，`first_round = current_round`
+
+### Step Δ5: 继续至 Step 6
+
+将汇总后的问题列表传入 [Step 6](flow.md#step-6)，继续执行 Step 6-9-10 的标准流程。
+
+注意：[Step 10](flow.md#step-10) 输出状态报告时，`Status` 为 `PASS` 的条件是不存在 `status="open"` 且 `resolution != "acknowledged"` 的 issues。
+
+---
+
+## 与完整流程的区别
+
+| 步骤 | 完整流程 | 增量流程 |
+|------|---------|---------|
+| Step 3 | summarizer + 5 个审查 Agent | delta-reviewer 1 个 Agent |
+| Step 4 | 5 个并行审查 Agent | 由 delta-reviewer 替代 |
+| Step 5 | 每个 issue 单独验证 | 由 delta-reviewer 内部完成对比验证 |
+| 输出 | 全新问题列表 | resolved + acknowledged + new + unresolved 分类 |
+
+**为什么用单 agent 替代 5 agent**：增量审查需要在"对比上一轮 issues 与新 diff"和"扫描新 commit 中的新问题"两件事之间做交叉判断，分散到多个独立 agent 后再合并会丢失上下文。delta-reviewer 在一个 agent 内完成这两件事，更连贯。

--- a/plugins/pr-automation/skills/github-code-review-batch/references/edge-cases.md
+++ b/plugins/pr-automation/skills/github-code-review-batch/references/edge-cases.md
@@ -1,0 +1,141 @@
+# Edge Cases, Troubleshooting, and Common False Positives
+
+---
+
+## 边界情况处理 {#边界情况}
+
+| 情况 | 处理方式 |
+|------|----------|
+| PR 已关闭/已合并 | [Step 1](flow.md#step-1) 或 [Step 7](flow.md#step-7) 捕获，停止执行并向用户说明 |
+| PR 是草稿 | [Step 1](flow.md#step-1) 捕获，停止执行并向用户说明 |
+| PR 是 trivial/自动化 | [Step 1](flow.md#step-1) 捕获，停止执行并向用户说明 |
+| 已有 bot 评论 | 正常审查，不跳过（非监听模式下多轮审查是预期行为） |
+| PR 由 AI 生成 | 正常审查，不跳过 |
+| 无 CLAUDE.md / AGENTS.md | 仅执行 bug scanner 和 logic analyzer |
+| 大 PR（超过 50 个文件） | 正常处理，并行 Agent 保证效率 |
+| 所有 issue 验证为无效 | 输出 "No issues found" |
+| 审查过程中 PR 关闭 | [Step 7](flow.md#step-7) 捕获，不发布评论 |
+| `gh` 命令失败 | 向用户报告错误详情，停止执行 |
+| 当前分支无关联 PR | 提示用户提供 PR 编号 |
+| 提取不到完整 SHA | 使用 `gh pr view <PR> --json headRefOid` 获取 head SHA，失败则报错 |
+| Agent 返回格式错误的 JSON | 尝试解析，失败则忽略该 Agent 的输出 |
+| diff 过大无法完整处理 | [Step 3.5](flow.md#step-3-5) 预处理：过滤测试文件 + 4000 字符硬限制（hunk-only 压缩 + 截断），不再丢弃整个分析 |
+| 无新 commit（调度器轮询） | [Step 0](flow.md#step-0-3) 检测 → 输出状态报告（含仍 open 的 issues），Status: `NO_NEW_COMMITS` |
+| Metadata 部分损坏（能拿到 round） | 以读到的 round 为底线，本轮 round+1，其余 fallback 默认值，输出警告 |
+| Metadata 完全无法解析 | 报错并停止；**不再静默 fallback 到 Round-1**（避免破坏外部调度器状态机） |
+| Round 编号溢出（>99） | 继续递增，无上限 |
+| committer 评论中无明确信号 | 分类为 null，按原有流程处理 |
+| committer 回应与代码实际不符 | delta-reviewer 结合 diff 判断，**以代码为准** |
+| 所有 open issues 被标记 acknowledged | 输出状态报告，Status: `PASS`（无真正 open issues） |
+
+---
+
+## 故障排除 {#故障排除}
+
+### 问题：无法获取 PR 信息
+
+**原因**：`gh` 未安装、未认证、或当前目录不在 Git 仓库中。
+
+**解决**：
+1. 运行 `gh --version` 确认已安装
+2. 运行 `gh auth status` 确认已认证
+3. 运行 `git remote -v` 确认有 GitHub remote
+
+### 问题：审查后没有发布评论
+
+**原因**：
+- PR 在审查过程中被关闭或合并（[Step 7](flow.md#step-7) 拦截）
+- `gh pr review` 命令失败
+- PR 未通过资格审查
+
+**排查**：
+1. 检查终端输出中的资格审查结果
+2. 检查 [Step 7](flow.md#step-7) 的输出
+3. 检查 `gh pr review` 是否有错误信息
+
+### 问题：Agent 输出格式错误
+
+**原因**：SubAgent 没有按要求输出 JSON。
+
+**解决**：
+- 在 prompt 中明确要求输出 JSON
+- 如果解析失败，忽略该 Agent 的输出，继续处理其他 Agent 的结果
+
+### 问题：代码链接无法点击
+
+**原因**：SHA 不完整、格式不正确、或行号计算错误。
+
+**解决**：
+- 确保使用 `gh pr view <PR> --json headRefOid --jq '.headRefOid'` 获取完整 40 字符 SHA
+- 确保格式严格为 `https://github.com/owner/repo/blob/[sha]/path#L[start]-L[end]`
+- 由 [build_review_body.py](../scripts/build_review_body.py) 生成时这些约束已固化
+
+---
+
+## 常见误报类型 {#常见误报}
+
+以下是审查 Agent 容易产生误报的场景，[issue-validator](subagent-prompts.md#issue-validator) 应特别注意识别：
+
+1. **原有问题**：问题在 PR 之前就已经存在，不是本次变更引入的
+2. **误读逻辑**：Agent 误解了代码的执行路径或条件分支
+3. **过度推断**：从代码中推导出了没有直接证据支持的结论
+4. **假设性问题**：基于某种假设场景（如极端输入）提出的问题
+5. **规范误用**：将不适用于当前代码类型的规范规则强加于此
+6. **上下文缺失**：由于未读取完整上下文而做出的错误判断
+
+### 有效 issue 示例
+
+```json
+{
+  "description": "函数返回了未初始化的变量，在错误路径中可能导致未定义行为",
+  "reason": "bug",
+  "file": "src/api/handlers.py",
+  "lines": "45-52",
+  "suggestion": "在错误路径中为 result 设置默认值或提前返回"
+}
+```
+
+### 无效 issue 示例（应被 validator 过滤）
+
+```json
+{
+  "description": "这个函数名不够描述性",
+  "reason": "CLAUDE.md",
+  "file": "src/utils.py",
+  "lines": "12-15",
+  "suggestion": "改为更具描述性的名字"
+}
+```
+
+过滤原因：CLAUDE.md 中并未明确规定函数命名的具体要求，属于主观判断。
+
+---
+
+## 审查覆盖原则 {#审查覆盖原则}
+
+各 checker 共享的判断框架。
+
+### 优先标记以下问题（高优先级）
+
+- **编译/解析错误**：语法错误、无法通过编译的代码
+- **缺失导入**：使用了未导入的模块、函数、类
+- **未解析引用**：引用了不存在的变量、函数、属性
+- **确定性逻辑错误**：代码逻辑明显错误，不依赖外部输入即可判定
+- **规范违规**：`CLAUDE.md` 或 `AGENTS.md` 中的规则违反（尽量引用规则原文；对于逻辑/安全问题，无需强制引用规范）
+- **资源泄漏与安全漏洞**：未关闭的文件句柄、未释放的连接、明显的注入风险、竞态条件
+
+### 同样值得关注的问题（中优先级）
+
+- **错误处理缺失**：关键路径缺少异常处理、错误码被静默吞掉
+- **边界条件问题**：空值、空列表、零除等未处理的边界情况
+- **文档与代码不一致**：PR 描述或文档声称做了某事，但代码实际未做到（如声称更新了某文件但 diff 中不存在）
+- **潜在的逻辑缺陷**：条件判断明显不合理、循环/递归终止条件有问题
+
+### 不标记以下问题
+
+- **代码风格问题**：缩进、命名风格、括号位置等纯格式问题
+- **一般代码质量问题**：函数过长、圈复杂度高等（除非导致明确错误）
+- **主观性建议**："这里可以优化..."、"建议换一种写法..." 等没有明确对错的意见
+- **PR 未修改的原有代码中的问题**：只审查变更内容
+- **Linter / TypeChecker 可以捕获的问题**：如果静态分析工具已经能发现，不重复报告
+- **已被 lint-ignore 注释忽略的规则**：代码中明确有 `eslint-disable`、`type: ignore` 等注释的，尊重开发者意图

--- a/plugins/pr-automation/skills/github-code-review-batch/references/flow.md
+++ b/plugins/pr-automation/skills/github-code-review-batch/references/flow.md
@@ -1,0 +1,373 @@
+# Flow: github-code-review-batch
+
+本文件包含 SKILL.md 主流程总览中各 Step 的详细规则。SKILL.md 通过锚点引用本文件具体小节。
+
+---
+
+## Step 0: 审查类型判断 {#step-0}
+
+本 Skill 为非监听模式，每次调用都是独立短会话。状态完全通过 PR 评论中的 metadata 持久化。在正式审查之前，判断本次审查的类型：首次完整审查，还是基于前一轮 metadata 的增量审查。
+
+### 0.1 检测 previous review metadata {#step-0-1}
+
+使用 `Bash` 执行：
+```bash
+gh pr view <PR> --json reviews --jq '.reviews[] | {body: .body, submitted_at: .submitted_at}'
+```
+
+把 JSON 通过 stdin 传给 `scripts/parse_metadata.py`，脚本返回最新一条 Claude Code 评论的 cc-cr-meta JSON（无则返回 `{}`）。详见 [scripts/parse_metadata.py](../scripts/parse_metadata.py)。
+
+脚本内部规则：
+1. 评论 body 包含 `"Generated with Claude Code"`
+2. 评论 body 包含 `"<!-- cc-cr-meta"`
+3. 按 `submitted_at` 排序，取最新一条
+4. 用正则 `<!-- cc-cr-meta\n(.*?)\n-->` 提取 JSON
+
+得到 metadata 字段：`round`, `head_sha`, `previous_head_sha`, `issues` 等。
+
+### 0.2a 读取并解析 committer 回应 {#step-0-2a}
+
+对于增量审查，在提取 previous_issues 后，需要读取 committer 对上一轮 issues 的回应，避免重复标记已解释/已拒绝修复的问题。
+
+**执行步骤：**
+
+1. 使用 `Bash` 执行 `gh pr view <PR> --comments` 获取所有 PR 评论
+2. 过滤掉所有 AI CR 评论（Claude Code 评论 body 包含 `"Generated with Claude Code"`，Kimi CLI 评论 body 包含 `"<!-- kimi-cr-meta"`），保留 committer / human reviewer 的评论。两个 Agent 的审查结论互不参考，保证交叉验证的独立性
+3. 对每个 `status="open"` 的 previous issue，检查 committer 评论中是否提及该 issue：
+   - 匹配方式：issue 描述前 10 个单词、或 `file:lines` 组合、或 `"issue-{id}"` 引用
+4. **分类 committer 回应**（关键词匹配，不区分大小写）：
+
+| 信号关键词 | 分类 (`resolution`) | 处理方式 |
+|-----------|---------------------|---------|
+| "wontfix", "won't fix", "by design", "intentional", "not a bug", "不需要修复", "不修复", "设计如此" | `wontfix` | 标记为 acknowledged，不列入 "Still open" |
+| "fixed", "已修复", "done", "resolved", "addressed" | `resolved` | 标记 `status="resolved"`（delta-reviewer 再验证） |
+| "clarify", "说明", "actually", "context:", "returns", "只返回", "strictly" | `clarified` | 添加 `committer_note`，传递给 delta-reviewer |
+| 无明确信号 | `null` | 无变化，按原有流程处理 |
+
+5. 当分类为 `wontfix` 或 `clarified` 时，在对应 issue 上增加字段：
+   - `resolution`: `"acknowledged"` / `"wontfix"` / `"resolved"` / `null`
+   - `committer_note`: committer 评论中的相关原文片段
+
+**为什么不脚本化这一步**：分类是启发式的，"前 10 个单词"匹配本身需要 NLP 直觉。脚本化容易因边界情况失真。不确定时，优先分类为 `clarified` 而非 `wontfix`，以保留人工判断空间。
+
+### 0.3 判断分支 {#step-0-3}
+
+**有 previous review metadata？**
+- 是 → 使用 `Bash` 执行 `gh pr view <PR> --json headRefOid --jq '.headRefOid'` 获取当前 head SHA
+  - 当前 SHA == `previous_head_sha` → **无新 commit**
+    - 输出：`"No new commits since Round-{round} review. Previous issues may still be open."`
+    - 列出仍 open 的 issues（排除已标记 `resolution="acknowledged"` / `"wontfix"` 的）
+    - 输出【状态报告】（见 [Step 10](#step-10)），Status: `NO_NEW_COMMITS`
+    - 结束
+  - 当前 SHA != `previous_head_sha` → **有新 commit**
+    - 标记当前为 `Round = round + 1`
+    - 提取 `previous_issues = issues`
+    - 执行 [Step 0.2a](#step-0-2a)：读取并解析 committer 对上一轮 issues 的回应，更新 `previous_issues` 的 `resolution` 和 `committer_note` 字段
+    - 进入【增量审查流程】（见 [delta-review.md](delta-review.md)），跳过 Step 1 之后的 Step 3-5
+- 否 → 首次审查 → 走完整流程（Round = 1）
+
+### 0.4 异常情况 {#step-0-4}
+
+- **Metadata 字段部分损坏但能拿到 round**：以读到的 round 为底线，本轮取 `round + 1`，其余字段按 fallback 默认（如 `previous_head_sha=null`，`previous_issues=[]`），输出警告
+- **Metadata 完全无法解析（连 round 都拿不到）**：报错并停止执行。**不再静默 fallback 到 Round-1**，因为对已存在 Round-N 历史的 PR 重置 round 会破坏外部调度器的状态机
+- `gh pr view --json reviews` 失败 → 视为无 previous review，继续正常 Round-1 流程
+
+---
+
+## Step 1: PR 资格审查 {#step-1}
+
+使用 `Bash` 执行 `gh pr view <PR>` 和 `gh pr view <PR> --comments` 检查 PR 状态。
+
+检查以下任一条件：
+- PR 是否已关闭 (state: CLOSED)
+- PR 是否为草稿 (isDraft: true)
+- PR 是否是 trivial PR（如 dependabot、renovate、纯格式化、仅修改配置文件）
+- PR 是否是自动化 PR（PR 标题或描述包含 "automated"、"bot" 等标识）
+
+如果上述任一条件为真，立即停止执行，向用户说明原因，不继续审查。
+
+**为什么不检查"是否已有 bot 评论"**：与监听模式不同，非监听模式下同一 PR 会被外部调度器多次审查（首次 → 增量 → 增量...），这是预期行为。Step 0 会通过 metadata 和 SHA 对比自动判断是首次审查还是增量审查。
+
+**为什么不跳过 AI 生成的 PR**：AI 生成的 PR 也可能存在规范违规或逻辑错误，因此不跳过。
+
+如何判断 trivial PR：
+- 标题包含 "bump"、"update"、"dependabot"、"renovate"、"format"、"lint"
+- 只修改了配置文件（如 `.github/workflows`、`.prettierrc`、锁文件）
+- 变更行数极少且明显无意义
+
+---
+
+## Step 2: 收集项目规范 {#step-2}
+
+使用 `Bash` 执行 `gh pr diff <PR> --name-only` 获取变更文件列表。
+
+根据变更文件路径，读取以下规范文件（使用 `Read` 工具）：
+- 根目录的 `CLAUDE.md`
+- 根目录的 `AGENTS.md`
+- 变更文件所在子目录的 `CLAUDE.md`
+- 变更文件所在子目录的 `AGENTS.md`
+
+例如，如果变更文件为 `src/utils/helpers.py`，则需要检查：
+- `./CLAUDE.md`
+- `./AGENTS.md`
+- `./src/CLAUDE.md`
+- `./src/AGENTS.md`
+- `./src/utils/CLAUDE.md`
+- `./src/utils/AGENTS.md`
+
+将读取到的规范文件内容汇总为一个规范上下文字符串，供后续审查 Agent 使用。如果某目录下没有规范文件，则跳过。
+
+**冲突处理**：子目录的规范文件优先于父目录。如果存在冲突，以最深目录的规范为准。
+
+---
+
+## Step 3: 获取 PR 摘要 {#step-3}
+
+使用 `Bash` 执行：
+- `gh pr view <PR>` 获取 PR 标题和描述
+- `gh pr diff <PR>` 获取完整 diff
+
+使用 `Agent` 启动 summarizer subagent（详见 [subagent-prompts.md#summarizer](subagent-prompts.md#summarizer)），输入包括 PR 标题、PR 描述、PR diff 内容。summarizer 输出一段简洁的变更摘要（不超过 300 字），帮助后续审查 Agent 快速理解变更意图。
+
+---
+
+## Step 3.5: Diff 预处理 {#step-3-5}
+
+在将 diff 传入 sub-agent 之前，进行预处理和长度保护，避免完整 diff 直接嵌入 prompt 导致 JSON 解析失败（参见原 issue #4）。
+
+调用 [scripts/compress_diff.py](../scripts/compress_diff.py) 执行预处理：
+
+**按 agent 类型过滤 diff**：
+- CLAUDE.md checker ×2、AGENTS.md checker：接收**完整 diff**（规范检查需要完整上下文），仅应用长度兜底
+  ```bash
+  gh pr diff <PR> | python scripts/compress_diff.py --max-len 4000
+  ```
+- Bug scanner、Logic analyzer：接收**过滤后的 diff**，排除测试相关文件
+  ```bash
+  gh pr diff <PR> | python scripts/compress_diff.py --filter-tests --max-len 4000
+  ```
+
+**脚本内部规则**：
+1. `--filter-tests` 排除：`tests/`、`test/` 目录下的文件；`*_test.py`、`*_spec.py`、`*_tests.py`；`.test.`、`.spec.` 等测试文件
+2. `--max-len N`：超长时先压缩为 hunk-only（保留 +/- 行及前后各 2 行上下文）；仍超长则截断至 N 字符并附 `... (diff truncated)`
+
+**效果**：过滤后 diff 长度通常减少 60-70%（测试文件往往占据大比例 diff）。
+
+---
+
+## Step 4: 5 个并行审查 Agent {#step-4}
+
+启动 5 个并行 `Agent`，每个接收经过 [Step 3.5](#step-3-5) 预处理的输入包：
+- **CLAUDE.md checker ×2、AGENTS.md checker**：完整 diff（或截断后的）+ 变更摘要 + PR 标题和描述 + 相关规范文件内容
+- **Bug scanner、Logic analyzer**：过滤掉测试文件的 diff（或截断后的）+ 变更摘要 + PR 标题和描述
+
+5 个 agent 的具体职责、输入输出契约、prompt 模板见 [subagent-prompts.md](subagent-prompts.md)：
+- [claude-compliance-checker](subagent-prompts.md#claude-compliance-checker)（启动两次，独立运行，交叉验证）
+- [agents-compliance-checker](subagent-prompts.md#agents-compliance-checker)
+- [bug-scanner](subagent-prompts.md#bug-scanner)
+- [logic-analyzer](subagent-prompts.md#logic-analyzer)
+
+每个 Agent 输出统一的 JSON 格式问题列表：
+
+```json
+[
+  {
+    "description": "问题描述（1-2 句话）",
+    "reason": "问题类别，如 'CLAUDE.md' / 'AGENTS.md' / 'bug' / 'logic' / 'security'",
+    "file": "相对仓库根目录的文件路径",
+    "lines": "行号范围，格式如 '45-52'",
+    "suggestion": "可选的修复建议"
+  }
+]
+```
+
+如果未发现任何问题，输出空列表 `[]`。
+
+**为什么 CLAUDE.md checker 跑两次**：两个独立 checker 通过交叉验证提高规范检查的召回率和准确率，减少漏检和误报。这与"双 CR Agent 交叉验证体系"（Claude Code vs Kimi CLI）是两个不同层次的冗余——前者在同一 skill 内部，后者跨 agent。
+
+---
+
+## Step 5: Issue 验证 {#step-5}
+
+对 [Step 4](#step-4) 中发现的每一个 issue，启动一个并行 `Agent` 进行验证。详见 [subagent-prompts.md#issue-validator](subagent-prompts.md#issue-validator)。
+
+验证 agent 输入：
+- 单个 issue 的完整信息
+- PR diff
+- 相关规范文件内容
+
+验证 agent 输出 JSON `{valid: boolean, explanation: string}`。只有 `valid: true` 的 issue 才会进入下一步。`valid: false` 的 issue 被直接丢弃。
+
+**核心原则**：issue 验证用于评估审查 agent 发现的问题。验证 agent 的职责是确认问题不是明显的误读，并补充说明问题的严重程度。**不要过度过滤**——宁可保留一个值得讨论的问题，也不要漏掉一个真实缺陷。只有当 issue 明显是误读代码、或问题在变更前就已存在且 PR 并未触及、或规则引用完全不相关时，才标记 `valid: false`。
+
+---
+
+## Step 6: 过滤与汇总 {#step-6}
+
+对通过验证的 issue 进行后处理：
+
+1. **丢弃无效 issue**：移除所有 `valid: false` 的 issue
+2. **去重**：如果多个 issue 的 `file`、`lines`、`reason` 相同或高度相似，合并为一个
+3. **排序优先级**：
+   1. CLAUDE.md 合规问题
+   2. AGENTS.md 合规问题
+   3. bug 问题
+   4. logic / security 问题
+
+去重规则：
+- 如果两个 issue 指向同一个文件、同一行范围、且原因相同，视为重复
+- 如果描述内容高度相似（超过 80% 相似度），也视为重复
+- 合并时保留描述更详细、建议更具体的一个
+
+---
+
+## Step 7: 最终资格审查 {#step-7}
+
+使用 `Bash` 执行 `gh pr view <PR> --json state` 再次检查 PR 状态。
+
+如果 PR 已关闭 (closed) 或已合并 (merged)，立即停止执行，**不发布评论**。
+
+**为什么需要二次检查**：整个审查流程（特别是并行 Agent 执行）可能需要数分钟时间，在此期间 PR 状态可能发生变化。直接发布评论会污染已关闭 PR 的评论流。
+
+---
+
+## Step 8: 终端输出 {#step-8}
+
+输出 Markdown 格式的审查报告到终端。完整模板与字段拼装由 [scripts/build_review_body.py](../scripts/build_review_body.py) 生成；终端输出可直接用脚本输出的 Part B（Markdown 部分）。
+
+精简模板：
+
+发现问题时：
+```markdown
+### Code Review
+
+Found N issues:
+
+1. {description} ({reason})
+
+https://github.com/owner/repo/blob/{full-sha}/{file}#L{start}-L{end}
+```
+
+无问题时：
+```markdown
+### Code Review
+
+No issues found. Checked for bugs, CLAUDE.md and AGENTS.md compliance.
+```
+
+完整 Round-N 多轮格式见 [output-examples.md](output-examples.md)。
+
+代码链接格式要求：
+- 使用 `Bash` 执行 `gh pr view <PR> --json headRefOid --jq '.headRefOid'` 获取 PR head SHA（40 字符）
+- 链接格式必须严格为：`https://github.com/owner/repo/blob/[sha]/path#L[start]-L[end]`
+- 行范围至少包含 1 行上下文（评论目标行的前后至少各 1 行）
+- 仓库 owner 和 repo 名通过 `gh pr view --json headRepositoryOwner,headRepository` 获取
+
+行号提取方法：
+- 在 diff 中，新增内容以 `+` 开头，对应的行号在 diff hunk 头部标明
+- 例如 `@@ -45,7 +67,9 @@` 表示旧文件从第 45 行开始，新文件从第 67 行开始
+- 计算目标代码在新文件中的实际行号
+
+---
+
+## Step 9: 构建并发布 PR Review 评论 {#step-9}
+
+此步骤构建包含 metadata 的结构化 review 评论，并发布到 PR。
+
+### 9.1 构建评论 Body
+
+调用 [scripts/build_review_body.py](../scripts/build_review_body.py)，输入 JSON 包括：
+- `round`, `pr_number`, `head_sha`, `previous_head_sha`
+- `repo_owner`, `repo_name`
+- `issues`（含 status / resolution / committer_note）
+- 分类计数：`resolved_count`, `acknowledged_count`, `new_count`, `total_issues`
+- `timestamp`（ISO 8601）
+
+脚本输出完整 review body，由两部分组成：
+
+**Part A: HTML Comment Metadata（机器可读，GitHub 渲染时隐藏）**
+
+```markdown
+<!-- cc-cr-meta
+{"round":N,"pr_number":...,"head_sha":"...","previous_head_sha":"...","total_issues":...,"resolved_count":...,"new_count":...,"acknowledged_count":...,"issues":[...],"timestamp":"..."}
+-->
+```
+
+字段说明：
+- `round`: 当前轮次（首次审查为 1，增量审查为 N+1）
+- `pr_number`: PR 编号
+- `head_sha`: 当前 PR head commit 的完整 SHA（40 字符）
+- `previous_head_sha`: 上一轮 review 时的 head SHA（Round-1 为 null）
+- `total_issues`: 当前轮次统计的问题总数（不含 acknowledged）
+- `resolved_count`: 本轮标记为 resolved 的问题数（Round-1 为 0）
+- `new_count`: 本轮新发现的问题数
+- `acknowledged_count`: 本轮标记为 acknowledged / wontfix 的问题数
+- `issues`: 问题数组，每个元素含 `status`（"open"/"resolved"）、`resolution`（"acknowledged"/"wontfix"/"resolved"/null）、`committer_note`（string 或 null）
+- `timestamp`: ISO 8601 格式时间戳
+
+**Part B: Markdown 人类可读部分**
+
+模板分三种：Round-1、Round-N（增量）、All-resolved。三种完整模板见 [output-examples.md](output-examples.md)。
+
+### 9.2 发布 Review 评论
+
+使用 `Bash` 执行：
+```bash
+# 将 review body 写入临时文件（避免 shell 转义和长命令问题）
+python scripts/build_review_body.py < input.json > /tmp/cc-cr-{pr_number}.md
+gh pr review <PR> --comment --body-file /tmp/cc-cr-{pr_number}.md
+```
+
+注意：
+- 每轮审查都发布**新评论**，不编辑旧评论。原因：metadata 是审查历史的事实记录，覆写会丢失中间状态
+- 必须包含 `"🤖 Generated with Claude Code"` 标识，用于后续识别（脚本已固化）
+- 必须包含 `"### Code Review | Round-{N}"` 标题（脚本已固化）
+- 此步骤必须执行：只要资格审查通过，无论是否发现问题，都必须发布评论
+- 如果 `gh pr review` 命令失败，向用户报告错误详情，不重复尝试
+
+---
+
+## Step 10: 状态报告输出 {#step-10}
+
+每次审查结束时，无论发现问题与否，都必须输出状态报告到终端。状态报告是供外部调度器（如 zima daemon）和 fix agent 消费的机器可读摘要。
+
+调用 [scripts/render_status_report.py](../scripts/render_status_report.py) 生成。
+
+### 输出时机
+
+以下情况均须输出状态报告：
+- [Step 0](#step-0-3) 检测到无新 commit → 输出当前 open issues 状态，Status: `NO_NEW_COMMITS`
+- [Step 6](#step-6) 过滤后存在 open issues → 输出问题统计，Status: `NEEDS_FIX`
+- [Step 6](#step-6) 过滤后无 open issues → 输出 "All issues resolved"，Status: `PASS`
+- PR 在 [Step 7](#step-7) 被判定为已关闭/已合并 → 已停止，**不输出**状态报告
+
+### 状态报告格式
+
+```
+=== CR Batch Status Report ===
+PR: #{pr_number} | Round: {round} | Head SHA: {head_sha}
+Previous Head SHA: {previous_head_sha}
+Total open issues: {open_count}
+- New this round: {new_count}
+- Still open from previous: {unresolved_count}
+- Resolved this round: {resolved_count}
+- Acknowledged / Won't Fix: {acknowledged_count}
+Status: {status}
+================================
+```
+
+字段说明：
+- `Total open issues`：当前仍 open 的问题总数（不含 acknowledged）
+- `Status` 枚举三态：
+  - `NEEDS_FIX` — 仍有 open issues 需要修复
+  - `PASS` — 无 open issues（可能仍有 acknowledged）
+  - `NO_NEW_COMMITS` — Step 0 检测到无新 commit
+
+### 用途
+
+- **zima 调度器**：根据 `Status` 决策是否调度 fix agent
+  - `NEEDS_FIX` → 调度 fix agent 修复 open issues
+  - `PASS` → 当前 PR 无需进一步 action
+  - `NO_NEW_COMMITS` → 本轮跳过，等待下次调度
+- **fix agent**：快速获取当前 open issues 列表，无需重新解析 metadata
+- **人工查看**：一目了然了解当前审查状态

--- a/plugins/pr-automation/skills/github-code-review-batch/references/output-examples.md
+++ b/plugins/pr-automation/skills/github-code-review-batch/references/output-examples.md
@@ -1,0 +1,123 @@
+# Output Examples
+
+本文件包含 [build_review_body.py](../scripts/build_review_body.py) 输出的完整样例，用于 review 评论格式的参考与回归核验。
+
+---
+
+## Round-1：发现问题
+
+```markdown
+<!-- cc-cr-meta
+{"round":1,"pr_number":123,"head_sha":"abc123def4567890123456789012345678901234","previous_head_sha":null,"total_issues":3,"resolved_count":0,"new_count":3,"acknowledged_count":0,"issues":[{"id":"issue-1","description":"Missing error handling for OAuth callback","reason":"bug","file":"src/auth.ts","lines":"67-72","status":"open","first_round":1},{"id":"issue-2","description":"Inconsistent naming pattern","reason":"AGENTS.md","file":"src/utils.ts","lines":"23-28","status":"open","first_round":1},{"id":"issue-3","description":"Memory leak: OAuth state not cleaned up","reason":"bug","file":"src/auth.ts","lines":"88-95","status":"open","first_round":1}],"timestamp":"2026-04-21T10:00:00Z"}
+-->
+
+### Code Review | Round-1
+
+Found 3 issues:
+
+1. Missing error handling for OAuth callback (CLAUDE.md: "Always handle OAuth errors explicitly")
+
+https://github.com/owner/repo/blob/abc123def4567890123456789012345678901234/src/auth.ts#L67-L72
+
+2. Memory leak: OAuth state not cleaned up (bug: missing cleanup in finally block)
+
+https://github.com/owner/repo/blob/abc123def4567890123456789012345678901234/src/auth.ts#L88-L95
+
+3. Inconsistent naming pattern (AGENTS.md: "Use camelCase for all new functions")
+
+https://github.com/owner/repo/blob/abc123def4567890123456789012345678901234/src/utils.ts#L23-L28
+
+🤖 Generated with Claude Code
+```
+
+---
+
+## Round-1：无问题
+
+```markdown
+<!-- cc-cr-meta
+{"round":1,"pr_number":123,"head_sha":"abc123def4567890123456789012345678901234","previous_head_sha":null,"total_issues":0,"resolved_count":0,"new_count":0,"acknowledged_count":0,"issues":[],"timestamp":"2026-04-21T10:00:00Z"}
+-->
+
+### Code Review | Round-1
+
+No issues found. Checked for bugs, CLAUDE.md and AGENTS.md compliance.
+
+🤖 Generated with Claude Code
+```
+
+---
+
+## Round-2：增量审查（部分问题已修复，部分被 committer 拒绝修复）
+
+```markdown
+<!-- cc-cr-meta
+{"round":2,"pr_number":123,"head_sha":"fed789abc0123456789012345678901234567890","previous_head_sha":"abc123def4567890123456789012345678901234","total_issues":1,"resolved_count":1,"acknowledged_count":1,"new_count":0,"issues":[{"id":"issue-2","description":"Daemon binds to localhost only, no auth needed","reason":"logic","file":"src/server.py","lines":"45-50","status":"open","first_round":1,"resolution":"acknowledged","committer_note":"daemon binds to localhost only, authentication not needed for local service"},{"id":"issue-3","description":"Memory leak: OAuth state not cleaned up","reason":"bug","file":"src/auth.ts","lines":"88-95","status":"open","first_round":1,"resolution":null,"committer_note":null}],"timestamp":"2026-04-21T10:30:00Z"}
+-->
+
+### Code Review | Round-2 (Re-check)
+
+Previous Round-1 issues: 3
+- **Resolved**: 1 (Missing error handling)
+- **Acknowledged / Won't Fix**: 1
+- **Still open**: 1
+
+New issues found: 0
+
+#### Acknowledged / Won't Fix
+
+2. Daemon binds to localhost only, no auth needed (committer: daemon binds to localhost only, authentication not needed for local service)
+
+#### Still Open from Round-1
+
+3. Memory leak: OAuth state not cleaned up (bug: missing cleanup in finally block)
+
+https://github.com/owner/repo/blob/fed789abc0123456789012345678901234567890/src/auth.ts#L88-L95
+
+🤖 Generated with Claude Code
+```
+
+**说明**：
+- 如果 `acknowledged_issues` 为空，省略 "Acknowledged / Won't Fix" 小节及其标题
+- Acknowledged issues 不计入 "Still open" 数量
+- Acknowledged issues 不会触发外部 fix agent 调度（调度器只关注真正 open 的 issues）
+
+---
+
+## Round-3：全部修复
+
+```markdown
+<!-- cc-cr-meta
+{"round":3,"pr_number":123,"head_sha":"aaa111bbb222333444555666777888999000aaaa","previous_head_sha":"fed789abc0123456789012345678901234567890","total_issues":0,"resolved_count":1,"new_count":0,"acknowledged_count":0,"issues":[],"timestamp":"2026-04-21T11:00:00Z"}
+-->
+
+### Code Review | Round-3 (Re-check)
+
+Previous Round-2 issues: 1
+- **Resolved**: 1 (Memory leak)
+- **Still open**: 0
+
+New issues found: 0
+
+✅ **All issues resolved!**
+
+🤖 Generated with Claude Code
+```
+
+---
+
+## 评论格式硬性要求
+
+代码链接必须遵循以下精确格式，否则 GitHub Markdown 无法正确渲染：
+
+```
+https://github.com/owner/repo/blob/[full-sha]/path/file.ext#L[start]-L[end]
+```
+
+要求：
+- 使用完整 SHA（40 字符，**不是缩写**）
+- `#L` 表示行号
+- 行范围格式：`L[start]-L[end]`
+- 至少包含 1 行上下文（评论目标行的前后至少各 1 行）
+
+这些要求由 [build_review_body.py](../scripts/build_review_body.py) 固化，但若手动构建 body 时需自行遵守。

--- a/plugins/pr-automation/skills/github-code-review-batch/references/subagent-prompts.md
+++ b/plugins/pr-automation/skills/github-code-review-batch/references/subagent-prompts.md
@@ -1,0 +1,331 @@
+# SubAgent Definitions and Prompt Templates
+
+本文件定义 7 个 sub-agent 的输入契约、输出 schema、任务要求和推荐 prompt 模板。
+
+---
+
+## summarizer {#summarizer}
+
+**输入**：PR 标题、PR 描述、PR diff
+**输出**：一段简洁的变更摘要（不超过 300 字）
+
+### 任务
+
+1. 阅读 PR 标题和描述，理解变更的意图和背景
+2. 阅读 diff 内容，识别主要修改点
+3. 忽略纯格式化和配置变更的细节
+4. 输出简洁摘要，突出关键的功能变更、架构调整或重要修复
+
+### 推荐 prompt
+
+```
+你是一个 PR 变更摘要员。基于 PR 标题、描述和 diff，输出一段不超过 300 字的中文摘要。
+
+输入：
+- PR 标题：{title}
+- PR 描述：{body}
+- PR diff：{diff}
+
+要求：
+1. 突出关键的功能变更、架构调整或重要修复
+2. 忽略纯格式化和配置变更的细节
+3. 直接输出摘要文本，不需要标题或前缀
+```
+
+---
+
+## claude-compliance-checker {#claude-compliance-checker}
+
+**输入**：PR diff、PR 摘要、相关 CLAUDE.md 文件内容
+**输出**：JSON 问题列表 `[{description, reason, file, lines, suggestion}]`
+
+### 任务
+
+1. 阅读所有相关 CLAUDE.md 文件
+2. 识别文件中陈述的规则和要求
+3. 检查 PR 变更是否违反这些规则
+4. 尽量引用规则原文，但不要求一字不差；对于逻辑/安全问题，无需强制引用规范
+5. 仅关注 PR 修改的内容，忽略原有代码
+6. 如果没有发现违规，返回空列表
+7. 不报告纯主观判断，但值得关注的逻辑缺陷和安全问题应当报告
+
+`reason` 字段应包含 "CLAUDE.md"。
+
+### 调用次数
+
+启动两次（独立运行），通过交叉验证提高规范检查的召回率和准确率。
+
+### 推荐 prompt
+
+```
+你是一个代码规范审查员。你的任务是检查 PR 变更是否违反了 CLAUDE.md 中的规则。
+
+输入：
+- PR 摘要：{summary}
+- PR diff：{diff}
+- 相关 CLAUDE.md 内容：{claude_md_content}
+
+要求：
+1. 只关注 PR 修改的代码，忽略原有代码
+2. 尽量引用 CLAUDE.md 中的规则原文，但不要求一字不差；对于逻辑/安全问题，无需强制引用规范
+3. 不报告纯主观判断，但值得关注的逻辑缺陷和安全问题应当报告
+4. 输出 JSON 数组，每个元素包含 description、reason（必须包含 "CLAUDE.md"）、file、lines、suggestion
+5. 如果没有发现违规，输出空数组 []
+```
+
+---
+
+## agents-compliance-checker {#agents-compliance-checker}
+
+**输入**：PR diff、PR 摘要、相关 AGENTS.md 文件内容
+**输出**：JSON 问题列表 `[{description, reason, file, lines, suggestion}]`
+
+### 任务
+
+1. 阅读所有相关 AGENTS.md 文件
+2. 识别文件中陈述的规则和要求
+3. **区分适用于代码审查的规则 vs 仅适用于编码行为的规则**——AGENTS.md 中部分规则是给 LLM 编码时遵循的（如"如何写代码"），并不是 PR 变更需要遵守的（如"提交前先运行测试"）
+4. 检查 PR 变更是否违反适用于审查的规则
+5. 尽量引用规则原文，但不要求一字不差；对于逻辑/安全问题，无需强制引用规范
+6. 仅关注 PR 修改的内容，忽略原有代码
+7. 如果没有发现违规，返回空列表
+
+`reason` 字段应包含 "AGENTS.md"。
+
+### 推荐 prompt
+
+```
+你是一个代码规范审查员。你的任务是检查 PR 变更是否违反了 AGENTS.md 中的规则。
+
+输入：
+- PR 摘要：{summary}
+- PR diff：{diff}
+- 相关 AGENTS.md 内容：{agents_md_content}
+
+要求：
+1. 只关注 PR 修改的代码，忽略原有代码
+2. 区分适用于代码审查的规则 vs 仅适用于编码行为的规则
+3. 尽量引用 AGENTS.md 中的规则原文，但不要求一字不差；对于逻辑/安全问题，无需强制引用规范
+4. 输出 JSON 数组，每个元素包含 description、reason（必须包含 "AGENTS.md"）、file、lines、suggestion
+5. 如果没有发现违规，输出空数组 []
+```
+
+---
+
+## bug-scanner {#bug-scanner}
+
+**输入**：经过 [Step 3.5](flow.md#step-3-5) 过滤测试文件后的 PR diff
+**输出**：JSON 问题列表 `[{description, reason, file, lines, suggestion}]`
+
+### 任务
+
+1. 仅关注变更本身，**不读取额外上下文文件**（避免引入外部噪音）
+2. 扫描明显的逻辑错误、空值处理、竞态条件、边界条件、缺失导入、未解析引用
+3. 关注所有可能导致运行时错误的 Bug，不要忽略"看起来可能是误报"的问题
+4. 对于不确定的问题仍然报告，在 description 中用 "Potential:" 或 "Possible:" 标注
+5. 返回发现的问题列表，无问题返回空列表
+
+`reason` 字段应为 "bug"。
+
+### 推荐 prompt
+
+```
+你是一个 Bug 扫描器。你的任务是基于 diff 内容扫描 Bug 和潜在问题。
+
+输入：
+- PR diff（已过滤测试文件）：{diff}
+  注意：此 diff 已预先过滤掉 tests/、test/ 目录及测试文件（*_test.py、*_spec.py 等），以控制 prompt 长度。你只需关注业务代码中的 Bug。
+
+要求：
+1. 仅基于 diff 内容判断，不读取额外文件
+2. 报告所有潜在问题：编译错误、缺失导入、未解析引用、逻辑错误、空值处理、竞态条件、边界条件
+3. 忽略纯风格问题，但关注可能导致运行时错误的设计问题
+4. 对于不确定的问题仍然报告，在 description 中用 "Potential:" 或 "Possible:" 标注
+5. 输出 JSON 数组，每个元素包含 description、reason（必须为 "bug"）、file、lines、suggestion
+6. 如果没有发现 Bug，输出空数组 []
+```
+
+---
+
+## logic-analyzer {#logic-analyzer}
+
+**输入**：经过 [Step 3.5](flow.md#step-3-5) 过滤测试文件后的 PR diff、PR 摘要
+**输出**：JSON 问题列表 `[{description, reason, file, lines, suggestion}]`
+
+### 任务
+
+1. 分析变更代码的逻辑正确性和安全性
+2. 仅关注被修改的代码
+3. 关注资源泄漏、错误处理缺失、安全漏洞、竞态条件、边界条件、异常路径
+4. 对于依赖输入的潜在问题，如果代码没有做任何防御性处理，仍然值得报告
+5. 忽略纯风格问题和无明确对错的主观建议
+6. 返回发现的问题列表，无问题返回空列表
+
+`reason` 字段应为 "logic" 或 "security"。
+
+### 推荐 prompt
+
+```
+你是一个逻辑和安全分析器。你的任务是分析变更代码的逻辑正确性和安全性。
+
+输入：
+- PR 摘要：{summary}
+- PR diff（已过滤测试文件）：{diff}
+  注意：此 diff 已预先过滤掉 tests/、test/ 目录及测试文件（*_test.py、*_spec.py 等），以控制 prompt 长度。你只需关注业务代码的逻辑和安全性问题。
+
+要求：
+1. 仅关注被修改的代码
+2. 关注资源泄漏、错误处理缺失、安全漏洞、竞态条件、边界条件、异常路径
+3. 对于依赖输入的潜在问题，如果代码没有做任何防御性处理，仍然值得报告
+4. 忽略纯风格问题和无明确对错的主观建议
+5. 输出 JSON 数组，每个元素包含 description、reason（"logic" 或 "security"）、file、lines、suggestion
+6. 如果没有发现问题，输出空数组 []
+```
+
+---
+
+## issue-validator {#issue-validator}
+
+**输入**：单个 issue、PR diff、相关规范文件内容
+**输出**：JSON `{valid: boolean, explanation: string}`
+
+### 任务
+
+1. 重新审查 issue 对应的目标代码
+2. 判断问题是否真实存在于代码中（**只有明显误读代码才标记 invalid**）
+3. 对于规范类 issue：检查规则是否在规范文件中被表述，且适用于当前变更（规则不必一字不差引用）
+4. 对于 bug 类 issue：检查代码逻辑是否确实有问题，是否是 PR 引入的或 PR 未修复的（**不要因为不够"确定性"就过滤掉**）
+5. 只有当 issue 明显是误读代码、或问题在变更前就已存在且 PR 并未触及、或规则引用完全不相关时，才标记 `valid: false`
+6. 返回验证结果和解释
+
+### 核心原则
+
+不要过度过滤——宁可保留一个值得讨论的问题，也不要漏掉一个真实缺陷。
+
+### 推荐 prompt
+
+```
+你是一个 issue 验证器。你的任务是评估一个代码审查问题是否值得保留。
+
+输入：
+- 待验证 issue：{issue_json}
+- PR diff：{diff}
+- 相关规范文件内容：{guidelines}
+
+要求：
+1. 重新审视 issue 对应的目标代码
+2. 只有当 issue 明显是误读代码、或问题在变更前就已存在且 PR 并未触及、或规则引用完全不相关时，才标记 `"valid": false`
+3. 对于规范类 issue：规则不必一字不差引用，大意匹配即可
+4. 对于 bug 类 issue：不要因为不够"确定性"就过滤掉，只有完全假设性的场景才标记 invalid
+5. 输出 JSON：{"valid": boolean, "explanation": "string"}
+```
+
+---
+
+## delta-reviewer {#delta-reviewer}
+
+**输入**：PR 完整 diff、`previous_issues` 列表（含 `resolution` 和 `committer_note` 字段）、`previous_head_sha`、`current_head_sha`、相关规范文件
+**输出**：JSON `{resolved_issues, acknowledged_issues, new_issues, unresolved_issues, pass}`
+
+### 任务
+
+1. **优先处理带 committer 回应的 previous issues**：
+   - `resolution="acknowledged"` / `"wontfix"` → 加入 `acknowledged_issues`，不再视为 open
+   - `resolution="clarified"`（有 `committer_note`）→ 结合澄清内容判断 issue 是否仍有效。如果澄清使 issue 失效，标记为 resolved 并引用澄清；否则加入 `unresolved_issues`
+   - `resolution=null` → 进入下一步 diff 对比
+2. **对比 `previous_issues` 和当前 diff**：
+   - 遍历每个 previous issue（无 resolution 或 resolution=null），检查其 `file` + `lines` 范围是否在 diff 中被修改
+   - 被修改 → 仔细阅读对应代码，判断是否已修复 → 加入 `resolved_issues`
+   - 未修改 → 加入 `unresolved_issues`
+3. **审查 diff 中其他新增/修改的代码**，发现新问题 → 加入 `new_issues`
+   - **特别注意**：修复 commit 可能引入新的问题，不要只关注原有问题的修复状态
+   - 仔细审查修复代码本身的正确性
+4. 对于规范类问题，检查 CLAUDE.md / AGENTS.md 中相关规则是否仍适用
+
+### 输出 JSON 格式
+
+```json
+{
+  "resolved_issues": [
+    {
+      "original_id": "issue-1",
+      "description": "Missing error handling for OAuth callback",
+      "reason": "bug",
+      "file": "src/auth.ts",
+      "lines": "67-72",
+      "resolution_note": "Error handling added in new commit"
+    }
+  ],
+  "acknowledged_issues": [
+    {
+      "original_id": "issue-2",
+      "description": "/shutdown endpoint lacks authentication",
+      "reason": "logic",
+      "file": "src/server.py",
+      "lines": "45-50",
+      "committer_note": "daemon binds to localhost only, authentication not needed for local service"
+    }
+  ],
+  "new_issues": [
+    {
+      "id": "issue-4",
+      "description": "New race condition in callback",
+      "reason": "logic",
+      "file": "src/auth.ts",
+      "lines": "100-105",
+      "suggestion": "Add mutex lock"
+    }
+  ],
+  "unresolved_issues": [
+    {
+      "original_id": "issue-3",
+      "description": "Memory leak: OAuth state not cleaned up",
+      "reason": "bug",
+      "file": "src/auth.ts",
+      "lines": "88-95"
+    }
+  ],
+  "pass": false
+}
+```
+
+### 约束
+
+- 只关注被修改的代码，不评论原有代码
+- 对于已修复的问题，必须简要说明修复方式（`resolution_note`）
+- 对于 acknowledged 的问题，保留 `committer_note`
+- 对于未修复的问题，保持原描述不变
+- 新问题使用新的 `id`，不影响原有 issue 编号
+
+### 推荐 prompt
+
+```
+你是一个增量代码审查员。你的任务是对比上一轮发现的问题和当前 PR 的最新 diff，判断哪些问题已被修复，并发现新问题。
+
+输入：
+- PR 完整 diff：{diff}
+- 上一轮问题列表：{previous_issues}（每个 issue 可能含 resolution 和 committer_note 字段）
+- 上一轮 head SHA：{previous_head_sha}
+- 当前 head SHA：{current_head_sha}
+- 相关规范文件：{guidelines}
+
+要求：
+1. 优先处理带 committer 回应的 issues：
+   - resolution="acknowledged" / "wontfix" → 加入 acknowledged_issues，不再视为 open
+   - resolution="clarified"（有 committer_note）→ 结合澄清内容判断。如果澄清使 issue 失效，标记 resolved 并引用澄清；否则加入 unresolved_issues
+2. 遍历其余 previous issue（resolution 为 null），检查其 file + lines 范围是否在 diff 中被修改：
+   - 被修改 → 仔细阅读对应代码，判断是否已修复 → 加入 resolved_issues，附 resolution_note
+   - 未修改 → 加入 unresolved_issues
+3. 审查 diff 中其他新增/修改的代码，发现新问题 → 加入 new_issues
+   - **特别注意**：修复 commit 可能引入新的问题，不要只关注原有问题的修复状态
+   - 仔细审查修复代码本身的正确性
+4. 忽略已确认 resolved 的旧问题
+5. 对于规范类问题，确认规则是否仍适用于当前变更
+6. 输出 JSON：{"resolved_issues": [...], "acknowledged_issues": [...], "new_issues": [...], "unresolved_issues": [...], "pass": boolean}
+```
+
+---
+
+## 审查覆盖原则参考
+
+各 checker 共享的审查覆盖原则——值得标记 vs 不值得标记的问题分类，详见 [edge-cases.md](edge-cases.md#审查覆盖原则)。

--- a/plugins/pr-automation/skills/github-code-review-batch/scripts/build_review_body.py
+++ b/plugins/pr-automation/skills/github-code-review-batch/scripts/build_review_body.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Build a Round-N PR review comment body.
+
+Input (stdin): JSON object with the following fields:
+  round              int   — current round (>=1)
+  pr_number          int
+  head_sha           str   — 40-char SHA
+  previous_head_sha  str | null
+  repo_owner         str
+  repo_name          str
+  timestamp          str   — ISO 8601, e.g. "2026-04-21T10:00:00Z"
+  issues             list  — each item: {id, description, reason, file, lines,
+                                          status, first_round, resolution?, committer_note?}
+  resolved_issues    list  — items with description (used in Round-N summary line)
+  acknowledged_issues list — items with description, committer_note
+  new_issues         list  — items with id, description, reason, file, lines
+  unresolved_issues  list  — items with description, reason, file, lines
+  prev_round_count   int   — total issues in previous round (Round-1 ignores)
+
+Output (stdout): full review body (HTML metadata + Markdown).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+
+
+def gh_link(owner: str, repo: str, sha: str, file: str, lines: str) -> str:
+    return f"https://github.com/{owner}/{repo}/blob/{sha}/{file}#L{lines.replace('-', '-L')}"
+
+
+def build_metadata(d: dict) -> str:
+    keys = [
+        "round", "pr_number", "head_sha", "previous_head_sha",
+        "total_issues", "resolved_count", "new_count", "acknowledged_count",
+        "issues", "timestamp",
+    ]
+    payload = {k: d.get(k) for k in keys}
+    payload["total_issues"] = d.get("total_issues", len([
+        i for i in d.get("issues", [])
+        if i.get("status") == "open" and i.get("resolution") not in ("acknowledged", "wontfix")
+    ]))
+    payload["resolved_count"] = d.get("resolved_count", len(d.get("resolved_issues", [])))
+    payload["new_count"] = d.get("new_count", len(d.get("new_issues", [])))
+    payload["acknowledged_count"] = d.get("acknowledged_count", len(d.get("acknowledged_issues", [])))
+    return f"<!-- cc-cr-meta\n{json.dumps(payload, ensure_ascii=False)}\n-->"
+
+
+def render_round_1(d: dict) -> str:
+    issues = d.get("issues", [])
+    if not issues:
+        return "### Code Review | Round-1\n\nNo issues found. Checked for bugs, CLAUDE.md and AGENTS.md compliance."
+    parts = ["### Code Review | Round-1", "", f"Found {len(issues)} issues:", ""]
+    for i, issue in enumerate(issues, 1):
+        parts.append(f"{i}. {issue['description']} ({issue['reason']})")
+        parts.append("")
+        parts.append(gh_link(d["repo_owner"], d["repo_name"], d["head_sha"],
+                             issue["file"], issue["lines"]))
+        parts.append("")
+    return "\n".join(parts).rstrip()
+
+
+def render_round_n(d: dict) -> str:
+    n = d["round"]
+    prev_n = n - 1
+    prev_count = d.get("prev_round_count", 0)
+    resolved = d.get("resolved_issues", [])
+    acknowledged = d.get("acknowledged_issues", [])
+    unresolved = d.get("unresolved_issues", [])
+    new_issues = d.get("new_issues", [])
+
+    still_open = len(unresolved)
+    all_resolved = (still_open == 0 and len(new_issues) == 0)
+
+    lines: list[str] = [f"### Code Review | Round-{n} (Re-check)", ""]
+    lines.append(f"Previous Round-{prev_n} issues: {prev_count}")
+    if all_resolved:
+        lines.append(f"- **Resolved**: {len(resolved)}")
+        lines.append("- **Still open**: 0")
+        lines.extend(["", "New issues found: 0", "", "✅ **All issues resolved!**"])
+        return "\n".join(lines)
+
+    resolved_label = ", ".join(r.get("description", "")[:40] for r in resolved) if resolved else ""
+    ack_label = ", ".join(a.get("description", "")[:40] for a in acknowledged) if acknowledged else ""
+    lines.append(f"- **Resolved**: {len(resolved)}" + (f" ({resolved_label})" if resolved_label else ""))
+    if acknowledged:
+        lines.append(f"- **Acknowledged / Won't Fix**: {len(acknowledged)}" + (f" ({ack_label})" if ack_label else ""))
+    lines.append(f"- **Still open**: {still_open}")
+    lines.append("")
+    lines.append(f"New issues found: {len(new_issues)}")
+    lines.append("")
+
+    if acknowledged:
+        lines.append("#### Acknowledged / Won't Fix")
+        lines.append("")
+        for i, item in enumerate(acknowledged, 1):
+            note = item.get("committer_note", "")
+            suffix = f" (committer: {note})" if note else ""
+            lines.append(f"{i}. {item['description']}{suffix}")
+        lines.append("")
+
+    if unresolved:
+        lines.append(f"#### Still Open from Previous Rounds")
+        lines.append("")
+        for i, item in enumerate(unresolved, 1):
+            lines.append(f"{i}. {item['description']} ({item['reason']})")
+            lines.append("")
+            lines.append(gh_link(d["repo_owner"], d["repo_name"], d["head_sha"],
+                                 item["file"], item["lines"]))
+            lines.append("")
+
+    if new_issues:
+        lines.append("#### New Issues")
+        lines.append("")
+        for i, item in enumerate(new_issues, 1):
+            lines.append(f"{i}. {item['description']} ({item['reason']})")
+            lines.append("")
+            lines.append(gh_link(d["repo_owner"], d["repo_name"], d["head_sha"],
+                                 item["file"], item["lines"]))
+            lines.append("")
+
+    return "\n".join(lines).rstrip()
+
+
+def render_body(d: dict) -> str:
+    metadata = build_metadata(d)
+    body = render_round_1(d) if d["round"] == 1 else render_round_n(d)
+    return f"{metadata}\n\n{body}\n\n🤖 Generated with Claude Code\n"
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        d = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"build_review_body: invalid JSON on stdin: {exc}", file=sys.stderr)
+        return 2
+    sys.stdout.write(render_body(d))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/pr-automation/skills/github-code-review-batch/scripts/compress_diff.py
+++ b/plugins/pr-automation/skills/github-code-review-batch/scripts/compress_diff.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Compress a unified diff for prompt embedding.
+
+Steps:
+  1. Optionally drop test-related files (--filter-tests).
+  2. If still too long, keep only +/- hunks plus N lines of context.
+  3. If still too long, hard-truncate at --max-len chars.
+
+Input (stdin): unified diff (output of `gh pr diff <PR>`).
+Output (stdout): compressed diff.
+
+Examples:
+    gh pr diff 123 | python compress_diff.py --max-len 4000
+    gh pr diff 123 | python compress_diff.py --filter-tests --max-len 4000
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+TEST_PATH_RE = re.compile(
+    r"(^|/)(tests?|__tests__)/"
+    r"|(^|/)[^/]+_(test|tests|spec)\.[A-Za-z0-9]+$"
+    r"|\.(test|spec)\.[A-Za-z0-9]+$"
+)
+FILE_HEADER_RE = re.compile(r"^diff --git a/(.+?) b/(.+?)$")
+HUNK_HEADER_RE = re.compile(r"^@@ ")
+
+
+def is_test_path(path: str) -> bool:
+    return bool(TEST_PATH_RE.search(path))
+
+
+def split_files(diff: str) -> list[list[str]]:
+    """Return a list of file-blocks (each a list of lines including its header)."""
+    files: list[list[str]] = []
+    current: list[str] = []
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            if current:
+                files.append(current)
+            current = [line]
+        else:
+            if not current:
+                # Stray preamble; keep as its own block.
+                current = []
+            current.append(line)
+    if current:
+        files.append(current)
+    return files
+
+
+def filter_test_files(diff: str) -> str:
+    blocks = split_files(diff)
+    keep: list[str] = []
+    for block in blocks:
+        header = block[0] if block else ""
+        m = FILE_HEADER_RE.match(header)
+        if m and (is_test_path(m.group(1)) or is_test_path(m.group(2))):
+            continue
+        keep.extend(block)
+    return "\n".join(keep)
+
+
+def keep_hunks_only(diff: str, context_lines: int = 2) -> str:
+    """Drop lines that aren't +/-/hunk-header/file-header or within `context_lines`."""
+    lines = diff.splitlines()
+    n = len(lines)
+    keep_idx: set[int] = set()
+    for i, line in enumerate(lines):
+        if line.startswith("diff --git ") or line.startswith("---") or line.startswith("+++"):
+            keep_idx.add(i)
+        elif HUNK_HEADER_RE.match(line):
+            keep_idx.add(i)
+        elif line.startswith(("+", "-")):
+            for j in range(max(0, i - context_lines), min(n, i + context_lines + 1)):
+                keep_idx.add(j)
+    return "\n".join(lines[i] for i in sorted(keep_idx))
+
+
+def truncate(diff: str, max_len: int) -> str:
+    if len(diff) <= max_len:
+        return diff
+    return diff[:max_len] + "\n... (diff truncated due to length)"
+
+
+def compress(diff: str, *, filter_tests: bool, max_len: int) -> str:
+    if filter_tests:
+        diff = filter_test_files(diff)
+    if len(diff) > max_len:
+        diff = keep_hunks_only(diff, context_lines=2)
+    if len(diff) > max_len:
+        diff = truncate(diff, max_len)
+    return diff
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--filter-tests", action="store_true",
+                    help="Drop test-related files (tests/, *_test.py, .spec., etc.)")
+    ap.add_argument("--max-len", type=int, default=4000,
+                    help="Hard length ceiling in characters (default: 4000)")
+    args = ap.parse_args()
+    diff = sys.stdin.read()
+    out = compress(diff, filter_tests=args.filter_tests, max_len=args.max_len)
+    sys.stdout.write(out)
+    if not out.endswith("\n"):
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/pr-automation/skills/github-code-review-batch/scripts/parse_metadata.py
+++ b/plugins/pr-automation/skills/github-code-review-batch/scripts/parse_metadata.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Extract latest cc-cr-meta JSON from PR review comments.
+
+Input (stdin): JSON output of `gh pr view <PR> --json reviews`.
+  Either the full object {"reviews": [...]} or a stream of {body, submitted_at}
+  records (one per line) as produced by the --jq filter.
+
+Output (stdout): Latest cc-cr-meta JSON object, or {} if not found.
+Exit codes:
+  0 success (including "no metadata found, output {}")
+  2 stdin not valid JSON
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+CC_MARKER = "Generated with Claude Code"
+META_MARKER = "<!-- cc-cr-meta"
+META_RE = re.compile(r"<!--\s*cc-cr-meta\s*\n(.*?)\n\s*-->", re.DOTALL)
+
+
+def load_reviews(raw: str) -> list[dict]:
+    """Accept both {"reviews": [...]} and JSON-Lines from --jq."""
+    raw = raw.strip()
+    if not raw:
+        return []
+    # Try whole-document parse first.
+    try:
+        doc = json.loads(raw)
+        if isinstance(doc, dict) and "reviews" in doc:
+            return doc["reviews"]
+        if isinstance(doc, list):
+            return doc
+        if isinstance(doc, dict):
+            return [doc]
+    except json.JSONDecodeError:
+        pass
+    # Fall back to JSON-Lines.
+    out: list[dict] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def extract_latest_meta(reviews: list[dict]) -> dict:
+    candidates = [
+        r for r in reviews
+        if isinstance(r, dict)
+        and isinstance(r.get("body"), str)
+        and CC_MARKER in r["body"]
+        and META_MARKER in r["body"]
+    ]
+    if not candidates:
+        return {}
+    candidates.sort(key=lambda r: r.get("submitted_at", ""), reverse=True)
+    for review in candidates:
+        match = META_RE.search(review["body"])
+        if not match:
+            continue
+        try:
+            return json.loads(match.group(1))
+        except json.JSONDecodeError:
+            continue
+    return {}
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        reviews = load_reviews(raw)
+    except Exception as exc:
+        print(f"parse_metadata: failed to read stdin: {exc}", file=sys.stderr)
+        return 2
+    meta = extract_latest_meta(reviews)
+    json.dump(meta, sys.stdout, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/pr-automation/skills/github-code-review-batch/scripts/render_status_report.py
+++ b/plugins/pr-automation/skills/github-code-review-batch/scripts/render_status_report.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Render the CR Batch Status Report block.
+
+Input (stdin): JSON object with the following fields:
+  pr_number          int
+  round              int
+  head_sha           str
+  previous_head_sha  str | null
+  open_count         int  — total currently-open issues (excluding acknowledged)
+  new_count          int
+  unresolved_count   int  — open issues carried from previous rounds
+  resolved_count     int
+  acknowledged_count int
+  status             str  — "NEEDS_FIX" | "PASS" | "NO_NEW_COMMITS"
+
+Output (stdout): the multi-line status report block.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+VALID_STATUSES = {"NEEDS_FIX", "PASS", "NO_NEW_COMMITS"}
+
+TEMPLATE = """\
+=== CR Batch Status Report ===
+PR: #{pr_number} | Round: {round} | Head SHA: {head_sha}
+Previous Head SHA: {previous_head_sha}
+Total open issues: {open_count}
+- New this round: {new_count}
+- Still open from previous: {unresolved_count}
+- Resolved this round: {resolved_count}
+- Acknowledged / Won't Fix: {acknowledged_count}
+Status: {status}
+================================
+"""
+
+
+def render(d: dict) -> str:
+    status = d.get("status", "")
+    if status not in VALID_STATUSES:
+        print(f"render_status_report: invalid status {status!r}; expected one of {sorted(VALID_STATUSES)}",
+              file=sys.stderr)
+        sys.exit(2)
+    return TEMPLATE.format(
+        pr_number=d.get("pr_number", ""),
+        round=d.get("round", ""),
+        head_sha=d.get("head_sha", ""),
+        previous_head_sha=d.get("previous_head_sha", "null") if d.get("previous_head_sha") is not None else "null",
+        open_count=d.get("open_count", 0),
+        new_count=d.get("new_count", 0),
+        unresolved_count=d.get("unresolved_count", 0),
+        resolved_count=d.get("resolved_count", 0),
+        acknowledged_count=d.get("acknowledged_count", 0),
+        status=status,
+    )
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        d = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"render_status_report: invalid JSON on stdin: {exc}", file=sys.stderr)
+        return 2
+    sys.stdout.write(render(d))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- 把 zima-blue-cli 同时作为 Claude Code **plugin marketplace**（name=`zima-blue`）
- 首发 plugin: **`pr-automation`**（version 0.1.0）
- 首发 skill: **`github-code-review-batch`**（从 `zhuxixi/claude-code-skills` byte-identical 迁移过来）
- README 加 Claude Code Marketplace 安装说明

## 为什么

- 这套 skill 给 zima daemon 调度自动化 PR 处理用 — 跟 zima 仓库耦合最紧，应该一起演进
- 未来同 plugin 还会加 `pr-monitor` 等 PR 自动化 skill，需要语义聚合的命名空间
- 老仓库 `zhuxixi/claude-code-skills` 将标记 deprecated

## Files

- **NEW** `.claude-plugin/marketplace.json` — marketplace 顶层 manifest
- **NEW** `plugins/pr-automation/.claude-plugin/plugin.json` — plugin manifest
- **NEW** `plugins/pr-automation/README.md` — plugin 使用说明
- **NEW** `plugins/pr-automation/skills/github-code-review-batch/` — 10 个文件，verbatim 拷贝
- **MODIFIED** `README.md` — 加 Claude Code Marketplace 章节

## 安装方式

```
/plugin marketplace add zhuxixi/zima-blue-cli
/plugin install pr-automation@zima-blue
```

## 关键约束

skill 触发短语作为外部契约保持原文（zima daemon 端依赖）：
- `"batch review pr"`
- `"review pr batch"`
- `"scheduled review pr"`

任何对这些字面短语的修改都会破坏 daemon 调度状态机。

## Test Plan

- [x] `python -m json.tool` 验证 marketplace.json + plugin.json 合法
- [x] `diff -r` 确认 skill 与 canonical 来源 byte-identical
- [x] `grep` 确认三条触发短语都在 SKILL.md frontmatter
- [x] 4 个 stdlib-only 脚本能正确响应 stdin / --help
- [x] `uv run pytest tests/unit/` 全部通过（marketplace 文件不影响 python 测试）
- [x] pre-commit self-review 通过（`pr-review-toolkit:code-reviewer` verdict: ready to merge）
- [ ] PR 合并后在 daemon 机器（7700k_modultra）上 `/plugin marketplace add` + `/plugin install` 烟雾测试，触发一轮真实 CR 验证 metadata 持久化

🤖 Generated with [Claude Code](https://claude.com/claude-code)