### PR TITLE
feat(cr-batch): severity + verdict (#119) and diff truncation visibility (#120)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pr-automation",
       "source": "./plugins/pr-automation",
       "description": "GitHub PR 自动化（批量 CR、调度式审查、双 Agent 交叉验证）",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "category": "automation",
       "keywords": ["github", "pull-request", "code-review", "automation", "zima"]
     }

--- a/plugins/pr-automation/.claude-plugin/plugin.json
+++ b/plugins/pr-automation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pr-automation",
   "displayName": "PR Automation",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "GitHub PR 自动化技能集 — 批量代码审查、调度式 CR、双 Agent 交叉验证。配合 zima daemon 实现端到端 PR 处理。",
   "author": {
     "name": "zhuxixi"

--- a/plugins/pr-automation/skills/github-code-review-batch/SKILL.md
+++ b/plugins/pr-automation/skills/github-code-review-batch/SKILL.md
@@ -90,8 +90,9 @@ PR 编号提取规则（依次尝试）：
    - `NEEDS_FIX` — 仍有 open issues 需要修复
    - `PASS` — 无 open issues（可能有 acknowledged）
    - `NO_NEW_COMMITS` — Step 0 检测到无新 commit，本轮跳过
+   - 状态报告还含 `Critical issues:` 计数与派生的 `Verdict:`（#119：SKIP / BLOCK_MERGE / READY_TO_MERGE / MERGE_WITH_CAUTION），均追加在 `Status:` 行之后，不影响 grep
 
-zima daemon 通过 grep `Status: <state>` 决策下一步动作。
+zima daemon 通过 grep `Status: <state>` 决策下一步动作（可选消费 `Verdict:` 优先处理含 critical 的 PR）。
 
 ## SubAgent 概览
 

--- a/plugins/pr-automation/skills/github-code-review-batch/SKILL.md
+++ b/plugins/pr-automation/skills/github-code-review-batch/SKILL.md
@@ -137,7 +137,7 @@ gh pr review <PR> --comment --body-file /tmp/cc-cr-{pr}.md      # 发布 review 
 
 1. 仅支持 GitHub 仓库（不支持 GitLab、Bitbucket）
 2. 依赖 `gh` CLI 与 Python 3
-3. 极大 PR（>1000 行）的审查可能不够全面
+3. 大 PR 审查可能不够全面：单 agent 的 diff 经 `compress_diff.py` 压缩到 4000 字符上限，超长会截断尾部；自 #120 起截断通过状态报告的 `Diff truncated` / `Coverage` 行显式提示（不再静默）
 4. 不能替代完整的测试套件和人工代码审查
 5. 非代码文件变更（图片、二进制）无法有效审查
 6. 仅静态分析，不执行代码或运行测试

--- a/plugins/pr-automation/skills/github-code-review-batch/references/edge-cases.md
+++ b/plugins/pr-automation/skills/github-code-review-batch/references/edge-cases.md
@@ -19,7 +19,7 @@
 | 当前分支无关联 PR | 提示用户提供 PR 编号 |
 | 提取不到完整 SHA | 使用 `gh pr view <PR> --json headRefOid` 获取 head SHA，失败则报错 |
 | Agent 返回格式错误的 JSON | 尝试解析，失败则忽略该 Agent 的输出 |
-| diff 过大无法完整处理 | [Step 3.5](flow.md#step-3-5) 预处理：过滤测试文件 + 4000 字符硬限制（hunk-only 压缩 + 截断），不再丢弃整个分析 |
+| diff 过大无法完整处理 | [Step 3.5](flow.md#step-3-5) 预处理：过滤测试文件 + 4000 字符硬限制（hunk-only 压缩 + 截断）；自 #120 起截断经 `--meta-file` 输出覆盖 meta，并在状态报告 `Diff truncated` / `Coverage` 行显式提示（不再静默丢尾部） |
 | 无新 commit（调度器轮询） | [Step 0](flow.md#step-0-3) 检测 → 输出状态报告（含仍 open 的 issues），Status: `NO_NEW_COMMITS` |
 | Metadata 部分损坏（能拿到 round） | 以读到的 round 为底线，本轮 round+1，其余 fallback 默认值，输出警告 |
 | Metadata 完全无法解析 | 报错并停止；**不再静默 fallback 到 Round-1**（避免破坏外部调度器状态机） |

--- a/plugins/pr-automation/skills/github-code-review-batch/references/flow.md
+++ b/plugins/pr-automation/skills/github-code-review-batch/references/flow.md
@@ -176,12 +176,24 @@ gh pr view <PR> --json reviews --jq '.reviews[] | {body: .body, submitted_at: .s
     "reason": "问题类别，如 'CLAUDE.md' / 'AGENTS.md' / 'bug' / 'logic' / 'security'",
     "file": "相对仓库根目录的文件路径",
     "lines": "行号范围，格式如 '45-52'",
-    "suggestion": "可选的修复建议"
+    "suggestion": "可选的修复建议",
+    "severity": "critical | high | medium | low（#119）"
   }
 ]
 ```
 
 如果未发现任何问题，输出空列表 `[]`。
+
+**severity 判定口径（#119）**：每个 issue 必须给出 `severity`，供状态报告计算 `Critical issues` 计数与 `Verdict`：
+
+| severity | 适用 |
+|----------|------|
+| `critical` | 数据损坏、安全漏洞、崩溃/不可恢复错误、阻塞主流程 |
+| `high` | 资源泄漏、错误处理缺失、很可能触发的边界 bug |
+| `medium` | 偶发边界、逻辑健壮性、规范硬性违规 |
+| `low` | 命名/风格类规范、轻微不一致 |
+
+issue-validator 验证时若 agent 未给 severity，按 `medium` 兜底。`build_review_body.py` 渲染时按 severity 降序排列（critical 在前），metadata `issues[]` 保留原始顺序。
 
 **为什么 CLAUDE.md checker 跑两次**：两个独立 checker 通过交叉验证提高规范检查的召回率和准确率，减少漏检和误报。这与"双 CR Agent 交叉验证体系"（Claude Code vs Kimi CLI）是两个不同层次的冗余——前者在同一 skill 内部，后者跨 agent。
 
@@ -208,11 +220,11 @@ gh pr view <PR> --json reviews --jq '.reviews[] | {body: .body, submitted_at: .s
 
 1. **丢弃无效 issue**：移除所有 `valid: false` 的 issue
 2. **去重**：如果多个 issue 的 `file`、`lines`、`reason` 相同或高度相似，合并为一个
-3. **排序优先级**：
-   1. CLAUDE.md 合规问题
-   2. AGENTS.md 合规问题
-   3. bug 问题
-   4. logic / security 问题
+3. **排序优先级**（#119：severity 优先）：
+   1. 先按 `severity` 降序（critical → high → medium → low）
+   2. 再按 reason 类别：CLAUDE.md → AGENTS.md → bug → logic / security
+
+   最终渲染顺序由 `build_review_body.py` 保证（见 [output-examples.md](output-examples.md)）。
 
 去重规则：
 - 如果两个 issue 指向同一个文件、同一行范围、且原因相同，视为重复
@@ -243,7 +255,7 @@ gh pr view <PR> --json reviews --jq '.reviews[] | {body: .body, submitted_at: .s
 
 Found N issues:
 
-1. {description} ({reason})
+1. {description} ({reason}, {severity})
 
 https://github.com/owner/repo/blob/{full-sha}/{file}#L{start}-L{end}
 ```
@@ -279,7 +291,7 @@ No issues found. Checked for bugs, CLAUDE.md and AGENTS.md compliance.
 调用 [scripts/build_review_body.py](../scripts/build_review_body.py)，输入 JSON 包括：
 - `round`, `pr_number`, `head_sha`, `previous_head_sha`
 - `repo_owner`, `repo_name`
-- `issues`（含 status / resolution / committer_note）
+- `issues`（含 status / resolution / committer_note / severity）
 - 分类计数：`resolved_count`, `acknowledged_count`, `new_count`, `total_issues`
 - `timestamp`（ISO 8601）
 
@@ -302,7 +314,7 @@ No issues found. Checked for bugs, CLAUDE.md and AGENTS.md compliance.
 - `resolved_count`: 本轮标记为 resolved 的问题数（Round-1 为 0）
 - `new_count`: 本轮新发现的问题数
 - `acknowledged_count`: 本轮标记为 acknowledged / wontfix 的问题数
-- `issues`: 问题数组，每个元素含 `status`（"open"/"resolved"）、`resolution`（"acknowledged"/"wontfix"/"resolved"/null）、`committer_note`（string 或 null）
+- `issues`: 问题数组，每个元素含 `status`（"open"/"resolved"）、`resolution`（"acknowledged"/"wontfix"/"resolved"/null）、`committer_note`（string 或 null）、`severity`（"critical"/"high"/"medium"/"low"，#119，缺省 medium）
 - `timestamp`: ISO 8601 格式时间戳
 
 **Part B: Markdown 人类可读部分**
@@ -353,15 +365,25 @@ Total open issues: {open_count}
 - Resolved this round: {resolved_count}
 - Acknowledged / Won't Fix: {acknowledged_count}
 Status: {status}
+Critical issues: {critical_count}
+Verdict: {verdict}
 ================================
 ```
 
 字段说明：
 - `Total open issues`：当前仍 open 的问题总数（不含 acknowledged）
-- `Status` 枚举三态：
+- `Critical issues`：当前 open issues 中 `severity=critical` 的数量（#119，向后兼容：未提供视为 0）
+- `Status` 枚举三态（不变，zima daemon 仍 grep 此行）：
   - `NEEDS_FIX` — 仍有 open issues 需要修复
   - `PASS` — 无 open issues（可能仍有 acknowledged）
   - `NO_NEW_COMMITS` — Step 0 检测到无新 commit
+- `Verdict`（#119 新增，由 `Status` + `critical_count` + `open_count` 派生，不替换三态）：
+  - `SKIP` — NO_NEW_COMMITS
+  - `BLOCK_MERGE` — critical_count > 0
+  - `READY_TO_MERGE` — open_count == 0
+  - `MERGE_WITH_CAUTION` — 其余（有 open 但无 critical）
+
+`critical_count` 由 Step 6 汇总后的 open issues 中 severity=critical 的个数得出，作为 `critical_count` 字段传入 `render_status_report.py`。
 
 ### 用途
 
@@ -369,5 +391,6 @@ Status: {status}
   - `NEEDS_FIX` → 调度 fix agent 修复 open issues
   - `PASS` → 当前 PR 无需进一步 action
   - `NO_NEW_COMMITS` → 本轮跳过，等待下次调度
+  - 可选：消费 `Verdict` 行优先处理 `BLOCK_MERGE`（有 critical）的 PR
 - **fix agent**：快速获取当前 open issues 列表，无需重新解析 metadata
 - **人工查看**：一目了然了解当前审查状态

--- a/plugins/pr-automation/skills/github-code-review-batch/references/flow.md
+++ b/plugins/pr-automation/skills/github-code-review-batch/references/flow.md
@@ -140,16 +140,20 @@ gh pr view <PR> --json reviews --jq '.reviews[] | {body: .body, submitted_at: .s
 **按 agent 类型过滤 diff**：
 - CLAUDE.md checker ×2、AGENTS.md checker：接收**完整 diff**（规范检查需要完整上下文），仅应用长度兜底
   ```bash
-  gh pr diff <PR> | python scripts/compress_diff.py --max-len 4000
+  gh pr diff <PR> | python scripts/compress_diff.py --max-len 4000 \
+      --meta-file /tmp/cc-cr-diff-meta.json > /tmp/cc-cr-diff.txt
   ```
 - Bug scanner、Logic analyzer：接收**过滤后的 diff**，排除测试相关文件
   ```bash
-  gh pr diff <PR> | python scripts/compress_diff.py --filter-tests --max-len 4000
+  gh pr diff <PR> | python scripts/compress_diff.py --filter-tests --max-len 4000 \
+      --meta-file /tmp/cc-cr-diff-meta.json > /tmp/cc-cr-diff.txt
   ```
+
+`--meta-file`（#120）写一份覆盖 meta（`diff_truncated`、`covered_files`/`total_files`、被丢弃文件等）到 sidecar JSON，供 [Step 10](#step-10) 在状态报告中显式提示部分覆盖；各 agent 改为读取 `/tmp/cc-cr-diff.txt` 作为 diff 输入。
 
 **脚本内部规则**：
 1. `--filter-tests` 排除：`tests/`、`test/` 目录下的文件；`*_test.py`、`*_spec.py`、`*_tests.py`；`.test.`、`.spec.` 等测试文件
-2. `--max-len N`：超长时先压缩为 hunk-only（保留 +/- 行及前后各 2 行上下文）；仍超长则截断至 N 字符并附 `... (diff truncated)`
+2. `--max-len N`：超长时先压缩为 hunk-only（保留 +/- 行及前后各 2 行上下文）；仍超长则截断至 N 字符并附 `... (diff truncated)`，并在 meta 中置 `diff_truncated: true`（#120）
 
 **效果**：过滤后 diff 长度通常减少 60-70%（测试文件往往占据大比例 diff）。
 
@@ -384,6 +388,15 @@ Verdict: {verdict}
   - `MERGE_WITH_CAUTION` — 其余（有 open 但无 critical）
 
 `critical_count` 由 Step 6 汇总后的 open issues 中 severity=critical 的个数得出，作为 `critical_count` 字段传入 `render_status_report.py`。
+
+**部分覆盖提示（#120）**：若 [Step 3.5](#step-3-5) 的 `--meta-file` 指示 `diff_truncated: true`，把 `diff_truncated` / `covered_files` / `total_files` 传入 `render_status_report.py`，报告会在 `Verdict:` 之后追加：
+
+```
+Diff truncated: yes
+Coverage: 7/10 files
+```
+
+调度器据此识别"本轮 0 issue 但 diff 被截断、覆盖不全"，不会把截断导致的空结果误读为"全量审查通过"。未提供这些字段时省略（向后兼容）。
 
 ### 用途
 

--- a/plugins/pr-automation/skills/github-code-review-batch/references/output-examples.md
+++ b/plugins/pr-automation/skills/github-code-review-batch/references/output-examples.md
@@ -8,27 +8,29 @@
 
 ```markdown
 <!-- cc-cr-meta
-{"round":1,"pr_number":123,"head_sha":"abc123def4567890123456789012345678901234","previous_head_sha":null,"total_issues":3,"resolved_count":0,"new_count":3,"acknowledged_count":0,"issues":[{"id":"issue-1","description":"Missing error handling for OAuth callback","reason":"bug","file":"src/auth.ts","lines":"67-72","status":"open","first_round":1},{"id":"issue-2","description":"Inconsistent naming pattern","reason":"AGENTS.md","file":"src/utils.ts","lines":"23-28","status":"open","first_round":1},{"id":"issue-3","description":"Memory leak: OAuth state not cleaned up","reason":"bug","file":"src/auth.ts","lines":"88-95","status":"open","first_round":1}],"timestamp":"2026-04-21T10:00:00Z"}
+{"round":1,"pr_number":123,"head_sha":"abc123def4567890123456789012345678901234","previous_head_sha":null,"total_issues":3,"resolved_count":0,"new_count":3,"acknowledged_count":0,"issues":[{"id":"issue-1","description":"Missing error handling for OAuth callback","reason":"bug","file":"src/auth.ts","lines":"67-72","status":"open","first_round":1,"severity":"high"},{"id":"issue-2","description":"Inconsistent naming pattern","reason":"AGENTS.md","file":"src/utils.ts","lines":"23-28","status":"open","first_round":1,"severity":"low"},{"id":"issue-3","description":"Memory leak: OAuth state not cleaned up","reason":"bug","file":"src/auth.ts","lines":"88-95","status":"open","first_round":1,"severity":"critical"}],"timestamp":"2026-04-21T10:00:00Z"}
 -->
 
 ### Code Review | Round-1
 
 Found 3 issues:
 
-1. Missing error handling for OAuth callback (CLAUDE.md: "Always handle OAuth errors explicitly")
-
-https://github.com/owner/repo/blob/abc123def4567890123456789012345678901234/src/auth.ts#L67-L72
-
-2. Memory leak: OAuth state not cleaned up (bug: missing cleanup in finally block)
+1. Memory leak: OAuth state not cleaned up (bug, critical)
 
 https://github.com/owner/repo/blob/abc123def4567890123456789012345678901234/src/auth.ts#L88-L95
 
-3. Inconsistent naming pattern (AGENTS.md: "Use camelCase for all new functions")
+2. Missing error handling for OAuth callback (bug, high)
+
+https://github.com/owner/repo/blob/abc123def4567890123456789012345678901234/src/auth.ts#L67-L72
+
+3. Inconsistent naming pattern (AGENTS.md, low)
 
 https://github.com/owner/repo/blob/abc123def4567890123456789012345678901234/src/utils.ts#L23-L28
 
 🤖 Generated with Claude Code
 ```
+
+> **#119**：issue 按 `severity` 降序排列（critical 在前），每条标注 `(reason, severity)`。metadata `issues[]` 保留输入顺序（issue-1/2/3），仅人类可读部分重排。
 
 ---
 
@@ -52,7 +54,7 @@ No issues found. Checked for bugs, CLAUDE.md and AGENTS.md compliance.
 
 ```markdown
 <!-- cc-cr-meta
-{"round":2,"pr_number":123,"head_sha":"fed789abc0123456789012345678901234567890","previous_head_sha":"abc123def4567890123456789012345678901234","total_issues":1,"resolved_count":1,"acknowledged_count":1,"new_count":0,"issues":[{"id":"issue-2","description":"Daemon binds to localhost only, no auth needed","reason":"logic","file":"src/server.py","lines":"45-50","status":"open","first_round":1,"resolution":"acknowledged","committer_note":"daemon binds to localhost only, authentication not needed for local service"},{"id":"issue-3","description":"Memory leak: OAuth state not cleaned up","reason":"bug","file":"src/auth.ts","lines":"88-95","status":"open","first_round":1,"resolution":null,"committer_note":null}],"timestamp":"2026-04-21T10:30:00Z"}
+{"round":2,"pr_number":123,"head_sha":"fed789abc0123456789012345678901234567890","previous_head_sha":"abc123def4567890123456789012345678901234","total_issues":1,"resolved_count":1,"acknowledged_count":1,"new_count":0,"issues":[{"id":"issue-2","description":"Daemon binds to localhost only, no auth needed","reason":"logic","file":"src/server.py","lines":"45-50","status":"open","first_round":1,"resolution":"acknowledged","committer_note":"daemon binds to localhost only, authentication not needed for local service","severity":"medium"},{"id":"issue-3","description":"Memory leak: OAuth state not cleaned up","reason":"bug","file":"src/auth.ts","lines":"88-95","status":"open","first_round":1,"resolution":null,"committer_note":null,"severity":"critical"}],"timestamp":"2026-04-21T10:30:00Z"}
 -->
 
 ### Code Review | Round-2 (Re-check)
@@ -70,7 +72,7 @@ New issues found: 0
 
 #### Still Open from Round-1
 
-3. Memory leak: OAuth state not cleaned up (bug: missing cleanup in finally block)
+3. Memory leak: OAuth state not cleaned up (bug, critical)
 
 https://github.com/owner/repo/blob/fed789abc0123456789012345678901234567890/src/auth.ts#L88-L95
 

--- a/plugins/pr-automation/skills/github-code-review-batch/references/subagent-prompts.md
+++ b/plugins/pr-automation/skills/github-code-review-batch/references/subagent-prompts.md
@@ -2,6 +2,8 @@
 
 本文件定义 7 个 sub-agent 的输入契约、输出 schema、任务要求和推荐 prompt 模板。
 
+> **severity（#119）**：所有产出 issue 的 agent（claude-compliance-checker / agents-compliance-checker / bug-scanner / logic-analyzer，以及 delta-reviewer 的 `new_issues`）必须为每个 issue 给出 `severity: critical | high | medium | low`，判定口径见 [flow.md Step 4](flow.md#step-4)。下游 `build_review_body.py` 按 severity 排序，状态报告据此计算 `Critical issues` 与 `Verdict`。
+
 ---
 
 ## summarizer {#summarizer}
@@ -37,7 +39,7 @@
 ## claude-compliance-checker {#claude-compliance-checker}
 
 **输入**：PR diff、PR 摘要、相关 CLAUDE.md 文件内容
-**输出**：JSON 问题列表 `[{description, reason, file, lines, suggestion}]`
+**输出**：JSON 问题列表 `[{description, reason, file, lines, suggestion, severity}]`
 
 ### 任务
 
@@ -69,7 +71,7 @@
 1. 只关注 PR 修改的代码，忽略原有代码
 2. 尽量引用 CLAUDE.md 中的规则原文，但不要求一字不差；对于逻辑/安全问题，无需强制引用规范
 3. 不报告纯主观判断，但值得关注的逻辑缺陷和安全问题应当报告
-4. 输出 JSON 数组，每个元素包含 description、reason（必须包含 "CLAUDE.md"）、file、lines、suggestion
+4. 输出 JSON 数组，每个元素包含 description、reason（必须包含 "CLAUDE.md"）、file、lines、suggestion、severity（critical/high/medium/low）
 5. 如果没有发现违规，输出空数组 []
 ```
 
@@ -78,7 +80,7 @@
 ## agents-compliance-checker {#agents-compliance-checker}
 
 **输入**：PR diff、PR 摘要、相关 AGENTS.md 文件内容
-**输出**：JSON 问题列表 `[{description, reason, file, lines, suggestion}]`
+**输出**：JSON 问题列表 `[{description, reason, file, lines, suggestion, severity}]`
 
 ### 任务
 
@@ -106,7 +108,7 @@
 1. 只关注 PR 修改的代码，忽略原有代码
 2. 区分适用于代码审查的规则 vs 仅适用于编码行为的规则
 3. 尽量引用 AGENTS.md 中的规则原文，但不要求一字不差；对于逻辑/安全问题，无需强制引用规范
-4. 输出 JSON 数组，每个元素包含 description、reason（必须包含 "AGENTS.md"）、file、lines、suggestion
+4. 输出 JSON 数组，每个元素包含 description、reason（必须包含 "AGENTS.md"）、file、lines、suggestion、severity（critical/high/medium/low）
 5. 如果没有发现违规，输出空数组 []
 ```
 
@@ -115,7 +117,7 @@
 ## bug-scanner {#bug-scanner}
 
 **输入**：经过 [Step 3.5](flow.md#step-3-5) 过滤测试文件后的 PR diff
-**输出**：JSON 问题列表 `[{description, reason, file, lines, suggestion}]`
+**输出**：JSON 问题列表 `[{description, reason, file, lines, suggestion, severity}]`
 
 ### 任务
 
@@ -141,7 +143,7 @@
 2. 报告所有潜在问题：编译错误、缺失导入、未解析引用、逻辑错误、空值处理、竞态条件、边界条件
 3. 忽略纯风格问题，但关注可能导致运行时错误的设计问题
 4. 对于不确定的问题仍然报告，在 description 中用 "Potential:" 或 "Possible:" 标注
-5. 输出 JSON 数组，每个元素包含 description、reason（必须为 "bug"）、file、lines、suggestion
+5. 输出 JSON 数组，每个元素包含 description、reason（必须为 "bug"）、file、lines、suggestion、severity（critical/high/medium/low）
 6. 如果没有发现 Bug，输出空数组 []
 ```
 
@@ -150,7 +152,7 @@
 ## logic-analyzer {#logic-analyzer}
 
 **输入**：经过 [Step 3.5](flow.md#step-3-5) 过滤测试文件后的 PR diff、PR 摘要
-**输出**：JSON 问题列表 `[{description, reason, file, lines, suggestion}]`
+**输出**：JSON 问题列表 `[{description, reason, file, lines, suggestion, severity}]`
 
 ### 任务
 
@@ -178,7 +180,7 @@
 2. 关注资源泄漏、错误处理缺失、安全漏洞、竞态条件、边界条件、异常路径
 3. 对于依赖输入的潜在问题，如果代码没有做任何防御性处理，仍然值得报告
 4. 忽略纯风格问题和无明确对错的主观建议
-5. 输出 JSON 数组，每个元素包含 description、reason（"logic" 或 "security"）、file、lines、suggestion
+5. 输出 JSON 数组，每个元素包含 description、reason（"logic" 或 "security"）、file、lines、suggestion、severity（critical/high/medium/low）
 6. 如果没有发现问题，输出空数组 []
 ```
 
@@ -273,7 +275,8 @@
       "reason": "logic",
       "file": "src/auth.ts",
       "lines": "100-105",
-      "suggestion": "Add mutex lock"
+      "suggestion": "Add mutex lock",
+      "severity": "high"
     }
   ],
   "unresolved_issues": [
@@ -296,6 +299,7 @@
 - 对于 acknowledged 的问题，保留 `committer_note`
 - 对于未修复的问题，保持原描述不变
 - 新问题使用新的 `id`，不影响原有 issue 编号
+- 新发现的 issue（`new_issues`）必须含 `severity`（critical/high/medium/low，#119）
 
 ### 推荐 prompt
 

--- a/plugins/pr-automation/skills/github-code-review-batch/scripts/build_review_body.py
+++ b/plugins/pr-automation/skills/github-code-review-batch/scripts/build_review_body.py
@@ -10,7 +10,8 @@ Input (stdin): JSON object with the following fields:
   repo_name          str
   timestamp          str   — ISO 8601, e.g. "2026-04-21T10:00:00Z"
   issues             list  — each item: {id, description, reason, file, lines,
-                                          status, first_round, resolution?, committer_note?}
+                                          status, first_round, severity?,
+                                          resolution?, committer_note?}
   resolved_issues    list  — items with description (used in Round-N summary line)
   acknowledged_issues list — items with description, committer_note
   new_issues         list  — items with id, description, reason, file, lines
@@ -33,20 +34,52 @@ def gh_link(owner: str, repo: str, sha: str, file: str, lines: str) -> str:
     return f"https://github.com/{owner}/{repo}/blob/{sha}/{file}#L{lines.replace('-', '-L')}"
 
 
+# Severity ordering for the human-readable review body (#119). Lower rank sorts
+# first (critical on top). Metadata `issues[]` keeps input order; only the
+# rendered Markdown is re-sorted, so the historical record is preserved.
+SEVERITY_RANK = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+
+
+def _severity(issue: dict) -> str:
+    """Issue severity with a 'medium' fallback (backward-compat, #119)."""
+    sev = issue.get("severity") or "medium"
+    return sev if sev in SEVERITY_RANK else "medium"
+
+
+def _severity_rank(issue: dict) -> int:
+    return SEVERITY_RANK[_severity(issue)]
+
+
 def build_metadata(d: dict) -> str:
     keys = [
-        "round", "pr_number", "head_sha", "previous_head_sha",
-        "total_issues", "resolved_count", "new_count", "acknowledged_count",
-        "issues", "timestamp",
+        "round",
+        "pr_number",
+        "head_sha",
+        "previous_head_sha",
+        "total_issues",
+        "resolved_count",
+        "new_count",
+        "acknowledged_count",
+        "issues",
+        "timestamp",
     ]
     payload = {k: d.get(k) for k in keys}
-    payload["total_issues"] = d.get("total_issues", len([
-        i for i in d.get("issues", [])
-        if i.get("status") == "open" and i.get("resolution") not in ("acknowledged", "wontfix")
-    ]))
+    payload["total_issues"] = d.get(
+        "total_issues",
+        len(
+            [
+                i
+                for i in d.get("issues", [])
+                if i.get("status") == "open"
+                and i.get("resolution") not in ("acknowledged", "wontfix")
+            ]
+        ),
+    )
     payload["resolved_count"] = d.get("resolved_count", len(d.get("resolved_issues", [])))
     payload["new_count"] = d.get("new_count", len(d.get("new_issues", [])))
-    payload["acknowledged_count"] = d.get("acknowledged_count", len(d.get("acknowledged_issues", [])))
+    payload["acknowledged_count"] = d.get(
+        "acknowledged_count", len(d.get("acknowledged_issues", []))
+    )
     return f"<!-- cc-cr-meta\n{json.dumps(payload, ensure_ascii=False)}\n-->"
 
 
@@ -54,12 +87,14 @@ def render_round_1(d: dict) -> str:
     issues = d.get("issues", [])
     if not issues:
         return "### Code Review | Round-1\n\nNo issues found. Checked for bugs, CLAUDE.md and AGENTS.md compliance."
+    issues = sorted(issues, key=_severity_rank)
     parts = ["### Code Review | Round-1", "", f"Found {len(issues)} issues:", ""]
     for i, issue in enumerate(issues, 1):
-        parts.append(f"{i}. {issue['description']} ({issue['reason']})")
+        parts.append(f"{i}. {issue['description']} ({issue['reason']}, {_severity(issue)})")
         parts.append("")
-        parts.append(gh_link(d["repo_owner"], d["repo_name"], d["head_sha"],
-                             issue["file"], issue["lines"]))
+        parts.append(
+            gh_link(d["repo_owner"], d["repo_name"], d["head_sha"], issue["file"], issue["lines"])
+        )
         parts.append("")
     return "\n".join(parts).rstrip()
 
@@ -70,11 +105,11 @@ def render_round_n(d: dict) -> str:
     prev_count = d.get("prev_round_count", 0)
     resolved = d.get("resolved_issues", [])
     acknowledged = d.get("acknowledged_issues", [])
-    unresolved = d.get("unresolved_issues", [])
-    new_issues = d.get("new_issues", [])
+    unresolved = sorted(d.get("unresolved_issues", []), key=_severity_rank)
+    new_issues = sorted(d.get("new_issues", []), key=_severity_rank)
 
     still_open = len(unresolved)
-    all_resolved = (still_open == 0 and len(new_issues) == 0)
+    all_resolved = still_open == 0 and len(new_issues) == 0
 
     lines: list[str] = [f"### Code Review | Round-{n} (Re-check)", ""]
     lines.append(f"Previous Round-{prev_n} issues: {prev_count}")
@@ -85,10 +120,17 @@ def render_round_n(d: dict) -> str:
         return "\n".join(lines)
 
     resolved_label = ", ".join(r.get("description", "")[:40] for r in resolved) if resolved else ""
-    ack_label = ", ".join(a.get("description", "")[:40] for a in acknowledged) if acknowledged else ""
-    lines.append(f"- **Resolved**: {len(resolved)}" + (f" ({resolved_label})" if resolved_label else ""))
+    ack_label = (
+        ", ".join(a.get("description", "")[:40] for a in acknowledged) if acknowledged else ""
+    )
+    lines.append(
+        f"- **Resolved**: {len(resolved)}" + (f" ({resolved_label})" if resolved_label else "")
+    )
     if acknowledged:
-        lines.append(f"- **Acknowledged / Won't Fix**: {len(acknowledged)}" + (f" ({ack_label})" if ack_label else ""))
+        lines.append(
+            f"- **Acknowledged / Won't Fix**: {len(acknowledged)}"
+            + (f" ({ack_label})" if ack_label else "")
+        )
     lines.append(f"- **Still open**: {still_open}")
     lines.append("")
     lines.append(f"New issues found: {len(new_issues)}")
@@ -104,23 +146,25 @@ def render_round_n(d: dict) -> str:
         lines.append("")
 
     if unresolved:
-        lines.append(f"#### Still Open from Previous Rounds")
+        lines.append("#### Still Open from Previous Rounds")
         lines.append("")
         for i, item in enumerate(unresolved, 1):
-            lines.append(f"{i}. {item['description']} ({item['reason']})")
+            lines.append(f"{i}. {item['description']} ({item['reason']}, {_severity(item)})")
             lines.append("")
-            lines.append(gh_link(d["repo_owner"], d["repo_name"], d["head_sha"],
-                                 item["file"], item["lines"]))
+            lines.append(
+                gh_link(d["repo_owner"], d["repo_name"], d["head_sha"], item["file"], item["lines"])
+            )
             lines.append("")
 
     if new_issues:
         lines.append("#### New Issues")
         lines.append("")
         for i, item in enumerate(new_issues, 1):
-            lines.append(f"{i}. {item['description']} ({item['reason']})")
+            lines.append(f"{i}. {item['description']} ({item['reason']}, {_severity(item)})")
             lines.append("")
-            lines.append(gh_link(d["repo_owner"], d["repo_name"], d["head_sha"],
-                                 item["file"], item["lines"]))
+            lines.append(
+                gh_link(d["repo_owner"], d["repo_name"], d["head_sha"], item["file"], item["lines"])
+            )
             lines.append("")
 
     return "\n".join(lines).rstrip()

--- a/plugins/pr-automation/skills/github-code-review-batch/scripts/compress_diff.py
+++ b/plugins/pr-automation/skills/github-code-review-batch/scripts/compress_diff.py
@@ -4,19 +4,26 @@
 Steps:
   1. Optionally drop test-related files (--filter-tests).
   2. If still too long, keep only +/- hunks plus N lines of context.
-  3. If still too long, hard-truncate at --max-len chars.
+  3. If still too long, hard-truncate at --max-len chars (sets diff_truncated).
 
 Input (stdin): unified diff (output of `gh pr diff <PR>`).
 Output (stdout): compressed diff.
 
+--meta-file PATH (#120): also write a coverage-meta JSON sidecar
+({diff_truncated, total_files, kept_files, covered_files, dropped_test_files,
+truncated_dropped_files, input_chars, output_chars}) so the status report can
+surface partial coverage instead of silently dropping the diff tail. Omit it to
+keep the legacy stdout-only behavior.
+
 Examples:
     gh pr diff 123 | python compress_diff.py --max-len 4000
-    gh pr diff 123 | python compress_diff.py --filter-tests --max-len 4000
+    gh pr diff 123 | python compress_diff.py --filter-tests --max-len 4000 --meta-file /tmp/meta.json
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 
@@ -52,16 +59,19 @@ def split_files(diff: str) -> list[list[str]]:
     return files
 
 
-def filter_test_files(diff: str) -> str:
-    blocks = split_files(diff)
-    keep: list[str] = []
-    for block in blocks:
-        header = block[0] if block else ""
-        m = FILE_HEADER_RE.match(header)
-        if m and (is_test_path(m.group(1)) or is_test_path(m.group(2))):
-            continue
-        keep.extend(block)
-    return "\n".join(keep)
+def _block_path(block: list[str]) -> str | None:
+    """The 'a/...' path of a file-block, or None for stray preamble."""
+    header = block[0] if block else ""
+    m = FILE_HEADER_RE.match(header)
+    return m.group(1) if m else None
+
+
+def _block_is_test(block: list[str]) -> bool:
+    header = block[0] if block else ""
+    m = FILE_HEADER_RE.match(header)
+    if not m:
+        return False
+    return is_test_path(m.group(1)) or is_test_path(m.group(2))
 
 
 def keep_hunks_only(diff: str, context_lines: int = 2) -> str:
@@ -86,28 +96,83 @@ def truncate(diff: str, max_len: int) -> str:
     return diff[:max_len] + "\n... (diff truncated due to length)"
 
 
-def compress(diff: str, *, filter_tests: bool, max_len: int) -> str:
+def compress(diff: str, *, filter_tests: bool, max_len: int) -> tuple[str, dict]:
+    """Compress the diff and report coverage meta (#120).
+
+    Returns (compressed_diff, meta). `meta["diff_truncated"]` is True iff the
+    hard char-ceiling cut content — the signal the status report surfaces so the
+    scheduler knows coverage was partial rather than a clean PASS.
+    """
+    blocks = split_files(diff)
+    total_files = sum(1 for b in blocks if _block_path(b))
+
     if filter_tests:
-        diff = filter_test_files(diff)
-    if len(diff) > max_len:
-        diff = keep_hunks_only(diff, context_lines=2)
-    if len(diff) > max_len:
-        diff = truncate(diff, max_len)
-    return diff
+        kept = [b for b in blocks if not _block_is_test(b)]
+        dropped_test_files = [p for p in (_block_path(b) for b in blocks) if p and is_test_path(p)]
+    else:
+        kept = list(blocks)
+        dropped_test_files = []
+    kept_paths = [p for p in (_block_path(b) for b in kept) if p]
+
+    out = "\n".join(line for b in kept for line in b)
+    diff_truncated = False
+    if len(out) > max_len:
+        out = keep_hunks_only(out, context_lines=2)
+    if len(out) > max_len:
+        out = truncate(out, max_len)
+        diff_truncated = True
+
+    covered = []
+    for line in out.splitlines():
+        m = FILE_HEADER_RE.match(line)
+        if m:
+            covered.append(m.group(1))
+    covered_set = set(covered)
+    truncated_dropped_files = [p for p in kept_paths if p not in covered_set]
+
+    meta = {
+        "filter_tests": filter_tests,
+        "diff_truncated": diff_truncated,
+        "total_files": total_files,
+        "kept_files": len(kept_paths),
+        "covered_files": len(covered_set),
+        "dropped_test_files": dropped_test_files,
+        "truncated_dropped_files": truncated_dropped_files,
+        "input_chars": len(diff),
+        "output_chars": len(out),
+    }
+    return out, meta
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--filter-tests", action="store_true",
-                    help="Drop test-related files (tests/, *_test.py, .spec., etc.)")
-    ap.add_argument("--max-len", type=int, default=4000,
-                    help="Hard length ceiling in characters (default: 4000)")
+    ap.add_argument(
+        "--filter-tests",
+        action="store_true",
+        help="Drop test-related files (tests/, *_test.py, .spec., etc.)",
+    )
+    ap.add_argument(
+        "--max-len",
+        type=int,
+        default=4000,
+        help="Hard length ceiling in characters (default: 4000)",
+    )
+    ap.add_argument(
+        "--meta-file",
+        metavar="PATH",
+        default=None,
+        help="Write coverage meta JSON to PATH (#120); omit for legacy behavior",
+    )
     args = ap.parse_args()
     diff = sys.stdin.read()
-    out = compress(diff, filter_tests=args.filter_tests, max_len=args.max_len)
+    out, meta = compress(diff, filter_tests=args.filter_tests, max_len=args.max_len)
     sys.stdout.write(out)
     if not out.endswith("\n"):
         sys.stdout.write("\n")
+    if args.meta_file:
+        with open(args.meta_file, "w", encoding="utf-8") as fh:
+            json.dump(meta, fh, ensure_ascii=False)
+            fh.write("\n")
     return 0
 
 

--- a/plugins/pr-automation/skills/github-code-review-batch/scripts/render_status_report.py
+++ b/plugins/pr-automation/skills/github-code-review-batch/scripts/render_status_report.py
@@ -38,7 +38,6 @@ Total open issues: {open_count}
 Status: {status}
 Critical issues: {critical_count}
 Verdict: {verdict}
-================================
 """
 
 
@@ -71,7 +70,7 @@ def render(d: dict) -> str:
         sys.exit(2)
     open_count = d.get("open_count", 0)
     critical_count = d.get("critical_count", 0)
-    return TEMPLATE.format(
+    block = TEMPLATE.format(
         pr_number=d.get("pr_number", ""),
         round=d.get("round", ""),
         head_sha=d.get("head_sha", ""),
@@ -87,6 +86,16 @@ def render(d: dict) -> str:
         critical_count=critical_count,
         verdict=_verdict(status, critical_count, open_count),
     )
+    # Optional partial-coverage lines (#120) — only when the caller provides
+    # them. Keeps the report backward-compatible when compress_diff meta is absent.
+    total_files = d.get("total_files")
+    if d.get("diff_truncated") or total_files is not None:
+        block += f"Diff truncated: {'yes' if d.get('diff_truncated') else 'no'}\n"
+        if total_files is not None:
+            covered = d.get("covered_files", total_files)
+            block += f"Coverage: {covered}/{total_files} files\n"
+    block += "================================\n"
+    return block
 
 
 def main() -> int:

--- a/plugins/pr-automation/skills/github-code-review-batch/scripts/render_status_report.py
+++ b/plugins/pr-automation/skills/github-code-review-batch/scripts/render_status_report.py
@@ -12,8 +12,11 @@ Input (stdin): JSON object with the following fields:
   resolved_count     int
   acknowledged_count int
   status             str  — "NEEDS_FIX" | "PASS" | "NO_NEW_COMMITS"
+  critical_count     int  — open issues with severity=critical (optional, default 0)
 
-Output (stdout): the multi-line status report block.
+Output (stdout): the multi-line status report block. After `Status:` the report
+also emits `Critical issues:` and a derived `Verdict:` line (#119). The 3-state
+`Status:` enum and its grep-ability for zima daemon are preserved.
 """
 
 from __future__ import annotations
@@ -33,27 +36,56 @@ Total open issues: {open_count}
 - Resolved this round: {resolved_count}
 - Acknowledged / Won't Fix: {acknowledged_count}
 Status: {status}
+Critical issues: {critical_count}
+Verdict: {verdict}
 ================================
 """
+
+
+def _verdict(status: str, critical_count: int, open_count: int) -> str:
+    """Derive a merge verdict from the 3-state Status plus counts (#119).
+
+    Verdict is an additive dimension; the `Status:` enum is unchanged so zima
+    daemon's `grep "Status:"` keeps working. Mapping:
+      NO_NEW_COMMITS          -> SKIP
+      critical_count > 0      -> BLOCK_MERGE
+      open_count == 0 (PASS)  -> READY_TO_MERGE
+      otherwise               -> MERGE_WITH_CAUTION
+    """
+    if status == "NO_NEW_COMMITS":
+        return "SKIP"
+    if critical_count > 0:
+        return "BLOCK_MERGE"
+    if open_count == 0:
+        return "READY_TO_MERGE"
+    return "MERGE_WITH_CAUTION"
 
 
 def render(d: dict) -> str:
     status = d.get("status", "")
     if status not in VALID_STATUSES:
-        print(f"render_status_report: invalid status {status!r}; expected one of {sorted(VALID_STATUSES)}",
-              file=sys.stderr)
+        print(
+            f"render_status_report: invalid status {status!r}; expected one of {sorted(VALID_STATUSES)}",
+            file=sys.stderr,
+        )
         sys.exit(2)
+    open_count = d.get("open_count", 0)
+    critical_count = d.get("critical_count", 0)
     return TEMPLATE.format(
         pr_number=d.get("pr_number", ""),
         round=d.get("round", ""),
         head_sha=d.get("head_sha", ""),
-        previous_head_sha=d.get("previous_head_sha", "null") if d.get("previous_head_sha") is not None else "null",
-        open_count=d.get("open_count", 0),
+        previous_head_sha=(
+            d.get("previous_head_sha", "null") if d.get("previous_head_sha") is not None else "null"
+        ),
+        open_count=open_count,
         new_count=d.get("new_count", 0),
         unresolved_count=d.get("unresolved_count", 0),
         resolved_count=d.get("resolved_count", 0),
         acknowledged_count=d.get("acknowledged_count", 0),
         status=status,
+        critical_count=critical_count,
+        verdict=_verdict(status, critical_count, open_count),
     )
 
 

--- a/tests/unit/test_cr_batch_contracts.py
+++ b/tests/unit/test_cr_batch_contracts.py
@@ -454,3 +454,98 @@ class TestSeverityRender:
         proc = _run(_script("build_review_body.py"), json.dumps(minimal))
         assert proc.returncode == 0, proc.stderr
         assert "(bug, medium)" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# #120: diff truncation visibility (compress_diff --meta-file + status report)
+# ---------------------------------------------------------------------------
+
+
+class TestTruncationMeta:
+    """compress_diff must emit structured coverage meta when asked (#120)."""
+
+    def test_meta_no_truncation(self, tmp_path):
+        diff = "diff --git a/foo.py b/foo.py\n+keep()\n"
+        meta_path = tmp_path / "meta.json"
+        proc = _run(_script("compress_diff.py"), diff, "--meta-file", str(meta_path))
+        assert proc.returncode == 0
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        assert meta["diff_truncated"] is False
+        assert meta["total_files"] == 1
+        assert meta["covered_files"] == 1
+        assert meta["dropped_test_files"] == []
+
+    def test_meta_truncation_within_file(self, tmp_path):
+        # Single file whose content exceeds max-len: header survives, content cut.
+        diff = "diff --git a/big.py b/big.py\n" + "+added\n" * 300
+        meta_path = tmp_path / "meta.json"
+        proc = _run(
+            _script("compress_diff.py"), diff, "--max-len", "100", "--meta-file", str(meta_path)
+        )
+        assert proc.returncode == 0
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        assert meta["diff_truncated"] is True
+        assert meta["total_files"] == 1
+        assert meta["covered_files"] == 1  # header present, body truncated
+
+    def test_meta_truncation_drops_tail_file(self, tmp_path):
+        # First file huge (truncation cuts inside it); tail file dropped entirely.
+        diff = (
+            "diff --git a/big.py b/big.py\n"
+            + "+x\n" * 200
+            + "diff --git a/tail.py b/tail.py\n+tail()\n"
+        )
+        meta_path = tmp_path / "meta.json"
+        proc = _run(
+            _script("compress_diff.py"), diff, "--max-len", "100", "--meta-file", str(meta_path)
+        )
+        assert proc.returncode == 0
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        assert meta["diff_truncated"] is True
+        assert meta["total_files"] == 2
+        assert "tail.py" in meta["truncated_dropped_files"]
+
+    def test_meta_filter_tests_drops_test_files(self, tmp_path):
+        diff = (
+            "diff --git a/src/app.py b/src/app.py\n+keep()\n"
+            "diff --git a/tests/test_app.py b/tests/test_app.py\n+drop()\n"
+        )
+        meta_path = tmp_path / "meta.json"
+        proc = _run(
+            _script("compress_diff.py"), diff, "--filter-tests", "--meta-file", str(meta_path)
+        )
+        assert proc.returncode == 0
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        assert meta["filter_tests"] is True
+        assert meta["total_files"] == 2
+        assert meta["kept_files"] == 1
+        assert "tests/test_app.py" in meta["dropped_test_files"]
+
+    def test_no_meta_file_is_backward_compatible(self, tmp_path):
+        # Omitting --meta-file must not change stdout or write anything.
+        diff = "diff --git a/foo.py b/foo.py\n+keep()\n"
+        proc = _run(_script("compress_diff.py"), diff)
+        assert proc.returncode == 0
+        assert "keep()" in proc.stdout
+        assert not list(tmp_path.iterdir())
+
+
+class TestCoverageLines:
+    """Status report surfaces partial-coverage when the caller provides it (#120)."""
+
+    def test_coverage_lines_when_truncated(self):
+        inp = _status_input_sev("NEEDS_FIX", critical_count=1, open_count=3)
+        inp["diff_truncated"] = True
+        inp["total_files"] = 10
+        inp["covered_files"] = 7
+        out = _run_json(_script("render_status_report.py"), inp)
+        assert "Diff truncated: yes" in out
+        assert "Coverage: 7/10 files" in out
+        assert "Status: NEEDS_FIX" in out
+
+    def test_coverage_lines_omitted_by_default(self):
+        out = _run_json(_script("render_status_report.py"), _status_input("PASS"))
+        assert "Diff truncated" not in out
+        assert "Coverage" not in out
+        # footer still last
+        assert out.splitlines()[-1] == "================================"

--- a/tests/unit/test_cr_batch_contracts.py
+++ b/tests/unit/test_cr_batch_contracts.py
@@ -137,6 +137,59 @@ def _status_input(status: str) -> dict:
     }
 
 
+def _status_input_sev(status: str, critical_count: int = 0, open_count: int = 1) -> dict:
+    """Status-report input carrying the #119 critical_count field."""
+    base = _status_input(status)
+    base["open_count"] = open_count
+    base["critical_count"] = critical_count
+    return base
+
+
+# Round-1 input with mixed severities, ordered low -> critical -> medium on
+# purpose so the sort-under-test is observable.
+SEV_ROUND1_INPUT = {
+    "round": 1,
+    "pr_number": 55,
+    "head_sha": HEAD_SHA_A,
+    "previous_head_sha": None,
+    "repo_owner": "owner",
+    "repo_name": "repo",
+    "timestamp": "2026-06-18T10:00:00Z",
+    "issues": [
+        {
+            "id": "issue-1",
+            "description": "Low-severity naming nit",
+            "reason": "CLAUDE.md",
+            "file": "src/a.py",
+            "lines": "1-2",
+            "status": "open",
+            "first_round": 1,
+            "severity": "low",
+        },
+        {
+            "id": "issue-2",
+            "description": "Critical null-deref crash",
+            "reason": "bug",
+            "file": "src/b.py",
+            "lines": "3-4",
+            "status": "open",
+            "first_round": 1,
+            "severity": "critical",
+        },
+        {
+            "id": "issue-3",
+            "description": "Medium edge case",
+            "reason": "logic",
+            "file": "src/c.py",
+            "lines": "5-6",
+            "status": "open",
+            "first_round": 1,
+            "severity": "medium",
+        },
+    ],
+}
+
+
 # ---------------------------------------------------------------------------
 # Contract 1: trigger phrases (literal external contract with zima daemon)
 # ---------------------------------------------------------------------------
@@ -324,3 +377,80 @@ class TestBackwardCompat:
         out = _run(_script("compress_diff.py"), diff, "--filter-tests", "--max-len", "4000").stdout
         assert "keep_me" in out
         assert "drop_me" not in out
+
+
+# ---------------------------------------------------------------------------
+# #119: severity ranking + verdict (added on top of the baseline gate)
+# ---------------------------------------------------------------------------
+
+
+class TestSeverityVerdict:
+    """Status report must surface critical count + a merge verdict (#119)."""
+
+    def test_block_merge_when_critical(self):
+        out = _run_json(
+            _script("render_status_report.py"),
+            _status_input_sev("NEEDS_FIX", critical_count=2, open_count=3),
+        )
+        assert "Status: NEEDS_FIX" in out
+        assert "Critical issues: 2" in out
+        assert "Verdict: BLOCK_MERGE" in out
+
+    def test_ready_to_merge_on_pass(self):
+        out = _run_json(
+            _script("render_status_report.py"),
+            _status_input_sev("PASS", critical_count=0, open_count=0),
+        )
+        assert "Verdict: READY_TO_MERGE" in out
+
+    def test_merge_with_caution(self):
+        out = _run_json(
+            _script("render_status_report.py"),
+            _status_input_sev("NEEDS_FIX", critical_count=0, open_count=2),
+        )
+        assert "Verdict: MERGE_WITH_CAUTION" in out
+
+    def test_skip_on_no_new_commits(self):
+        out = _run_json(
+            _script("render_status_report.py"),
+            _status_input_sev("NO_NEW_COMMITS", critical_count=0, open_count=1),
+        )
+        assert "Verdict: SKIP" in out
+
+    def test_critical_count_backward_compat(self):
+        """Old callers that omit critical_count must still get a valid block."""
+        out = _run_json(_script("render_status_report.py"), _status_input("NEEDS_FIX"))
+        assert "Critical issues: 0" in out
+        assert "Status: NEEDS_FIX" in out
+        assert "Verdict: MERGE_WITH_CAUTION" in out
+
+
+class TestSeverityRender:
+    """Review body sorts issues by severity and annotates it (#119)."""
+
+    def test_round1_sorted_critical_first_and_annotated(self):
+        out = _run_json(_script("build_review_body.py"), SEV_ROUND1_INPUT)
+        # Skip the metadata block — it deliberately preserves input order; the
+        # rendered body is what gets severity-sorted.
+        body = out.split("-->", 1)[1]
+        crit_pos = body.index("Critical null-deref crash")
+        low_pos = body.index("Low-severity naming nit")
+        assert crit_pos < low_pos  # critical sorts above low
+        assert "(bug, critical)" in body
+        assert "(CLAUDE.md, low)" in body
+
+    def test_missing_severity_falls_back_to_medium(self):
+        minimal = {
+            "round": 1,
+            "pr_number": 1,
+            "head_sha": HEAD_SHA_A,
+            "repo_owner": "o",
+            "repo_name": "r",
+            "timestamp": "2026-06-18T10:00:00Z",
+            "issues": [
+                {"description": "no sev field", "reason": "bug", "file": "a.py", "lines": "1-2"}
+            ],
+        }
+        proc = _run(_script("build_review_body.py"), json.dumps(minimal))
+        assert proc.returncode == 0, proc.stderr
+        assert "(bug, medium)" in proc.stdout


### PR DESCRIPTION
## What

Group 1 of the `github-code-review-batch` optimization (#119–#126). **Closes #119, closes #120.** Builds on the contract gate (#127, merged). A-tier (code) — gate + unit tests + real CR.

## #119 — severity + verdict

- **`render_status_report.py`**: `Critical issues:` count + a derived `Verdict:` line (`SKIP` / `BLOCK_MERGE` / `READY_TO_MERGE` / `MERGE_WITH_CAUTION`) emitted **after** the unchanged 3-state `Status:` line — zima daemon's `grep "Status:"` is unaffected.
- **`build_review_body.py`**: issues sorted by severity (critical first) and annotated `(reason, severity)`; metadata `issues[]` preserves input order (historical record intact).
- Agents now emit `severity` (`critical`/`high`/`medium`/`low`) — wired through flow.md (Step 4 schema + criteria, Step 6 severity-first sort, Step 9.1, Step 10), subagent-prompts.md (all 4 checkers + delta-reviewer), output-examples.md, SKILL.md.
- Backward-compatible: missing severity → `medium`, missing `critical_count` → `0`.

## #120 — truncation visibility

- **`compress_diff.py`**: new `--meta-file PATH` writes a coverage sidecar JSON (`diff_truncated`, `total/kept/covered_files`, `dropped_test_files`, `truncated_dropped_files`).
- **`render_status_report.py`**: optional `Diff truncated:` / `Coverage: M/N files` lines after `Verdict:` when the caller provides them (omitted by default → fully backward-compatible).
- flow.md Step 3.5 captures the meta and feeds Step 10; SKILL.md fixes the stale ">1000 行" threshold; edge-cases.md updated.
- The scheduler can now tell a clean `PASS` from a partial-coverage (truncated) `PASS` instead of silently trusting a truncated empty result.

## Verification

- `uv run pytest tests/unit/test_cr_batch_contracts.py` → **33 passed** (19 baseline + 7 for #119 + 7 for #120)
- `uv run ruff check` / `black --check` on changed files → clean
- All 6 external contracts preserved (trigger phrases, `Status:` grep, `cc-cr-meta`, build→parse round-trip, stdlib-only, backward-compat) — the gate asserts each.

## Commits

- `feat(cr-batch): add severity ranking + merge verdict (#119)` — scripts + tests
- `docs(cr-batch): wire severity + verdict through skill prompts and spec (#119)`
- `feat(cr-batch): surface diff truncation in status report (#120)`

🤖 Generated with Claude Code
