### PR TITLE
fix(agent): use kimi-cli instead of kimi for backward compatibility

### DIFF
--- a/zima/models/agent.py
+++ b/zima/models/agent.py
@@ -168,7 +168,7 @@ class AgentConfig(BaseConfig):
             return cmd if isinstance(cmd, list) else [str(cmd)]
 
         templates = {
-            "kimi": ["kimi", "--print", "--yolo"],
+            "kimi": ["kimi-cli", "--print", "--yolo"],
             "claude": ["claude", "-p"],
         }
         return templates.get(self.type, [])


### PR DESCRIPTION
## Summary

Kimi Code (kimi v0.11.0+) replaced the old \+kimi-cli+ CLI with a new interface that no longer supports , , ,  and other flags used by zima.

Users who still have the legacy ╭──────────────────────────────────────────────────────────────────────────────╮
│                                                                              │
│   ▐█▛█▛█▌  Welcome to Kimi Code CLI!                                         │
│   ▐█████▌  Send /help for help information.                                  │
│                                                                              │
│  Directory: ~/work/github-proj/zima-blue-cli                                 │
│  Session: d1fe744c-367a-4e52-ab78-6e1d604dd4fc                               │
│  API Key: ****** (from KIMI_API_KEY)                                         │
│  Model: Kimi-k2.6                                                            │
│                                                                              │
│  ✨ Update: The new Kimi Code is already installed. Start it in a fresh ter  │
│  minal with kimi (verify: which kimi → ~/.kimi-code).                        │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
⠼ MCP Servers: 0/8 connected, 0 tools
• sequential-thinking (pending)
• filesystem (pending)
• zai-mcp-server (pending)
• web-search-prime (pending)
• web-reader (pending)
• zread (pending)
• exa (pending)
• playwright (pending)

── input ───────────────────────────────────────────────────────────────────────
 
Bye! binary installed can continue using it by calling ╭──────────────────────────────────────────────────────────────────────────────╮
│                                                                              │
│   ▐█▛█▛█▌  Welcome to Kimi Code CLI!                                         │
│   ▐█████▌  Send /help for help information.                                  │
│                                                                              │
│  Directory: ~/work/github-proj/zima-blue-cli                                 │
│  Session: 4dbad9e9-2faf-4f02-9970-185138b5c482                               │
│  API Key: ****** (from KIMI_API_KEY)                                         │
│  Model: Kimi-k2.6                                                            │
│                                                                              │
│  ✨ Update: The new Kimi Code is already installed. Start it in a fresh ter  │
│  minal with kimi (verify: which kimi → ~/.kimi-code).                        │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
⠇ MCP Servers: 0/8 connected, 0 tools
• sequential-thinking (pending)
• filesystem (pending)
• zai-mcp-server (pending)
• web-search-prime (pending)
• web-reader (pending)
• zread (pending)
• exa (pending)
• playwright (pending)

── input ───────────────────────────────────────────────────────────────────────
 
Bye! directly.

## Change

- Update the default Kimi command template from `kimi` to `kimi-cli`

## Related

- kimi-cli → kimi-code migration