### PR TITLE
fix(agent): migrate Kimi command to Kimi Code CLI (release 0.5.5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zima-blue-cli"
-version = "0.5.4"
+version = "0.5.5"
 description = "Zima Blue CLI - Personal Agent Orchestration Platform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/integration/test_kimi_agent_integration.py
+++ b/tests/integration/test_kimi_agent_integration.py
@@ -41,11 +41,11 @@ class TestKimiAgentConfigLayer:
 
         # Verify default parameters from template are merged (model omitted)
         assert "model" not in agent.parameters
-        assert agent.parameters["maxStepsPerTurn"] == 50
-        assert agent.parameters["maxRalphIterations"] == 10
-        assert agent.parameters["maxRetriesPerStep"] == 3
-        assert agent.parameters["yolo"] is True
-        assert agent.parameters["workDir"] == "./workspace"
+        assert "maxStepsPerTurn" not in agent.parameters
+        assert "maxRalphIterations" not in agent.parameters
+        assert "maxRetriesPerStep" not in agent.parameters
+        assert "yolo" not in agent.parameters
+        assert "workDir" not in agent.parameters
         assert agent.parameters["outputFormat"] == "text"
 
     def test_kimi_agent_custom_parameters_override(self):
@@ -54,17 +54,15 @@ class TestKimiAgentConfigLayer:
             code="test-kimi-custom",
             name="Custom Kimi Agent",
             agent_type="kimi",
-            parameters={"model": "kimi-custom-model", "maxStepsPerTurn": 100, "yolo": False},
+            parameters={"model": "kimi-custom-model", "addDirs": ["./src"]},
         )
 
         # Verify overrides
         assert agent.parameters["model"] == "kimi-custom-model"
-        assert agent.parameters["maxStepsPerTurn"] == 100
-        assert agent.parameters["yolo"] is False
+        assert agent.parameters["addDirs"] == ["./src"]
 
         # Verify non-overridden defaults remain
-        assert agent.parameters["maxRalphIterations"] == 10
-        assert agent.parameters["workDir"] == "./workspace"
+        assert agent.parameters["outputFormat"] == "text"
 
     def test_kimi_agent_build_command(self):
         """TC-2: Verify build_command generates correct Kimi CLI command."""
@@ -72,7 +70,7 @@ class TestKimiAgentConfigLayer:
             code="test-kimi-cmd",
             name="Command Test Agent",
             agent_type="kimi",
-            parameters={"model": "kimi-k2-072515-preview", "maxStepsPerTurn": 50, "yolo": True},
+            parameters={"model": "kimi-k2-072515-preview"},
         )
 
         prompt_file = Path("/tmp/test_prompt.md")
@@ -81,17 +79,17 @@ class TestKimiAgentConfigLayer:
         cmd = agent.build_command(prompt_file=prompt_file, work_dir=work_dir)
 
         # Verify command structure
-        assert cmd[0] == "kimi-cli"
-        assert "--print" in cmd
-        assert "--yolo" in cmd
+        assert cmd[0] == "kimi"
+        assert "kimi-cli" not in cmd
+        assert "--print" not in cmd
+        assert "--yolo" not in cmd
         assert "--prompt" in cmd
         assert str(prompt_file) in cmd
-        assert "--work-dir" in cmd
-        assert str(work_dir) in cmd
+        # Kimi Code CLI does not support --work-dir; cwd is handled by subprocess
+        assert "--work-dir" not in cmd
         assert "--model" in cmd
         assert "kimi-k2-072515-preview" in cmd
-        assert "--max-steps-per-turn" in cmd
-        assert "50" in cmd
+        assert "--max-steps-per-turn" not in cmd
 
     def test_kimi_agent_build_command_with_extra_args(self):
         """TC-2b: Verify extra_args can override parameters at build time."""
@@ -102,15 +100,15 @@ class TestKimiAgentConfigLayer:
             parameters={"model": "default-model"},
         )
 
