### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.6.0] - 2026-07-18
+
+### Features
+- **webhook**: webhook-triggered automatic code review (#135)
+
+### Changes
+- **claude.md**: note Kimi Code CLI migration (0.5.5) (#137)
+
+[0.6.0]: https://github.com/zhuxixi/zima-blue-cli/compare/v0.5.5...v0.6.0
+
 ## [Unreleased]
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zima-blue-cli"
-version = "0.5.5"
+version = "0.6.0"
 description = "Zima Blue CLI - Personal Agent Orchestration Platform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ wheels = [
 
 [[package]]
 name = "zima-blue-cli"
-version = "0.5.5"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
@@ -954,7 +954,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "requests", specifier = ">=2.0" },
+    { name = "requests", specifier = ">=2.32.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "typer", specifier = ">=0.12.0" },
 ]


### PR DESCRIPTION
## Summary
Bump version from 0.5.5 to 0.6.0

## [0.6.0] - 2026-07-18

### Features
- **webhook**: webhook-triggered automatic code review (#135)

### Changes
- **claude.md**: note Kimi Code CLI migration (0.5.5) (#137)

[0.6.0]: https://github.com/zhuxixi/zima-blue-cli/compare/v0.5.5...v0.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)