### PR TITLE
docs(claude.md): refresh b248cde..9fab418 (Kimi Code CLI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,11 @@ PR 评论有三个独立 API，不同 CR 工具用不同 API 提交，获取完�
 - Windows taskkill: 加 `/T` 杀整个进程树（PJob 子进程不会随 daemon 一起死）
 - 新增运行时路径必须用 `get_zima_home()` 而非 `Path.home() / ".zima"`（ZIMA_HOME env var）
 
+### Agent CLIs
+
+- Kimi agent 调用 `kimi`（Kimi Code CLI）二进制（旧名 `kimi-cli` 已废弃，0.5.5 迁移），运行 Kimi PJob 前需确保 `kimi` 在 PATH 中
+- Kimi 旧参数 `maxStepsPerTurn`/`maxRalphIterations`/`maxRetriesPerStep`/`yolo`/`workDir` 已移除；两个 agent 的工作目录统一由 subprocess `cwd` 控制，无 `--work-dir` CLI flag
+
 ## Documentation
 
 - `AGENTS.md` — Agent context file for Kimi Code agents


### PR DESCRIPTION
Auto-generated CLAUDE.md refresh by the md-review polling agent.

## Range
`b248cde..9fab418` (single commit)

## What changed in code
- `9fab418` fix(agent): migrate Kimi command to Kimi Code CLI (release 0.5.5) — `zima/models/agent.py`

## What was added to CLAUDE.md
New `### Agent CLIs` subsection under `## Gotchas` (2 lines):
- Kimi agent now invokes the `kimi` binary (Kimi Code CLI); legacy `kimi-cli` is retired (0.5.5 migration). `kimi` must be on PATH to run Kimi PJobs.
- Kimi legacy params (`maxStepsPerTurn`/`maxRalphIterations`/`maxRetriesPerStep`/`yolo`/`workDir`) removed; both agents' working dir is now set purely via subprocess `cwd` (no `--work-dir` CLI flag).

These are environment/dependency + behavioral gotchas not obvious from a high-level read. Diff is CLAUDE.md-only (+5).