### PR TITLE
test(cr-batch): extract + fixture-test committer-response matching (#125)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pr-automation",
       "source": "./plugins/pr-automation",
       "description": "GitHub PR 自动化（批量 CR、调度式审查、双 Agent 交叉验证）",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "category": "automation",
       "keywords": ["github", "pull-request", "code-review", "automation", "zima"]
     }

--- a/plugins/pr-automation/.claude-plugin/plugin.json
+++ b/plugins/pr-automation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pr-automation",
   "displayName": "PR Automation",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "GitHub PR 自动化技能集 — 批量代码审查、调度式 CR、双 Agent 交叉验证。配合 zima daemon 实现端到端 PR 处理。",
   "author": {
     "name": "zhuxixi"

--- a/plugins/pr-automation/skills/github-code-review-batch/references/flow.md
+++ b/plugins/pr-automation/skills/github-code-review-batch/references/flow.md
@@ -48,7 +48,9 @@ gh pr view <PR> --json reviews --jq '.reviews[] | {body: .body, submitted_at: .s
    - `resolution`: `"acknowledged"` / `"wontfix"` / `"resolved"` / `null`
    - `committer_note`: committer 评论中的相关原文片段
 
-**为什么不脚本化这一步**：分类是启发式的，"前 10 个单词"匹配本身需要 NLP 直觉。脚本化容易因边界情况失真。不确定时，优先分类为 `clarified` 而非 `wontfix`，以保留人工判断空间。
+**为什么不完全脚本化这一步**：分类是启发式的，"前 10 个单词"匹配本身需要 NLP 直觉，完全脚本化容易因边界情况失真。不确定时，优先分类为 `clarified` 而非 `wontfix`，以保留人工判断空间。
+
+**可脚本化的核心（#125）**：关键词表与三种匹配键（`issue-{id}` / `file:lines` / 描述前若干 token）已固化在 [scripts/match_committer_response.py](../scripts/match_committer_response.py)，作为可单测的确定性参考实现（优先级 resolved > clarified > wontfix）。LLM 可把它当作"候选匹配 + 初步分类"的预筛，再对歧义做最终裁决；该脚本的关键词表是单一事实来源，本节表格与之保持一致。
 
 ### 0.3 判断分支 {#step-0-3}
 

--- a/plugins/pr-automation/skills/github-code-review-batch/scripts/match_committer_response.py
+++ b/plugins/pr-automation/skills/github-code-review-batch/scripts/match_committer_response.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Pure, deterministic core of Step 0.2a — match committer comments to previous
+issues and classify the response (#125).
+
+Step 0.2a is intentionally heuristic, but the keyword table + match keys are
+deterministic enough to extract and unit-test. This script does the scriptable
+part; the skill's LLM still does final adjudication for genuinely ambiguous
+multi-signal comments (see flow.md Step 0.2a). Having the rules as a pure
+function also gives #125 its regression safety net.
+
+Input (stdin): JSON
+  {
+    "previous_issues": [ {id, description, file, lines, status}, ... ],
+    "committer_comments": [ "comment text", ... ]
+  }
+Output (stdout): JSON list, one entry per OPEN previous issue:
+  [ {issue_id, resolution, committer_note}, ... ]
+  resolution in {"resolved","wontfix","clarified", null}
+  committer_note is the first matching comment text, or null
+
+Precedence: resolved > clarified > wontfix > null — honoring Step 0.2a's
+"prefer clarified over wontfix when ambiguous".
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+
+# Keyword table mirrored from flow.md Step 0.2a. Order within the dict is NOT
+# the precedence — see _PRECEDENCE below.
+RESOLUTION_KEYWORDS: dict[str, list[str]] = {
+    "resolved": ["fixed", "已修复", "done", "resolved", "addressed"],
+    "clarified": [
+        "clarify",
+        "说明",
+        "actually",
+        "context:",
+        "returns",
+        "只返回",
+        "strictly",
+    ],
+    "wontfix": [
+        "wontfix",
+        "won't fix",
+        "by design",
+        "intentional",
+        "not a bug",
+        "不需要修复",
+        "不修复",
+        "设计如此",
+    ],
+}
+# resolved is the strongest signal; clarified beats wontfix when both appear.
+_PRECEDENCE = ["resolved", "clarified", "wontfix"]
+
+_TOKEN_RE = re.compile(r"\S+")
+
+
+def _first_tokens(text: str, limit: int = 10) -> list[str]:
+    return [t.lower() for t in _TOKEN_RE.findall(text)[:limit]]
+
+
+def comment_mentions_issue(issue: dict, comment: str) -> bool:
+    """True if `comment` refers to `issue` via any of the 3 Step 0.2a match keys."""
+    c = comment.lower()
+    # (a) literal issue-id reference, e.g. "issue-2". The id field already
+    #     carries the full token ("issue-1"), so match it as a delimited token
+    #     so "issue-1" doesn't match "issue-10".
+    iid = str(issue.get("id", "")).lower()
+    if iid and re.search(rf"(?<![\w-]){re.escape(iid)}(?![\w-])", c):
+        return True
+    # (b) file path + lines together
+    file = str(issue.get("file", "")).lower()
+    lines = str(issue.get("lines", "")).lower()
+    if file and lines and file in c and lines in c:
+        return True
+    # (c) a run of >=4 description tokens quoted in the comment (a deterministic
+    #     take on "前 10 个单词"). CJK descriptions without spaces produce <4
+    #     tokens and fall back to keys (a)/(b) — documented, tested.
+    desc_tokens = _first_tokens(str(issue.get("description", "")), 10)
+    if len(desc_tokens) >= 4:
+        c_norm = " ".join(_TOKEN_RE.findall(c))
+        for i in range(len(desc_tokens) - 3):
+            if " ".join(desc_tokens[i : i + 4]) in c_norm:
+                return True
+    return False
+
+
+def classify_resolution(comment: str) -> str | None:
+    """Classify a committer comment via the keyword table (resolved>clarified>wontfix)."""
+    c = comment.lower()
+    for category in _PRECEDENCE:
+        if any(kw.lower() in c for kw in RESOLUTION_KEYWORDS[category]):
+            return category
+    return None
+
+
+def match_committer_response(
+    previous_issues: list[dict], committer_comments: list[str]
+) -> list[dict]:
+    results: list[dict] = []
+    for issue in previous_issues:
+        if issue.get("status") != "open":
+            continue
+        note = None
+        resolution = None
+        for comment in committer_comments:
+            if comment_mentions_issue(issue, comment):
+                note = comment
+                resolution = classify_resolution(comment)
+                break
+        results.append(
+            {"issue_id": issue.get("id"), "resolution": resolution, "committer_note": note}
+        )
+    return results
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        d = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"match_committer_response: invalid JSON on stdin: {exc}", file=sys.stderr)
+        return 2
+    out = match_committer_response(d.get("previous_issues", []), d.get("committer_comments", []))
+    json.dump(out, sys.stdout, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_cr_batch_committer_match.py
+++ b/tests/unit/test_cr_batch_committer_match.py
@@ -1,0 +1,157 @@
+"""Fixture/regression tests for committer-response matching (#125).
+
+Exercises scripts/match_committer_response.py — the pure, deterministic core of
+flow.md Step 0.2a (match keys + keyword table) — as a subprocess black box.
+These fixtures freeze the heuristic's expected behavior so keyword-table or
+model drift is caught before it silently changes zima daemon's acknowledged
+counts or cross-round metadata.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = (
+    _REPO_ROOT
+    / "plugins"
+    / "pr-automation"
+    / "skills"
+    / "github-code-review-batch"
+    / "scripts"
+    / "match_committer_response.py"
+)
+
+
+def _run(payload: dict) -> list[dict]:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def _issue(iid, desc, file="src/a.py", lines="10-12", status="open"):
+    return {"id": iid, "description": desc, "file": file, "lines": lines, "status": status}
+
+
+class TestPortability:
+    def test_stdlib_only(self):
+        tree = ast.parse(SCRIPT.read_text(encoding="utf-8"))
+        imports = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports.extend(a.name.split(".")[0] for a in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imports.append(node.module.split(".")[0])
+        non_stdlib = sorted({m for m in imports if m not in sys.stdlib_module_names})
+        assert not non_stdlib, f"non-stdlib imports: {non_stdlib}"
+
+
+class TestClassifyViaMatch:
+    def test_resolved_via_issue_id(self):
+        out = _run(
+            {
+                "previous_issues": [_issue("issue-1", "Memory leak in OAuth state cleanup")],
+                "committer_comments": ["issue-1 fixed in commit abc"],
+            }
+        )
+        assert out[0]["resolution"] == "resolved"
+
+    def test_wontfix_via_file_lines(self):
+        out = _run(
+            {
+                "previous_issues": [_issue("issue-2", "Naming inconsistency", "src/b.py", "20-25")],
+                "committer_comments": ["src/b.py lines 20-25: by design, wontfix"],
+            }
+        )
+        assert out[0]["resolution"] == "wontfix"
+
+    def test_clarified_via_description_window(self):
+        out = _run(
+            {
+                "previous_issues": [
+                    _issue("issue-3", "Missing error handling for OAuth callback handler")
+                ],
+                "committer_comments": [
+                    "Actually, missing error handling for OAuth callback only happens on timeout - clarify"
+                ],
+            }
+        )
+        assert out[0]["resolution"] == "clarified"
+
+    def test_no_match_yields_null(self):
+        out = _run(
+            {
+                "previous_issues": [_issue("issue-4", "Some unrelated issue right here now")],
+                "committer_comments": ["completely different topic, no signal words"],
+            }
+        )
+        assert out[0]["resolution"] is None
+        assert out[0]["committer_note"] is None
+
+
+class TestPrecedence:
+    def test_clarified_beats_wontfix(self):
+        # "actually" (clarified) + "by design" (wontfix) -> clarified wins
+        out = _run(
+            {
+                "previous_issues": [_issue("issue-5", "Race condition in the worker pool loop")],
+                "committer_comments": ["issue-5: actually by design"],
+            }
+        )
+        assert out[0]["resolution"] == "clarified"
+
+    def test_resolved_beats_clarified(self):
+        out = _run(
+            {
+                "previous_issues": [_issue("issue-6", "Null pointer dereference in parser path")],
+                "committer_comments": ["issue-6: fixed, added context: returns None"],
+            }
+        )
+        assert out[0]["resolution"] == "resolved"
+
+
+class TestEdgeCases:
+    def test_non_open_issues_skipped(self):
+        out = _run(
+            {
+                "previous_issues": [
+                    _issue("issue-7", "Open issue one", status="open"),
+                    _issue("issue-8", "Resolved issue", status="resolved"),
+                ],
+                "committer_comments": ["issue-7 wontfix", "issue-8 fixed"],
+            }
+        )
+        assert [r["issue_id"] for r in out] == ["issue-7"]
+
+    def test_cjk_description_falls_back_to_id(self):
+        # CJK description has no spaces -> <4 tokens -> token-window key never
+        # fires; must match via issue-id or file:lines.
+        out = _run(
+            {
+                "previous_issues": [_issue("issue-9", "内存泄漏未清理", "src/c.py", "1-5")],
+                "committer_comments": ["issue-9 不需要修复"],
+            }
+        )
+        assert out[0]["resolution"] == "wontfix"
+
+    def test_first_matching_comment_wins(self):
+        out = _run(
+            {
+                "previous_issues": [_issue("issue-10", "Some specific bug right here now")],
+                "committer_comments": [
+                    "issue-10 actually it is fine",  # clarified, first match
+                    "issue-10 fixed later",  # resolved, but second -> ignored
+                ],
+            }
+        )
+        assert out[0]["resolution"] == "clarified"


### PR DESCRIPTION
## What

Closes #125 — regression-test safety net for the skill's most fragile step (Step 0.2a committer-response matching). Test-infra + an extracted pure function; no change to the running skill's behavior.

## Changes

- **New `scripts/match_committer_response.py`** — the deterministic core of Step 0.2a: the keyword table (resolved/clarified/wontfix) + the 3 match keys (`issue-{id}` / `file:lines` / description token-window), with precedence `resolved > clarified > wontfix` (honors "prefer clarified over wontfix"). Stdlib-only; id matched as a delimited token so `issue-1` ≠ `issue-10`.
- **New `tests/unit/test_cr_batch_committer_match.py`** — 10 subprocess fixtures: each resolution class, each match key, both precedence orderings, non-open issues skipped, CJK description fallback (no spaces → <4 tokens → falls back to id/file), first-match-wins.
- **flow.md Step 0.2a** points to the script as the canonical keyword source (single source of truth).

## Verification

- `uv run pytest tests/unit/test_cr_batch_contracts.py tests/unit/test_cr_batch_committer_match.py` → **43 passed** (33 + 10).
- ruff/black clean on the new files. CI runs the new test file (under `tests/`).
- Bumps pr-automation `0.3.0 → 0.3.1` (test/infra; patch).

🤖 Generated with Claude Code