-        extra_args = {"model": "runtime-model", "maxStepsPerTurn": 75}
+        extra_args = {"model": "runtime-model", "outputFormat": "stream-json"}
         cmd = agent.build_command(extra_args=extra_args)
 
         # Verify extra_args override
         model_idx = cmd.index("--model")
         assert cmd[model_idx + 1] == "runtime-model"
 
-        max_steps_idx = cmd.index("--max-steps-per-turn")
-        assert cmd[max_steps_idx + 1] == "75"
+        output_format_idx = cmd.index("--output-format")
+        assert cmd[output_format_idx + 1] == "stream-json"
 
     def test_kimi_agent_build_command_with_addDirs(self):
         """TC-2c: Verify addDirs parameter generates multiple --add-dir flags."""
@@ -138,14 +136,14 @@ class TestKimiAgentConfigLayer:
         claude_cmd = claude_agent.get_cli_command_template()
 
         # Verify command differences
-        assert kimi_cmd == ["kimi-cli", "--print", "--yolo"]
+        assert kimi_cmd == ["kimi"]
         assert claude_cmd == ["claude", "-p"]
 
-        # Verify work-dir parameter differences
+        # Verify work-dir is not emitted for Kimi (cwd handled by subprocess)
         work_dir = Path("/tmp/test")
         kimi_full = kimi_agent.build_command(work_dir=work_dir)
 
-        assert "--work-dir" in kimi_full
+        assert "--work-dir" not in kimi_full
 
 
 class TestKimiAgentRunnerLayer:
@@ -164,7 +162,7 @@ class TestKimiAgentRunnerLayer:
             code="test-kimi",
             name="Test Kimi Agent",
             agent_type="kimi",
-            parameters={"maxStepsPerTurn": 50, "maxExecutionTime": 600, "cycleInterval": 900},
+            parameters={"maxExecutionTime": 600, "cycleInterval": 900},
         )
 
     def test_kimi_runner_directory_setup(self):
@@ -461,8 +459,7 @@ class TestKimiAgentCLILayer:
         assert result.exit_code == 0
         assert "Generated Command" in result.output
         assert "kimi" in result.output
-        assert "--print" in result.output
-        assert "--yolo" in result.output
+        assert "--prompt" in result.output
         assert "test-cmd-agent" in result.output
 
     def test_agent_test_with_different_types(self):
@@ -506,9 +503,7 @@ class TestKimiAgentCLILayer:
         output = result.output
         # Check for key elements in output (handle encoding issues on Windows)
         assert "DRY RUN" in output or "dry" in output.lower()
-        assert "kimi" in output.lower() or "--print" in output
-        # Verify command structure is present
-        assert "--work-dir" in output or "work" in output.lower()
+        assert "kimi" in output.lower() or "--prompt" in output
 
 
 class TestKimiAgentEdgeCases:

