### PR TITLE
fix(test): update kimi test assertions to match kimi-cli rename

### DIFF
--- a/tests/integration/test_kimi_agent_integration.py
+++ b/tests/integration/test_kimi_agent_integration.py
@@ -81,7 +81,7 @@ class TestKimiAgentConfigLayer:
         cmd = agent.build_command(prompt_file=prompt_file, work_dir=work_dir)
 
         # Verify command structure
-        assert cmd[0] == "kimi"
+        assert cmd[0] == "kimi-cli"
         assert "--print" in cmd
         assert "--yolo" in cmd
         assert "--prompt" in cmd
@@ -138,7 +138,7 @@ class TestKimiAgentConfigLayer:
         claude_cmd = claude_agent.get_cli_command_template()
 
         # Verify command differences
-        assert kimi_cmd == ["kimi", "--print", "--yolo"]
+        assert kimi_cmd == ["kimi-cli", "--print", "--yolo"]
         assert claude_cmd == ["claude", "-p"]
 
         # Verify work-dir parameter differences

--- a/tests/unit/test_config_bundle.py
+++ b/tests/unit/test_config_bundle.py
@@ -277,7 +277,7 @@ class TestConfigBundle:
             prompt_file = Path("/tmp/prompt.md")
             cmd = bundle.build_command(prompt_file)
 
-            assert "kimi" in cmd
+            assert "kimi-cli" in cmd
             assert "--print" in cmd
             assert "--prompt" in cmd
             assert str(prompt_file) in cmd

--- a/tests/unit/test_models_agent.py
+++ b/tests/unit/test_models_agent.py
@@ -218,7 +218,7 @@ class TestAgentConfigCommandBuilding(TestIsolator):
         config = AgentConfig.create("test", "Test", "kimi")
         template = config.get_cli_command_template()
 
-        assert "kimi" in template
+        assert "kimi-cli" in template
         assert "--print" in template
         assert "--yolo" in template
 
@@ -238,7 +238,7 @@ class TestAgentConfigCommandBuilding(TestIsolator):
 
         cmd = config.build_command(prompt_file="/tmp/prompt.md", work_dir="/tmp/workspace")
 
-        assert "kimi" in cmd
+        assert "kimi-cli" in cmd
         assert "--prompt" in cmd
         assert "/tmp/prompt.md" in cmd
         assert "--work-dir" in cmd


### PR DESCRIPTION
## Summary

PR #117 renamed the kimi CLI command from `kimi` to `kimi-cli` for backward compatibility, but 5 test assertions were not updated to match.

## Changes

Updated string assertions in 3 test files:

| File | Test | Change |
|------|------|--------|
| `test_kimi_agent_integration.py` | `test_kimi_agent_build_command` | `"kimi"` → `"kimi-cli"` |
| `test_kimi_agent_integration.py` | `test_agent_type_command_differences` | `["kimi", ...]` → `["kimi-cli", ...]` |
| `test_config_bundle.py` | `test_build_kimi_command` | `"kimi" in cmd` → `"kimi-cli" in cmd` |
| `test_models_agent.py` | `test_get_cli_template_kimi` | `"kimi" in template` → `"kimi-cli" in template` |
| `test_models_agent.py` | `test_build_kimi_command` | `"kimi" in cmd` → `"kimi-cli" in cmd` |

## Verification

- ✅ All 5 previously failing tests now pass
- ✅ Full test suite (981 tests, `-m "not slow"`): only pre-existing local `test_kimi_agent_real` failure (kimi binary issue, skipped in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)