### PR TITLE
feat(cr-batch): opt-in cross-PR wontfix suppression (#126)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pr-automation",
       "source": "./plugins/pr-automation",
       "description": "GitHub PR 自动化（批量 CR、调度式审查、双 Agent 交叉验证）",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "category": "automation",
       "keywords": ["github", "pull-request", "code-review", "automation", "zima"]
     }

--- a/plugins/pr-automation/.claude-plugin/plugin.json
+++ b/plugins/pr-automation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pr-automation",
   "displayName": "PR Automation",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "GitHub PR 自动化技能集 — 批量代码审查、调度式 CR、双 Agent 交叉验证。配合 zima daemon 实现端到端 PR 处理。",
   "author": {
     "name": "zhuxixi"

--- a/plugins/pr-automation/skills/github-code-review-batch/references/edge-cases.md
+++ b/plugins/pr-automation/skills/github-code-review-batch/references/edge-cases.md
@@ -27,6 +27,7 @@
 | committer 评论中无明确信号 | 分类为 null，按原有流程处理 |
 | committer 回应与代码实际不符 | delta-reviewer 结合 diff 判断，**以代码为准** |
 | 所有 open issues 被标记 acknowledged | 输出状态报告，Status: `PASS`（无真正 open issues） |
+| `.claude/cr-suppressions.json` 缺失或损坏 | 视为无抑制，正常审查（#126，默认 off） |
 
 ---
 

--- a/plugins/pr-automation/skills/github-code-review-batch/references/flow.md
+++ b/plugins/pr-automation/skills/github-code-review-batch/references/flow.md
@@ -239,6 +239,17 @@ issue-validator 验证时若 agent 未给 severity，按 `medium` 兜底。`buil
 - 如果描述内容高度相似（超过 80% 相似度），也视为重复
 - 合并时保留描述更详细、建议更具体的一个
 
+**可选：跨 PR suppress（#126，默认 off）**：若仓库根存在 `.claude/cr-suppressions.json`，去重后调用 [scripts/apply_suppressions.py](../scripts/apply_suppressions.py) 把命中的 issue 降级为 `suppressed`——不计入 open、不触发 fix-agent，但仍出现在终端输出供人工核验。条目格式：
+
+```json
+[
+  {"reason": "CLAUDE.md", "pattern": "naming", "expires": "2026-12-31", "rationale": "wontfix on #12,#18"},
+  {"pattern": "ci 配置", "expires": null, "rationale": "by design"}
+]
+```
+
+匹配规则：`reason` 精确匹配 AND `pattern`（描述子串、不区分大小写）命中；`expires` 过期则忽略该条。无文件 = 无抑制。**宁可漏抑不可误抑**：条目应窄；committer 仍可在 PR 评论 override。
+
 ---
 
 ## Step 7: 最终资格审查 {#step-7}

--- a/plugins/pr-automation/skills/github-code-review-batch/scripts/apply_suppressions.py
+++ b/plugins/pr-automation/skills/github-code-review-batch/scripts/apply_suppressions.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Apply an optional cross-PR suppression list (#126).
+
+Lets a repo owner stop the skill from re-raising issue classes that have been
+repeatedly wontfix'd, without editing the skill. Default-off: no suppressions
+=> everything stays open. Suppressed issues are NOT counted as open and do NOT
+trigger fix-agent, but are still returned (for human visibility in the report).
+
+Input (stdin): JSON
+  {
+    "issues":        [ {description, reason, ...}, ... ],
+    "suppressions":  [ {pattern?, reason?, expires?, rationale?}, ... ],
+    "today?":        "YYYY-MM-DD"   # for testing; defaults to today
+  }
+Output (stdout): JSON { "open": [...], "suppressed": [...] }
+
+A suppression matches an issue iff:
+  - reason  unset OR == issue.reason, AND
+  - pattern unset OR (pattern, case-insensitive, is a substring of description)
+AND the suppression is active (expires unset OR expires >= today).
+
+Portability: stdlib only. Default-off by design — never over-suppress.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+
+
+def _parse_date(s):
+    if not s:
+        return None
+    try:
+        return date.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
+
+
+def _is_active(sup, today: date) -> bool:
+    exp = _parse_date(sup.get("expires"))
+    return exp is None or exp >= today
+
+
+def _matches(sup: dict, issue: dict) -> bool:
+    reason = sup.get("reason")
+    pattern = sup.get("pattern")
+    if reason is not None and reason != issue.get("reason"):
+        return False
+    if (
+        pattern is not None
+        and str(pattern).lower() not in str(issue.get("description", "")).lower()
+    ):
+        return False
+    return True  # both unset = catch-all; otherwise one/both matched
+
+
+def apply_suppressions(issues: list[dict], suppressions: list[dict], today=None) -> dict:
+    if today is None:
+        today = date.today()
+    active = [s for s in suppressions if _is_active(s, today)]
+    open_out: list[dict] = []
+    suppressed: list[dict] = []
+    for issue in issues:
+        hit = next((s for s in active if _matches(s, issue)), None)
+        if hit:
+            marked = dict(issue)
+            marked["suppressed_reason"] = (
+                hit.get("rationale") or hit.get("pattern") or hit.get("reason")
+            )
+            suppressed.append(marked)
+        else:
+            open_out.append(issue)
+    return {"open": open_out, "suppressed": suppressed}
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        d = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError as exc:
+        print(f"apply_suppressions: invalid JSON on stdin: {exc}", file=sys.stderr)
+        return 2
+    out = apply_suppressions(
+        d.get("issues", []),
+        d.get("suppressions", []),
+        _parse_date(d.get("today")),
+    )
+    json.dump(out, sys.stdout, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_cr_batch_suppressions.py
+++ b/tests/unit/test_cr_batch_suppressions.py
@@ -1,0 +1,156 @@
+"""Tests for the cross-PR suppression list (#126).
+
+Default-off, opt-in suppression: matching issues are demoted out of `open`
+(never trigger fix-agent) but kept in `suppressed` for human visibility.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = (
+    _REPO_ROOT
+    / "plugins"
+    / "pr-automation"
+    / "skills"
+    / "github-code-review-batch"
+    / "scripts"
+    / "apply_suppressions.py"
+)
+
+sys.path.insert(0, str(SCRIPT.parent))
+import apply_suppressions as asu  # noqa: E402
+
+TODAY = date(2026, 6, 18)
+
+
+def _run(payload: dict) -> dict:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def _issue(desc="x", reason="bug"):
+    return {"description": desc, "reason": reason, "file": "a.py", "lines": "1-2"}
+
+
+class TestPortability:
+    def test_stdlib_only(self):
+        tree = ast.parse(SCRIPT.read_text(encoding="utf-8"))
+        imports = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports.extend(a.name.split(".")[0] for a in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imports.append(node.module.split(".")[0])
+        non_stdlib = sorted({m for m in imports if m not in sys.stdlib_module_names})
+        assert not non_stdlib, f"non-stdlib imports: {non_stdlib}"
+
+
+class TestMatches:
+    def test_by_reason(self):
+        assert asu._matches({"reason": "CLAUDE.md"}, _issue(reason="CLAUDE.md"))
+
+    def test_reason_mismatch(self):
+        assert not asu._matches({"reason": "CLAUDE.md"}, _issue(reason="bug"))
+
+    def test_by_pattern(self):
+        assert asu._matches({"pattern": "naming"}, _issue(desc="bad naming here"))
+
+    def test_pattern_mismatch(self):
+        assert not asu._matches({"pattern": "naming"}, _issue(desc="nothing here"))
+
+    def test_both_must_hold(self):
+        assert asu._matches(
+            {"reason": "CLAUDE.md", "pattern": "naming"},
+            _issue(desc="naming nit", reason="CLAUDE.md"),
+        )
+        assert not asu._matches(
+            {"reason": "CLAUDE.md", "pattern": "naming"},
+            _issue(desc="naming nit", reason="bug"),
+        )
+
+
+class TestExpiry:
+    def test_no_expires_is_active(self):
+        assert asu._is_active({}, TODAY)
+
+    def test_future_active(self):
+        assert asu._is_active({"expires": "2027-01-01"}, TODAY)
+
+    def test_past_expired(self):
+        assert not asu._is_active({"expires": "2020-01-01"}, TODAY)
+
+    def test_invalid_date_ignored_as_inactive(self):
+        # unparseable expires => treated as None => active (fail-open, not fail-closed)
+        assert asu._is_active({"expires": "not-a-date"}, TODAY)
+
+
+class TestApply:
+    def test_suppress_by_reason(self):
+        r = asu.apply_suppressions(
+            [_issue(reason="CLAUDE.md"), _issue(reason="bug")],
+            [{"reason": "CLAUDE.md"}],
+            TODAY,
+        )
+        assert [i["reason"] for i in r["open"]] == ["bug"]
+        assert [i["reason"] for i in r["suppressed"]] == ["CLAUDE.md"]
+
+    def test_no_suppressions_all_open(self):
+        r = asu.apply_suppressions([_issue(), _issue()], [], TODAY)
+        assert len(r["open"]) == 2 and r["suppressed"] == []
+
+    def test_expired_not_applied(self):
+        r = asu.apply_suppressions(
+            [_issue(reason="CLAUDE.md")],
+            [{"reason": "CLAUDE.md", "expires": "2020-01-01"}],
+            TODAY,
+        )
+        assert len(r["open"]) == 1 and r["suppressed"] == []
+
+    def test_suppressed_marked_with_rationale(self):
+        r = asu.apply_suppressions(
+            [_issue(desc="naming", reason="CLAUDE.md")],
+            [{"pattern": "naming", "rationale": "style not reviewed"}],
+            TODAY,
+        )
+        assert r["suppressed"][0]["suppressed_reason"] == "style not reviewed"
+
+
+class TestEndToEnd:
+    def test_cli_default_off(self):
+        r = _run({"issues": [_issue(), _issue()], "suppressions": []})
+        assert len(r["open"]) == 2 and r["suppressed"] == []
+
+    def test_cli_expired_via_today(self):
+        r = _run(
+            {
+                "issues": [_issue(reason="CLAUDE.md")],
+                "suppressions": [{"reason": "CLAUDE.md", "expires": "2020-01-01"}],
+                "today": "2026-06-18",
+            }
+        )
+        assert len(r["open"]) == 1 and r["suppressed"] == []
+
+    def test_cli_suppress_by_pattern(self):
+        r = _run(
+            {
+                "issues": [_issue(desc="naming nit"), _issue(desc="real crash")],
+                "suppressions": [{"pattern": "naming"}],
+                "today": "2026-06-18",
+            }
+        )
+        assert [i["description"] for i in r["open"]] == ["real crash"]
+        assert [i["description"] for i in r["suppressed"]] == ["naming nit"]


### PR DESCRIPTION
Closes #126. New scripts/apply_suppressions.py + optional .claude/cr-suppressions.json: matching issues are demoted out of open (no fix-agent) but kept for human visibility. Match = reason AND pattern(substring); expires honored; default-off (no file = no suppression); fail-open on bad dates. Wired into flow.md Step 6 + edge-cases row. 17 new tests (match, expiry, end-to-end CLI, portability); full cr-batch suite ~70 green. Bumps pr-automation 0.4.1 -> 0.5.0 (minor).