--- a/tests/integration/test_kimi_agent_real.py
+++ b/tests/integration/test_kimi_agent_real.py
@@ -1,8 +1,8 @@
 """
-Real integration tests for Kimi Agent - actually calls kimi-cli.
+Real integration tests for Kimi Agent - actually calls Kimi Code CLI.
 
 These tests require:
-- kimi-cli installed and authenticated
+- Kimi Code CLI (kimi) installed and authenticated
 - Network connection to Kimi API
 - Sufficient API quota
 
@@ -27,7 +27,7 @@ runner = CliRunner()
 
 
 def check_kimi_available():
-    """Check if kimi-cli is available and working."""
+    """Check if Kimi Code CLI is available and working."""
     try:
         result = subprocess.run(
             ["kimi", "--version"], capture_output=True, text=True, encoding="utf-8", timeout=5
@@ -39,7 +39,7 @@ def check_kimi_available():
 
 # Skip all tests in this file if kimi is not available
 pytestmark = pytest.mark.skipif(
-    not check_kimi_available(), reason="kimi-cli not available or not authenticated"
+    not check_kimi_available(), reason="Kimi Code CLI not available or not authenticated"
 )
 
 
@@ -48,10 +48,12 @@ class TestKimiAgentRealCommands:
 
     @pytest.fixture(autouse=True)
     def setup_isolation(self, monkeypatch, tmp_path):
-        """Set up isolated test environment."""
+        """Set up isolated test environment.
+
+        Note: HOME is intentionally NOT monkeypatched so that the real Kimi
+        Code CLI can locate its config.toml and default model.
+        """
         monkeypatch.setenv("ZIMA_HOME", str(tmp_path))
-        # Also set a temporary home for any config files
-        monkeypatch.setenv("HOME", str(tmp_path))
         self.temp_dir = tmp_path
         self.agent_dir = tmp_path / "agents" / "test-kimi-real"
         self.agent_dir.mkdir(parents=True, exist_ok=True)
@@ -60,10 +62,6 @@ class TestKimiAgentRealCommands:
             code="test-kimi-real",
             name="Real Test Kimi Agent",
             agent_type="kimi",
-            parameters={
-                "maxStepsPerTurn": 1,  # Limit to 1 step for fast tests
-                "maxRalphIterations": 1,
-            },
         )
         self.manager = ConfigManager()
 
@@ -83,7 +81,7 @@ class TestKimiAgentRealCommands:
         print(f"✅ Kimi CLI version info: {result.stdout[:200]}")
 
     def test_kimi_cli_simple_print_mode(self):
-        """Test 2: Test kimi --print mode with a simple prompt."""
+        """Test 2: Test kimi prompt mode with a simple prompt."""
         # Create a simple prompt file
         prompt_file = self.temp_dir / "simple_prompt.md"
         prompt_file.write_text(
@@ -93,23 +91,20 @@ class TestKimiAgentRealCommands:
         workspace = self.temp_dir / "workspace"
         workspace.mkdir(exist_ok=True)
 
-        # Run kimi with --print mode
+        # Run kimi with prompt mode (non-interactive)
         result = subprocess.run(
             [
                 "kimi",
-                "--print",
-                "--yolo",
                 "--prompt",
                 str(prompt_file),
-                "--work-dir",
-                str(workspace),
-                "--max-steps-per-turn",
-                "1",
+                "--output-format",
+                "text",
             ],
             capture_output=True,
             text=True,
             encoding="utf-8",
             timeout=60,  # Give it up to 60 seconds
+            cwd=str(workspace),
         )
 
         # Print output for debugging
@@ -213,9 +208,6 @@ Then output this JSON:
             name="Real Command Test",
             agent_type="kimi",
             parameters={
-                "model": "kimi-k2-072515-preview",
-                "yolo": True,
-                "maxStepsPerTurn": 1,
                 "addDirs": [str(extra_dir)],
             },
         )
@@ -251,6 +243,8 @@ class TestKimiAgentRealPJobIntegration:
     def setup_isolation(self, monkeypatch, tmp_path):
         """Set up isolated test environment."""
         monkeypatch.setenv("ZIMA_HOME", str(tmp_path))
+        # HOME is intentionally NOT monkeypatched so Kimi Code CLI can find
+        # its config and default model.
         self.temp_dir = tmp_path
         self.manager = ConfigManager()
 
@@ -264,7 +258,6 @@ class TestKimiAgentRealPJobIntegration:
             code=code,
             name="Real Test Agent",
             agent_type="kimi",
-            parameters={"maxStepsPerTurn": 1, "maxRalphIterations": 1, "yolo": True},
         )
         self.manager.save_config("agent", code, config.to_dict())
         return config
@@ -360,6 +353,8 @@ class TestKimiAgentErrorHandling:
     def setup_isolation(self, monkeypatch, tmp_path):
         """Set up isolated test environment."""
         monkeypatch.setenv("ZIMA_HOME", str(tmp_path))
+        # HOME is intentionally NOT monkeypatched so Kimi Code CLI can find
+        # its config and default model.
         self.temp_dir = tmp_path
         self.agent_dir = tmp_path / "agents" / "error-test"
         self.agent_dir.mkdir(parents=True, exist_ok=True)
@@ -368,49 +363,42 @@ class TestKimiAgentErrorHandling:
             code="error-test",
             name="Error Test Agent",
             agent_type="kimi",
-            parameters={"maxStepsPerTurn": 1},
         )
 
     def test_invalid_work_directory(self):
         """Test 7: Test behavior with invalid work directory."""
-        # Try to use a path that doesn't exist
+        # Try to use a path that doesn't exist. subprocess.run cwd must exist,
+        # so we expect a FileNotFoundError from Python rather than from kimi.
         invalid_workspace = self.temp_dir / "does_not_exist" / "nested"
 
         prompt_file = self.temp_dir / "prompt.md"
         prompt_file.write_text("Say hello", encoding="utf-8")
 
-        # This should either create the directory or fail gracefully
-        result = subprocess.run(
-            [
-                "kimi",
-                "--print",
-                "--prompt",
-                str(prompt_file),
-                "--work-dir",
-                str(invalid_workspace),
-                "--max-steps-per-turn",
-                "1",
-            ],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            timeout=30,
-        )
+        # This should fail gracefully since cwd does not exist
+        with pytest.raises(FileNotFoundError):
+            subprocess.run(
+                [
+                    "kimi",
+                    "--prompt",
+                    str(prompt_file),
+                    "--output-format",
+                    "text",
+                ],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                timeout=30,
+                cwd=str(invalid_workspace),
+            )
 
-        print("\n📊 Invalid directory test:")
-        print(f"   Return code: {result.returncode}")
-        print(f"   STDERR: {result.stderr[:300]}")
-
-        # Either it should create the directory or return an error
-        # We just verify it doesn't crash
-        assert result.returncode in [0, 1, 2]
+        print("\n📊 Invalid directory test: subprocess correctly raised FileNotFoundError")
 
 
 def pytest_configure(config):
     """Configure pytest to add custom markers."""
     config.addinivalue_line(
         "markers",
-        "real_kimi: marks tests that make real calls to kimi-cli (may be slow and use API quota)",
+        "real_kimi: marks tests that make real calls to Kimi Code CLI (may be slow and use API quota)",
     )
     config.addinivalue_line(
         "markers", "slow: marks tests as slow (deselect with '-m \"not slow\"')"

--- a/tests/unit/test_config_bundle.py
+++ b/tests/unit/test_config_bundle.py
@@ -277,8 +277,9 @@ class TestConfigBundle:
             prompt_file = Path("/tmp/prompt.md")
             cmd = bundle.build_command(prompt_file)
 
-            assert "kimi-cli" in cmd
-            assert "--print" in cmd
+            assert "kimi" in cmd
+            assert "kimi-cli" not in cmd
+            assert "--print" not in cmd
             assert "--prompt" in cmd
             assert str(prompt_file) in cmd
 

--- a/tests/unit/test_models_agent.py
+++ b/tests/unit/test_models_agent.py
@@ -19,8 +19,8 @@ class TestAgentConfigCreation(TestIsolator):
         assert config.metadata.name == "Kimi Agent"
         assert config.type == "kimi"
         assert "model" not in config.parameters
-        assert config.parameters["yolo"] is True
-        assert config.parameters["maxStepsPerTurn"] == 50
+        assert "outputFormat" in config.parameters
+        assert "yolo" not in config.parameters
 
     def test_create_claude_agent(self):
         """Test creating Claude agent."""
@@ -40,10 +40,9 @@ class TestAgentConfigCreation(TestIsolator):
         )
 
         assert config.parameters["model"] == "kimi-custom"
-        assert config.parameters["yolo"] is False
         assert config.parameters["customParam"] == "value"
         # Other defaults still present
-        assert "maxStepsPerTurn" in config.parameters
+        assert "outputFormat" in config.parameters
 
     def test_create_with_defaults(self):
         """Test creating with default references."""
@@ -218,9 +217,9 @@ class TestAgentConfigCommandBuilding(TestIsolator):
         config = AgentConfig.create("test", "Test", "kimi")
         template = config.get_cli_command_template()
 
-        assert "kimi-cli" in template
-        assert "--print" in template
-        assert "--yolo" in template
+        assert template[0] == "kimi"
+        assert "kimi-cli" not in template
+        assert "--print" not in template
 
     def test_get_cli_template_claude(self):
         """Test getting Claude command template."""
@@ -232,21 +231,18 @@ class TestAgentConfigCommandBuilding(TestIsolator):
 
     def test_build_kimi_command(self):
         """Test building Kimi command."""
-        config = AgentConfig.create(
-            "test", "Test", "kimi", parameters={"model": "kimi-custom", "maxStepsPerTurn": 100}
-        )
+        config = AgentConfig.create("test", "Test", "kimi", parameters={"model": "kimi-custom"})
 
         cmd = config.build_command(prompt_file="/tmp/prompt.md", work_dir="/tmp/workspace")
 
-        assert "kimi-cli" in cmd
+        assert "kimi" in cmd
+        assert "kimi-cli" not in cmd
         assert "--prompt" in cmd
         assert "/tmp/prompt.md" in cmd
-        assert "--work-dir" in cmd
-        assert "/tmp/workspace" in cmd
         assert "--model" in cmd
         assert "kimi-custom" in cmd
-        assert "--max-steps-per-turn" in cmd
-        assert "100" in cmd
+        # Kimi Code CLI does not support --work-dir; cwd is handled by subprocess
+        assert "--work-dir" not in cmd
 
     def test_build_claude_command(self):
         """Test building Claude command."""
@@ -346,6 +342,17 @@ class TestAgentConfigDefaults(TestIsolator):
         assert config.updated_at != old_timestamp
 
 
+class TestKimiCodeCLI(TestIsolator):
+    """Tests for Kimi Code CLI command template."""
+
+    def test_kimi_command_template(self):
+        """Kimi agent uses Kimi Code CLI command."""
+        agent = AgentConfig.create(code="test", name="Test", agent_type="kimi")
+        cmd = agent.get_cli_command_template()
+        assert cmd[0] == "kimi"
+        assert "kimi-cli" not in cmd
+
+
 class TestValidAgentTypes(TestIsolator):
     """Test valid agent types constant."""
 
@@ -359,4 +366,4 @@ class TestValidAgentTypes(TestIsolator):
         """Test that parameter templates exist for all valid types."""
         for agent_type in VALID_AGENT_TYPES:
             assert agent_type in AGENT_PARAMETER_TEMPLATES
-            assert "workDir" in AGENT_PARAMETER_TEMPLATES[agent_type]
+            assert "outputFormat" in AGENT_PARAMETER_TEMPLATES[agent_type]

--- a/uv.lock
+++ b/uv.lock
@@ -801,7 +801,7 @@ wheels = [
 
 [[package]]
 name = "zima-blue-cli"
-version = "0.5.3"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },

--- a/zima/models/agent.py
+++ b/zima/models/agent.py
@@ -12,11 +12,6 @@ from zima.utils import generate_timestamp, validate_code
 # Agent-specific parameters templates
 AGENT_PARAMETER_TEMPLATES = {
     "kimi": {
-        "maxStepsPerTurn": 50,
-        "maxRalphIterations": 10,
-        "maxRetriesPerStep": 3,
-        "yolo": True,
-        "workDir": "./workspace",
         "addDirs": [],
         "outputFormat": "text",
     },
@@ -160,7 +155,7 @@ class AgentConfig(BaseConfig):
         template.
 
         Returns:
-            Base command list (e.g., ["kimi", "--print", "--yolo"])
+            Base command list (e.g., ["kimi"])
         """
         # Mock override: if mockCommand is set, use it instead of real CLI
         if self.parameters.get("mockCommand"):
@@ -168,7 +163,7 @@ class AgentConfig(BaseConfig):
             return cmd if isinstance(cmd, list) else [str(cmd)]
 
         templates = {
-            "kimi": ["kimi-cli", "--print", "--yolo"],
+            "kimi": ["kimi"],  # Kimi Code CLI
             "claude": ["claude", "-p"],
         }
         return templates.get(self.type, [])
@@ -205,34 +200,18 @@ class AgentConfig(BaseConfig):
 
         # Add prompt file - agent-type-specific handling
         # Claude Code: prompt passed via stdin pipe, not as CLI argument
-        # Kimi: uses --prompt flag
+        # Kimi Code CLI: uses --prompt flag
         if prompt_file:
             if self.type == "kimi":
                 cmd.extend(["--prompt", str(prompt_file)])
             # Claude: prompt_file is passed via stdin pipe by the executor, not added to cmd
 
-        # Add working directory flag — only for agents that support it.
-        # Claude Code does not have a --work-dir or --cwd CLI flag; the
-        # working directory is handled by subprocess.Popen(cwd=...) in the
-        # executor. Kimi CLI supports --work-dir.
-        if work_dir and self.type == "kimi":
-            cmd.extend(["--work-dir", str(work_dir)])
-
         return cmd
 
     def _build_kimi_command(self, cmd: list[str], params: dict) -> list[str]:
-        """Build Kimi-specific command arguments."""
+        """Build Kimi Code CLI-specific command arguments."""
         if params.get("model"):
             cmd.extend(["--model", str(params["model"])])
-
-        if params.get("maxStepsPerTurn"):
-            cmd.extend(["--max-steps-per-turn", str(params["maxStepsPerTurn"])])
-
-        if params.get("maxRalphIterations"):
-            cmd.extend(["--max-ralph-iterations", str(params["maxRalphIterations"])])
-
-        if params.get("maxRetriesPerStep"):
-            cmd.extend(["--max-retries-per-step", str(params["maxRetriesPerStep"])])
 
         # Handle addDirs
         for add_dir in params.get("addDirs", []):


### PR DESCRIPTION
## What

Switch the `kimi` agent CLI from the deprecated **`kimi-cli`** to **Kimi Code CLI** (binary `kimi`), and release as **0.5.5**.

## Why

`kimi-cli` is deprecated; Kimi Code is the successor (installed binary is literally named `kimi`, config dir `~/.kimi-code`). `main` currently still issues `kimi-cli --print --yolo` (reverted to kimi-cli in #117 for backward compatibility). This re-introduces the migration as a clean, isolated release so `pjob run kimi` launches Kimi Code.

## Changes

- `zima/models/agent.py`:
  - Command template `["kimi-cli", "--print", "--yolo"]` → `["kimi"]`
  - Drop kimi-cli-only flags (`--work-dir`, `--max-steps-per-turn`, `--max-ralph-iterations`, `--max-retries-per-step`) and their parameter template entries (`maxStepsPerTurn`/`maxRalphIterations`/`maxRetriesPerStep`/`yolo`/`workDir`)
  - Keep/align Kimi Code flags: `--model`, `--add-dir`, `--output-format`, `--prompt`
  - Fix stale docstring example
- Tests updated to match the new command shape (4 files)
- `pyproject.toml` `0.5.4 → 0.5.5`; `uv.lock` project version synced

## How it was built

Isolated cherry-pick of the migration commit (originally on `webhook-triggered-cr-review`) onto current `main` — verified zero-conflict (the 5 touched files are byte-identical between `main` and the commit's parent). Not pulling the whole webhook branch (it carries unrelated WIP).

## Verification

- `pytest tests/unit/test_models_agent.py tests/unit/test_config_bundle.py tests/integration/test_kimi_agent_integration.py` → **70 passed**
- `grep` confirms no `kimi-cli`/`--print`/`--yolo`/`--work-dir` residual in `agent.py`

## Release plan (after merge)

1. Merge this PR to `main`
2. `git tag v0.5.5 && git push --tags` + `gh release create v0.5.5`
3. `publish.yml` builds + publishes to PyPI
4. `uv tool upgrade zima-blue-cli` → restart daemon (from a non-repo cwd so `-m` resolves to the installed 0.5.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)